### PR TITLE
feat: add shared Marvin client and MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ data.json
 .DS_Store
 
 dist/**
+packages/*/dist/**

--- a/README.md
+++ b/README.md
@@ -106,11 +106,66 @@ By following these guidelines, you can ensure your Amazing Marvin data is accura
 3. Run `npm install` to install the dependencies.
 4. Make your desired changes.
 5. Use `npm run dev` to watch for changes and compile the plugin to `dist/main.js`.
+6. Run `npm test` for the shared-client, plugin-adapter, and MCP contract tests.
+7. Run `npm run build` to build the shared client, Obsidian plugin, and MCP server.
 
 For more detailed development instructions, refer to the [sample plugin](https://github.com/obsidianmd/obsidian-sample-plugin) provided by Obsidian.
+
+## Companion MCP server
+
+The repository includes a local stdio MCP server for direct LLM access to
+Amazing Marvin. Marvin-only operations do not need to pass through Obsidian.
+The MCP and plugin use the same typed client, local/public routing, cache, and
+error behavior.
+
+Build it with:
+
+```sh
+npm install
+npm run build
+```
+
+Then configure an MCP host with an absolute path to the generated server:
+
+```json
+{
+  "mcpServers": {
+    "amazing-marvin": {
+      "command": "node",
+      "args": ["/absolute/path/to/obsidian-am/packages/marvin-mcp/dist/server.js"],
+      "env": {
+        "AMAZING_MARVIN_API_TOKEN": "your-limited-api-token",
+        "AMAZING_MARVIN_USE_LOCAL": "true"
+      }
+    }
+  }
+}
+```
+
+`AMAZING_MARVIN_USE_LOCAL` is optional and defaults to `false`. When enabled,
+reads try `http://localhost:12082/api` before the public API. Override the
+origins with `AMAZING_MARVIN_LOCAL_API_URL` and
+`AMAZING_MARVIN_PUBLIC_API_URL`.
+
+The initial tool surface is deliberately small:
+
+- `marvin_today`
+- `marvin_due`
+- `marvin_create_task`
+- `marvin_mark_done`
+
+Read results identify whether data is fresh, cached, or stale. Errors retain
+the attempted local/public origins and throttling details. The server uses the
+limited API token only; it does not use Marvin's full-access CouchDB API.
+
+See
+[`docs/architecture/marvin-client-and-mcp.md`](docs/architecture/marvin-client-and-mcp.md)
+for package boundaries and the #51 extension seam.
 
 ### Testing
 
 While you're testing, you're going to send a lot of requests to the Amazing Marvin API. To avoid hitting the rate limit, you can use the Desktop local API server. See [Desktop Local API Server](https://help.amazingmarvin.com/en/articles/5165191-desktop-local-api-server) for more information. Once setup, you can specify the local API server in the plugin settings.
 
-Note that the `/api/children` endpoint is not available in the local API server, always returning 404. I've followed up with the Amazing Marvin team to see if this can be added.
+The desktop API implements a subset of the public API. Unsupported local read
+endpoints, historically including `/api/children`, fall back to the public
+API. A valid empty local response does not trigger fallback.

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -1,0 +1,52 @@
+# Marvin client and MCP boundaries
+
+The Amazing Marvin client and first MCP server intentionally live in this
+repository while the integration has two consumers. Their package boundaries
+allow a later split without making separate repositories a prerequisite.
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links | Obsidian vault/UI behavior; MCP schemas; source-note identity |
+| `src/marvin` | Obsidian `requestUrl` transport adapter | HTTP/API semantics, cache policy, or fallback decisions |
+| Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
+| `packages/marvin-mcp` | Stdio lifecycle, four tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
+
+Both runtime adapters construct `MarvinApiClient` instances and one
+`MarvinRouter`. Writes use the public API only. Safe reads may use the desktop
+API when explicitly enabled, then fall back only when the local endpoint is
+unavailable or unsupported.
+
+The Node fetch transport enforces request timeouts with cancellation.
+Obsidian's `requestUrl` API does not expose cancellation, so its timeout value
+is advisory at that adapter boundary. Neither adapter retries automatically;
+live Obsidian verification should include a stalled or unreachable endpoint.
+
+The router caches successful reads in memory. Empty arrays are successful data;
+errors are never cached as empty results. Stale-on-error responses are marked
+`freshness: "stale"` and carry the current failure. Task creation and
+completion invalidate today, due, and children entries.
+
+## Extension seam for #51
+
+The next layer should add deterministic integration operations above this
+client:
+
+- ensure one Marvin task for a stable Obsidian source/action key;
+- persist the resulting Marvin ID/deep link back to the source note; and
+- refresh a bounded daily-note region by stable Marvin ID without overwriting
+  surrounding prose.
+
+That source/action identity is not a task title and does not belong in MCP
+prompt text. The Obsidian projection remains responsible for note mutation;
+the shared client remains responsible for Marvin state and explicit failures.
+
+## Upstream and security boundary
+
+The client is an internal fork of
+[`@jacobboykin/amazing-marvin-client` v1.1.1](https://github.com/jacobboykin/amazing-marvin-client-js/tree/1f04630374c5ec9c3ff08e847dad96e8ad62fae9).
+Its provenance and MIT license are retained in
+`packages/marvin-client/UPSTREAM.md` and
+`packages/marvin-client/LICENSE.upstream`.
+
+Only Amazing Marvin's limited `X-API-Token` endpoints are in scope. Full-access
+CouchDB operations are intentionally absent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,18 @@
 {
-  "name": "cloud-atlas",
+  "name": "cloud-atlas-am",
   "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cloud-atlas",
+      "name": "cloud-atlas-am",
       "version": "0.9.9",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
+        "@open-horizon/marvin-client": "file:packages/marvin-client",
         "obsidian-daily-notes-interface": "^0.9.4"
       },
       "devDependencies": {
@@ -19,7 +23,8 @@
         "esbuild": "^0.19.7",
         "obsidian": "^1.4.11",
         "tslib": "^2.6.2",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.2",
+        "vitest": "^1.6.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -499,6 +504,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -559,6 +576,88 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -594,6 +693,410 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@open-horizon/marvin-client": {
+      "resolved": "packages/marvin-client",
+      "link": true
+    },
+    "node_modules/@open-horizon/marvin-mcp": {
+      "resolved": "packages/marvin-mcp",
+      "link": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
       "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -603,9 +1106,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -833,12 +1337,128 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -854,6 +1474,19 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -872,6 +1505,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -915,11 +1587,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -954,6 +1673,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -962,6 +1729,25 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/chalk": {
@@ -979,6 +1765,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/color-convert": {
@@ -1008,12 +1807,75 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
-      "peer": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1024,12 +1886,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1040,12 +1902,44 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1070,6 +1964,65 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1109,6 +2062,12 @@
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1286,6 +2245,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1296,12 +2265,126 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -1345,6 +2428,22 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -1377,6 +2476,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -1418,12 +2538,114 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1519,6 +2741,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1533,6 +2767,85 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -1585,9 +2898,25 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1629,12 +2958,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -1662,6 +3024,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1694,6 +3062,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1717,6 +3102,16 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1728,6 +3123,53 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1751,6 +3193,44 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -1766,6 +3246,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -1775,16 +3275,94 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/obsidian": {
       "version": "1.5.7",
@@ -1816,14 +3394,40 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -1889,6 +3493,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1913,10 +3526,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -1927,6 +3548,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1940,6 +3585,63 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1950,6 +3652,47 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1958,6 +3701,22 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -1979,6 +3738,50 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2016,6 +3819,67 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2039,6 +3903,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -2054,12 +3924,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2071,10 +3990,100 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/slash": {
@@ -2085,6 +4094,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -2099,6 +4141,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2110,6 +4165,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/style-mod": {
@@ -2138,6 +4206,33 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2148,6 +4243,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2181,6 +4285,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -2192,6 +4306,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2207,11 +4352,27 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -2221,6 +4382,594 @@
       "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/w3c-keyname": {
@@ -2233,8 +4982,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2245,12 +4992,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -2269,6 +5031,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "packages/marvin-client": {
+      "name": "@open-horizon/marvin-client",
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "packages/marvin-mcp": {
+      "name": "@open-horizon/marvin-mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@open-horizon/marvin-client": "file:../marvin-client",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "amazing-marvin-mcp": "dist/server.js"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,17 +2,27 @@
   "name": "cloud-atlas-am",
   "version": "0.9.9",
   "description": "Interoperability between Obsidian and Amazing Marvin",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "main": "dist/main.js",
   "scripts": {
-    "dev": "node esbuild.config.mjs",
-    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-    "dev-build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs dev-build",
+    "build": "npm run build:client && npm run build:plugin && npm run build:mcp",
+    "build:client": "npm run build --workspace @open-horizon/marvin-client",
+    "build:mcp": "npm run build --workspace @open-horizon/marvin-mcp",
+    "build:plugin": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "dev": "npm run build:client && node esbuild.config.mjs",
+    "dev-build": "npm run build:client && tsc -noEmit -skipLibCheck && node esbuild.config.mjs dev-build",
+    "test": "npm run build:client && vitest run",
+    "typecheck": "npm run build:client && tsc -noEmit -skipLibCheck && npm run typecheck --workspaces --if-present",
     "version": "node version-bump.mjs && git add manifest.json versions.json"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@open-horizon/marvin-client": "file:packages/marvin-client",
     "obsidian-daily-notes-interface": "^0.9.4"
   },
   "devDependencies": {
@@ -23,6 +33,7 @@
     "esbuild": "^0.19.7",
     "obsidian": "^1.4.11",
     "tslib": "^2.6.2",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^1.6.1"
   }
 }

--- a/packages/marvin-client/LICENSE.upstream
+++ b/packages/marvin-client/LICENSE.upstream
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jacob Boykin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/marvin-client/UPSTREAM.md
+++ b/packages/marvin-client/UPSTREAM.md
@@ -1,0 +1,14 @@
+# Upstream provenance
+
+This package is an internal fork derived from
+[`@jacobboykin/amazing-marvin-client` v1.1.1](https://github.com/jacobboykin/amazing-marvin-client-js/tree/1f04630374c5ec9c3ff08e847dad96e8ad62fae9),
+used under its MIT license.
+
+The fork retains the limited-token endpoint models and client patterns that
+are relevant to this repository. It intentionally changes the transport,
+packaging, retry, routing, cache, and error contracts so the same behavior is
+available to the Obsidian plugin and the in-repository MCP server.
+
+See
+[`docs/evaluations/0053-amazing-marvin-client.md`](../../docs/evaluations/0053-amazing-marvin-client.md)
+for the evidence and decision.

--- a/packages/marvin-client/package.json
+++ b/packages/marvin-client/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@open-horizon/marvin-client",
+  "version": "0.1.0",
+  "description": "Shared Amazing Marvin limited-token client for Obsidian and MCP adapters",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "LICENSE.upstream",
+    "UPSTREAM.md"
+  ],
+  "scripts": {
+    "build": "npm run clean && esbuild src/index.ts --bundle --platform=node --target=node18 --format=esm --outfile=dist/index.js && esbuild src/index.ts --bundle --platform=node --target=node18 --format=cjs --outfile=dist/index.cjs && tsc --project tsconfig.json --emitDeclarationOnly",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "typecheck": "tsc --project tsconfig.test.json --noEmit"
+  },
+  "sideEffects": false,
+  "license": "MIT"
+}

--- a/packages/marvin-client/src/cache.ts
+++ b/packages/marvin-client/src/cache.ts
@@ -1,0 +1,82 @@
+import type {
+	MarvinErrorSummary,
+	MarvinOrigin,
+} from "./types.js";
+
+export interface MarvinCachePolicy {
+	freshTtlMs: number;
+	staleIfErrorMs: number;
+}
+
+export interface MarvinCacheEntry<T> {
+	data: T;
+	origin: Exclude<MarvinOrigin, "mixed">;
+	fetchedAt: number;
+	expiresAt: number;
+	staleUntil: number;
+	warnings: MarvinErrorSummary[];
+}
+
+export class MarvinReadCache {
+	private readonly entries = new Map<string, MarvinCacheEntry<unknown>>();
+
+	constructor(private readonly maximumEntries = 128) {
+		if (maximumEntries <= 0) {
+			throw new Error("Cache maximum entries must be greater than zero");
+		}
+	}
+
+	get<T>(key: string, now: number): MarvinCacheEntry<T> | undefined {
+		const entry = this.entries.get(key) as MarvinCacheEntry<T> | undefined;
+		if (!entry) {
+			return undefined;
+		}
+		if (entry.staleUntil <= now) {
+			this.entries.delete(key);
+			return undefined;
+		}
+
+		this.entries.delete(key);
+		this.entries.set(key, entry);
+		return entry;
+	}
+
+	set<T>(
+		key: string,
+		value: {
+			data: T;
+			origin: Exclude<MarvinOrigin, "mixed">;
+			fetchedAt: number;
+			warnings: MarvinErrorSummary[];
+		},
+		policy: MarvinCachePolicy,
+	): void {
+		const entry: MarvinCacheEntry<T> = {
+			...value,
+			expiresAt: value.fetchedAt + policy.freshTtlMs,
+			staleUntil: value.fetchedAt + policy.freshTtlMs + policy.staleIfErrorMs,
+		};
+		this.entries.delete(key);
+		this.entries.set(key, entry);
+
+		while (this.entries.size > this.maximumEntries) {
+			const oldest = this.entries.keys().next().value as string | undefined;
+			if (oldest === undefined) {
+				break;
+			}
+			this.entries.delete(oldest);
+		}
+	}
+
+	invalidatePrefixes(prefixes: string[]): void {
+		for (const key of this.entries.keys()) {
+			if (prefixes.some((prefix) => key.startsWith(prefix))) {
+				this.entries.delete(key);
+			}
+		}
+	}
+
+	clear(): void {
+		this.entries.clear();
+	}
+}

--- a/packages/marvin-client/src/client.test.ts
+++ b/packages/marvin-client/src/client.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { MarvinApiClient } from "./client";
+import { jsonResponse, QueueTransport } from "./test-helpers";
+
+function client(transport: QueueTransport): MarvinApiClient {
+	return new MarvinApiClient({
+		apiToken: "test-token",
+		baseUrl: "https://example.test/api",
+		origin: "public",
+		transport,
+	});
+}
+
+describe("MarvinApiClient", () => {
+	it("uses the documented and encoded by parameter for due items", async () => {
+		const transport = new QueueTransport(jsonResponse(200, []));
+
+		await client(transport).getDueItems("2026-07-23 & later");
+
+		expect(transport.requests).toHaveLength(1);
+		expect(transport.requests[0]?.url).toBe(
+			"https://example.test/api/dueItems?by=2026-07-23+%26+later",
+		);
+	});
+
+	it("defaults task done to false without requiring callers to provide it", async () => {
+		const transport = new QueueTransport(
+			jsonResponse(200, { _id: "task-1", title: "Decide", done: false }),
+		);
+
+		await client(transport).addTask({ title: "Decide" });
+
+		expect(JSON.parse(transport.requests[0]?.body ?? "{}")).toEqual({
+			done: false,
+			title: "Decide",
+		});
+	});
+
+	it("keeps a successful empty list distinct from a failure", async () => {
+		const transport = new QueueTransport(
+			jsonResponse(200, []),
+			{
+				status: 503,
+				statusText: "Unavailable",
+				headers: {},
+				text: "maintenance",
+			},
+		);
+		const api = client(transport);
+
+		await expect(api.getTodayItems("2026-07-23")).resolves.toEqual([]);
+		await expect(api.getTodayItems("2026-07-24")).rejects.toMatchObject({
+			kind: "http",
+			status: 503,
+			responseBody: "maintenance",
+		});
+	});
+
+	it("does not retry a throttled request", async () => {
+		const transport = new QueueTransport({
+			status: 429,
+			statusText: "Too Many Requests",
+			headers: { "retry-after": "30" },
+			text: "slow down",
+		});
+
+		await expect(client(transport).getCategories()).rejects.toMatchObject({
+			kind: "throttle",
+			status: 429,
+			retryAfterMs: 30_000,
+			responseBody: "slow down",
+		});
+		expect(transport.requests).toHaveLength(1);
+	});
+
+	it("rejects malformed successful read responses before they can be cached", async () => {
+		const transport = new QueueTransport(jsonResponse(200, { not: "an array" }));
+
+		await expect(client(transport).getTodayItems()).rejects.toMatchObject({
+			kind: "validation",
+		});
+	});
+});

--- a/packages/marvin-client/src/client.ts
+++ b/packages/marvin-client/src/client.ts
@@ -1,0 +1,247 @@
+import { asMarvinError, MarvinError } from "./errors.js";
+import type {
+	AddTaskRequest,
+	Category,
+	MarkDoneResult,
+	MarvinOrigin,
+	MarvinTransport,
+	MarvinTransportRequest,
+	Project,
+	Task,
+	TaskOrProject,
+} from "./types.js";
+
+const DEFAULT_PUBLIC_BASE_URL = "https://serv.amazingmarvin.com/api";
+
+export interface MarvinApiClientOptions {
+	apiToken: string;
+	transport: MarvinTransport;
+	origin: Exclude<MarvinOrigin, "mixed">;
+	baseUrl?: string;
+	timeoutMs?: number;
+}
+
+function parseRetryAfter(value: string | undefined, now = Date.now()): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+
+	const seconds = Number(value);
+	if (!Number.isNaN(seconds)) {
+		return Math.max(0, Math.floor(seconds * 1_000));
+	}
+
+	const date = Date.parse(value);
+	return Number.isNaN(date) ? undefined : Math.max(0, date - now);
+}
+
+function requireArray<T>(
+	value: unknown,
+	context: {
+		operation: string;
+		origin: Exclude<MarvinOrigin, "mixed">;
+		endpoint: string;
+		method: string;
+	},
+): T[] {
+	if (!Array.isArray(value)) {
+		throw new MarvinError({
+			kind: "validation",
+			message: `Amazing Marvin ${context.operation} returned a non-array response`,
+			...context,
+		});
+	}
+	return value as T[];
+}
+
+function requireTask(
+	value: unknown,
+	context: {
+		operation: string;
+		origin: Exclude<MarvinOrigin, "mixed">;
+		endpoint: string;
+		method: string;
+	},
+): Task {
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| typeof (value as Partial<Task>)._id !== "string"
+		|| typeof (value as Partial<Task>).title !== "string"
+	) {
+		throw new MarvinError({
+			kind: "validation",
+			message: `Amazing Marvin ${context.operation} returned an invalid task`,
+			...context,
+		});
+	}
+	return value as Task;
+}
+
+export class MarvinApiClient {
+	readonly origin: Exclude<MarvinOrigin, "mixed">;
+	private readonly apiToken: string;
+	private readonly baseUrl: string;
+	private readonly timeoutMs: number;
+	private readonly transport: MarvinTransport;
+
+	constructor(options: MarvinApiClientOptions) {
+		if (!options.apiToken.trim()) {
+			throw new Error("Amazing Marvin API token is required");
+		}
+		this.apiToken = options.apiToken;
+		this.transport = options.transport;
+		this.origin = options.origin;
+		this.baseUrl = (options.baseUrl ?? DEFAULT_PUBLIC_BASE_URL).replace(/\/+$/, "");
+		this.timeoutMs = options.timeoutMs ?? 10_000;
+		if (this.timeoutMs <= 0) {
+			throw new Error("Amazing Marvin timeout must be greater than zero");
+		}
+	}
+
+	async getTodayItems(date?: string): Promise<TaskOrProject[]> {
+		const endpoint = this.withQuery("/todayItems", date ? { date } : {});
+		const value = await this.requestJson("today items", endpoint, "GET");
+		return requireArray<TaskOrProject>(value, this.context("today items", endpoint, "GET"));
+	}
+
+	async getDueItems(by?: string): Promise<TaskOrProject[]> {
+		const endpoint = this.withQuery("/dueItems", by ? { by } : {});
+		const value = await this.requestJson("due items", endpoint, "GET");
+		return requireArray<TaskOrProject>(value, this.context("due items", endpoint, "GET"));
+	}
+
+	async getCategories(): Promise<(Category | Project)[]> {
+		const endpoint = "/categories";
+		const value = await this.requestJson("categories", endpoint, "GET");
+		return requireArray<Category | Project>(
+			value,
+			this.context("categories", endpoint, "GET"),
+		);
+	}
+
+	async getChildren(parentId: string): Promise<(Task | Project)[]> {
+		const endpoint = this.withQuery("/children", { parentId });
+		const value = await this.requestJson("children", endpoint, "GET");
+		return requireArray<Task | Project>(value, this.context("children", endpoint, "GET"));
+	}
+
+	async addTask(task: AddTaskRequest): Promise<Task> {
+		const endpoint = "/addTask";
+		const value = await this.requestJson("add task", endpoint, "POST", {
+			done: false,
+			...task,
+		});
+		return requireTask(value, this.context("add task", endpoint, "POST"));
+	}
+
+	async markDone(itemId: string, timeZoneOffset?: number): Promise<MarkDoneResult> {
+		const endpoint = "/markDone";
+		const value = await this.requestJson(
+			"mark done",
+			endpoint,
+			"POST",
+			{
+				itemId,
+				...(timeZoneOffset === undefined ? {} : { timeZoneOffset }),
+			},
+			true,
+		);
+
+		if (value === null) {
+			return null;
+		}
+		if (typeof value !== "object" || Array.isArray(value)) {
+			throw new MarvinError({
+				kind: "validation",
+				message: "Amazing Marvin mark done returned an invalid response",
+				...this.context("mark done", endpoint, "POST"),
+			});
+		}
+		return value as Record<string, unknown>;
+	}
+
+	private context(
+		operation: string,
+		endpoint: string,
+		method: MarvinTransportRequest["method"],
+	) {
+		return {
+			operation,
+			origin: this.origin,
+			endpoint,
+			method,
+		};
+	}
+
+	private withQuery(endpoint: string, query: Record<string, string>): string {
+		const params = new URLSearchParams(query);
+		const serialized = params.toString();
+		return serialized ? `${endpoint}?${serialized}` : endpoint;
+	}
+
+	private async requestJson(
+		operation: string,
+		endpoint: string,
+		method: MarvinTransportRequest["method"],
+		body?: unknown,
+		allowEmpty = false,
+	): Promise<unknown> {
+		const request: MarvinTransportRequest = {
+			url: `${this.baseUrl}${endpoint}`,
+			method,
+			headers: {
+				"Content-Type": "application/json",
+				"X-API-Token": this.apiToken,
+			},
+			...(body === undefined ? {} : { body: JSON.stringify(body) }),
+			timeoutMs: this.timeoutMs,
+		};
+
+		let response;
+		try {
+			response = await this.transport.request(request);
+		} catch (error) {
+			throw asMarvinError(error, {
+				kind: "transport",
+				...this.context(operation, endpoint, method),
+			});
+		}
+
+		if (response.status < 200 || response.status >= 300) {
+			const retryAfterMs = parseRetryAfter(response.headers["retry-after"]);
+			throw new MarvinError({
+				kind: response.status === 429 ? "throttle" : "http",
+				message: `Amazing Marvin ${operation} failed with HTTP ${response.status}`,
+				...this.context(operation, endpoint, method),
+				status: response.status,
+				...(response.statusText === undefined ? {} : { statusText: response.statusText }),
+				responseBody: response.text,
+				...(retryAfterMs === undefined ? {} : { retryAfterMs }),
+			});
+		}
+
+		if (!response.text.trim()) {
+			if (allowEmpty) {
+				return null;
+			}
+			throw new MarvinError({
+				kind: "parse",
+				message: `Amazing Marvin ${operation} returned an empty response`,
+				...this.context(operation, endpoint, method),
+			});
+		}
+
+		try {
+			return JSON.parse(response.text) as unknown;
+		} catch (error) {
+			throw new MarvinError({
+				kind: "parse",
+				message: `Amazing Marvin ${operation} returned invalid JSON`,
+				...this.context(operation, endpoint, method),
+				responseBody: response.text,
+				cause: error,
+			});
+		}
+	}
+}

--- a/packages/marvin-client/src/errors.ts
+++ b/packages/marvin-client/src/errors.ts
@@ -1,0 +1,119 @@
+import type {
+	MarvinErrorSummary,
+	MarvinOrigin,
+} from "./types.js";
+
+type ErrorKind = MarvinErrorSummary["kind"];
+type ConcreteOrigin = Exclude<MarvinOrigin, "mixed">;
+
+export interface MarvinErrorOptions {
+	kind: ErrorKind;
+	message: string;
+	operation: string;
+	origin: ConcreteOrigin;
+	endpoint?: string;
+	method?: string;
+	status?: number;
+	statusText?: string;
+	responseBody?: string;
+	retryAfterMs?: number;
+	cause?: unknown;
+}
+
+export class MarvinError extends Error {
+	readonly kind: ErrorKind;
+	readonly operation: string;
+	readonly origin: ConcreteOrigin;
+	readonly endpoint: string | undefined;
+	readonly method: string | undefined;
+	readonly status: number | undefined;
+	readonly statusText: string | undefined;
+	readonly responseBody: string | undefined;
+	readonly retryAfterMs: number | undefined;
+	override readonly cause: unknown;
+
+	constructor(options: MarvinErrorOptions) {
+		super(options.message);
+		this.name = "MarvinError";
+		this.kind = options.kind;
+		this.operation = options.operation;
+		this.origin = options.origin;
+		this.endpoint = options.endpoint;
+		this.method = options.method;
+		this.status = options.status;
+		this.statusText = options.statusText;
+		this.responseBody = options.responseBody;
+		this.retryAfterMs = options.retryAfterMs;
+		this.cause = options.cause;
+	}
+
+	isTransient(): boolean {
+		return this.kind === "transport"
+			|| this.kind === "throttle"
+			|| (this.status !== undefined && this.status >= 500);
+	}
+
+	toSummary(): MarvinErrorSummary {
+		return {
+			kind: this.kind,
+			message: this.message,
+			operation: this.operation,
+			origin: this.origin,
+			...(this.endpoint === undefined ? {} : { endpoint: this.endpoint }),
+			...(this.method === undefined ? {} : { method: this.method }),
+			...(this.status === undefined ? {} : { status: this.status }),
+			...(this.statusText === undefined ? {} : { statusText: this.statusText }),
+			...(this.responseBody === undefined ? {} : { responseBody: this.responseBody }),
+			...(this.retryAfterMs === undefined ? {} : { retryAfterMs: this.retryAfterMs }),
+		};
+	}
+}
+
+export class MarvinRouteError extends MarvinError {
+	readonly attempts: MarvinError[];
+
+	constructor(operation: string, attempts: MarvinError[]) {
+		const last = attempts[attempts.length - 1];
+		super({
+			kind: "route",
+			message: `Amazing Marvin ${operation} failed via ${attempts
+				.map((attempt) => attempt.origin)
+				.join(" then ")}`,
+			operation,
+			origin: last?.origin ?? "public",
+			...(last?.endpoint === undefined ? {} : { endpoint: last.endpoint }),
+			...(last?.method === undefined ? {} : { method: last.method }),
+			...(last?.status === undefined ? {} : { status: last.status }),
+			...(last?.statusText === undefined ? {} : { statusText: last.statusText }),
+			...(last?.responseBody === undefined ? {} : { responseBody: last.responseBody }),
+			...(last?.retryAfterMs === undefined ? {} : { retryAfterMs: last.retryAfterMs }),
+			cause: last,
+		});
+		this.name = "MarvinRouteError";
+		this.attempts = attempts;
+	}
+
+	override isTransient(): boolean {
+		return this.attempts.at(-1)?.isTransient() ?? false;
+	}
+}
+
+export function asMarvinError(
+	error: unknown,
+	context: Pick<MarvinErrorOptions, "operation" | "origin"> & Partial<MarvinErrorOptions>,
+): MarvinError {
+	if (error instanceof MarvinError) {
+		return error;
+	}
+
+	const cause = error instanceof Error ? error : undefined;
+	return new MarvinError({
+		kind: "transport",
+		message: cause?.message ?? String(error),
+		operation: context.operation,
+		origin: context.origin,
+		...(context.endpoint === undefined ? {} : { endpoint: context.endpoint }),
+		...(context.method === undefined ? {} : { method: context.method }),
+		cause: error,
+	});
+}

--- a/packages/marvin-client/src/index.ts
+++ b/packages/marvin-client/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./cache.js";
+export * from "./client.js";
+export * from "./errors.js";
+export * from "./router.js";
+export * from "./transport.js";
+export * from "./types.js";

--- a/packages/marvin-client/src/package.test.ts
+++ b/packages/marvin-client/src/package.test.ts
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("@open-horizon/marvin-client package", () => {
+	it("loads through native ESM and CommonJS entry points", () => {
+		const cwd = process.cwd();
+		const esm = execFileSync(
+			process.execPath,
+			[
+				"--input-type=module",
+				"--eval",
+				"import { MarvinRouter } from '@open-horizon/marvin-client'; process.stdout.write(typeof MarvinRouter)",
+			],
+			{ cwd, encoding: "utf8" },
+		);
+		const commonJs = execFileSync(
+			process.execPath,
+			[
+				"--eval",
+				"const { MarvinRouter } = require('@open-horizon/marvin-client'); process.stdout.write(typeof MarvinRouter)",
+			],
+			{ cwd, encoding: "utf8" },
+		);
+
+		expect(esm).toBe("function");
+		expect(commonJs).toBe("function");
+	});
+});

--- a/packages/marvin-client/src/router.test.ts
+++ b/packages/marvin-client/src/router.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+import { MarvinReadCache } from "./cache";
+import { MarvinApiClient } from "./client";
+import { MarvinRouteError } from "./errors";
+import { MarvinRouter, marvinDeepLink } from "./router";
+import { jsonResponse, QueueTransport } from "./test-helpers";
+import type { MarvinTransportResponse } from "./types";
+
+function api(
+	origin: "local" | "public",
+	transport: QueueTransport,
+): MarvinApiClient {
+	return new MarvinApiClient({
+		apiToken: "test-token",
+		baseUrl: origin === "local"
+			? "http://localhost:12082/api"
+			: "https://example.test/api",
+		origin,
+		transport,
+	});
+}
+
+describe("MarvinRouter", () => {
+	it("never contacts local when no configured local client exists", async () => {
+		const local = new QueueTransport(jsonResponse(200, ["unexpected"]));
+		const publicApi = new QueueTransport(jsonResponse(200, []));
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getTodayItems("2026-07-23")).resolves.toMatchObject({
+			data: [],
+			freshness: "fresh",
+			origin: "public",
+		});
+		expect(local.requests).toHaveLength(0);
+		expect(publicApi.requests).toHaveLength(1);
+	});
+
+	it("accepts a successful empty local result without public fallback", async () => {
+		const local = new QueueTransport(jsonResponse(200, []));
+		const publicApi = new QueueTransport(jsonResponse(200, ["unexpected"]));
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getTodayItems("2026-07-23")).resolves.toMatchObject({
+			data: [],
+			origin: "local",
+		});
+		expect(local.requests).toHaveLength(1);
+		expect(publicApi.requests).toHaveLength(0);
+	});
+
+	it("falls back for an unsupported local endpoint and exposes why", async () => {
+		const local = new QueueTransport({
+			status: 404,
+			statusText: "Not Found",
+			headers: {},
+			text: "unsupported",
+		});
+		const publicApi = new QueueTransport(
+			jsonResponse(200, [{ _id: "task-1", title: "Task", done: false }]),
+		);
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		const result = await router.getChildren("unassigned");
+
+		expect(result.origin).toBe("public");
+		expect(result.warnings).toMatchObject([
+			{ origin: "local", status: 404, responseBody: "unsupported" },
+		]);
+	});
+
+	it("preserves both attempted-origin failures", async () => {
+		const local = new QueueTransport(new Error("ECONNREFUSED"));
+		const publicApi = new QueueTransport({
+			status: 503,
+			statusText: "Unavailable",
+			headers: {},
+			text: "maintenance",
+		});
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getCategories()).rejects.toSatisfy((error) => {
+			expect(error).toBeInstanceOf(MarvinRouteError);
+			if (!(error instanceof MarvinRouteError)) {
+				return false;
+			}
+			expect(error.attempts).toMatchObject([
+				{ origin: "local", kind: "transport", message: "ECONNREFUSED" },
+				{ origin: "public", kind: "http", status: 503 },
+			]);
+			return true;
+		});
+	});
+
+	it("does not turn a local throttle into a public request", async () => {
+		const local = new QueueTransport({
+			status: 429,
+			statusText: "Too Many Requests",
+			headers: { "retry-after": "30" },
+			text: "slow down",
+		});
+		const publicApi = new QueueTransport(jsonResponse(200, []));
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getTodayItems()).rejects.toMatchObject({
+			attempts: [{ origin: "local", status: 429 }],
+		});
+		expect(publicApi.requests).toHaveLength(0);
+	});
+
+	it("does not hide a local authentication failure behind public fallback", async () => {
+		const local = new QueueTransport({
+			status: 401,
+			statusText: "Unauthorized",
+			headers: {},
+			text: "bad token",
+		});
+		const publicApi = new QueueTransport(jsonResponse(200, []));
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getCategories()).rejects.toMatchObject({
+			attempts: [{ origin: "local", status: 401, responseBody: "bad token" }],
+		});
+		expect(publicApi.requests).toHaveLength(0);
+	});
+
+	it("reuses a fresh cached read", async () => {
+		const publicApi = new QueueTransport(jsonResponse(200, []));
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		expect((await router.getTodayItems("2026-07-23")).freshness).toBe("fresh");
+		expect((await router.getTodayItems("2026-07-23")).freshness).toBe("cached");
+		expect(publicApi.requests).toHaveLength(1);
+	});
+
+	it("coalesces concurrent reads for the same key", async () => {
+		let release: ((value: MarvinTransportResponse) => void) | undefined;
+		let calls = 0;
+		const response = new Promise<MarvinTransportResponse>((resolve) => {
+			release = resolve;
+		});
+		const transport = {
+			request: async () => {
+				calls += 1;
+				return response;
+			},
+		};
+		const router = new MarvinRouter({
+			publicClient: new MarvinApiClient({
+				apiToken: "test-token",
+				baseUrl: "https://example.test/api",
+				origin: "public",
+				transport,
+			}),
+		});
+
+		const first = router.getTodayItems("2026-07-23");
+		const second = router.getTodayItems("2026-07-23");
+		release?.(jsonResponse(200, []));
+
+		await expect(Promise.all([first, second])).resolves.toMatchObject([
+			{ data: [], freshness: "fresh" },
+			{ data: [], freshness: "fresh" },
+		]);
+		expect(calls).toBe(1);
+	});
+
+	it("returns explicitly stale data on throttle and opens a public circuit", async () => {
+		let now = 1_000;
+		const publicApi = new QueueTransport(
+			jsonResponse(200, [{ _id: "task-1", title: "Cached", done: false }]),
+			{
+				status: 429,
+				statusText: "Too Many Requests",
+				headers: { "retry-after": "30" },
+				text: "slow down",
+			},
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+			now: () => now,
+		});
+
+		await router.getTodayItems("2026-07-23");
+		now += 31_000;
+		const firstStale = await router.getTodayItems("2026-07-23");
+		const circuitStale = await router.getTodayItems("2026-07-23");
+
+		expect(firstStale).toMatchObject({
+			freshness: "stale",
+			data: [{ _id: "task-1" }],
+			warnings: [{ kind: "throttle", status: 429 }],
+		});
+		expect(circuitStale.freshness).toBe("stale");
+		expect(publicApi.requests).toHaveLength(2);
+	});
+
+	it("does not cache failures as empty successes", async () => {
+		const publicApi = new QueueTransport(
+			{
+				status: 503,
+				statusText: "Unavailable",
+				headers: {},
+				text: "maintenance",
+			},
+			jsonResponse(200, []),
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getDueItems("2026-07-23")).rejects.toBeInstanceOf(
+			MarvinRouteError,
+		);
+		await expect(router.getDueItems("2026-07-23")).resolves.toMatchObject({
+			data: [],
+			freshness: "fresh",
+		});
+		expect(publicApi.requests).toHaveLength(2);
+	});
+
+	it("invalidates task-list reads after a write", async () => {
+		const publicApi = new QueueTransport(
+			jsonResponse(200, []),
+			jsonResponse(200, { _id: "task-1", title: "New", done: false }),
+			jsonResponse(200, [{ _id: "task-1", title: "New", done: false }]),
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		await router.getTodayItems("2026-07-23");
+		await router.addTask({ title: "New" });
+		const refreshed = await router.getTodayItems("2026-07-23");
+
+		expect(refreshed.data).toHaveLength(1);
+		expect(publicApi.requests).toHaveLength(3);
+	});
+
+	it("deduplicates scheduled and due results by Marvin ID", async () => {
+		const publicApi = new QueueTransport(
+			jsonResponse(200, [
+				{ _id: "same", title: "Scheduled", done: false },
+				{ _id: "today-only", title: "Today", done: false },
+			]),
+			jsonResponse(200, [
+				{ _id: "same", title: "Due", done: false },
+				{ _id: "due-only", title: "Due", done: false },
+			]),
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		const result = await router.getTodayAndDue("2026-07-23");
+
+		expect(result.data.map((item) => item._id)).toEqual([
+			"same",
+			"today-only",
+			"due-only",
+		]);
+		expect(publicApi.requests.map((request) => request.url)).toEqual([
+			"https://example.test/api/todayItems?date=2026-07-23",
+			"https://example.test/api/dueItems?by=2026-07-23",
+		]);
+	});
+
+	it("bounds the read cache and uses container deep links", () => {
+		const cache = new MarvinReadCache(2);
+		const policy = { freshTtlMs: 1_000, staleIfErrorMs: 1_000 };
+		cache.set("today:1", {
+			data: [],
+			origin: "public",
+			fetchedAt: 0,
+			warnings: [],
+		}, policy);
+		cache.set("today:2", {
+			data: [],
+			origin: "public",
+			fetchedAt: 0,
+			warnings: [],
+		}, policy);
+		cache.set("today:3", {
+			data: [],
+			origin: "public",
+			fetchedAt: 0,
+			warnings: [],
+		}, policy);
+
+		expect(cache.get("today:1", 1)).toBeUndefined();
+		expect(cache.get("today:2", 1)).toBeDefined();
+		expect(marvinDeepLink({ _id: "category-1", type: "category" })).toBe(
+			"https://app.amazingmarvin.com/#p=category-1",
+		);
+	});
+});

--- a/packages/marvin-client/src/router.ts
+++ b/packages/marvin-client/src/router.ts
@@ -1,0 +1,327 @@
+import { MarvinApiClient } from "./client.js";
+import {
+	MarvinReadCache,
+	type MarvinCachePolicy,
+} from "./cache.js";
+import {
+	MarvinError,
+	MarvinRouteError,
+	asMarvinError,
+} from "./errors.js";
+import type {
+	AddTaskRequest,
+	Category,
+	MarkDoneResult,
+	MarvinErrorSummary,
+	MarvinItem,
+	MarvinOrigin,
+	MarvinReadResult,
+	Project,
+	Task,
+	TaskOrProject,
+} from "./types.js";
+
+const LOCAL_FALLBACK_STATUSES = new Set([404, 405, 500, 501, 502, 503, 504]);
+const DEFAULT_THROTTLE_BLOCK_MS = 60_000;
+
+const DEFAULT_CACHE_POLICIES = {
+	today: { freshTtlMs: 30_000, staleIfErrorMs: 10 * 60_000 },
+	due: { freshTtlMs: 30_000, staleIfErrorMs: 10 * 60_000 },
+	children: { freshTtlMs: 60_000, staleIfErrorMs: 15 * 60_000 },
+	categories: { freshTtlMs: 5 * 60_000, staleIfErrorMs: 60 * 60_000 },
+} satisfies Record<ReadKind, MarvinCachePolicy>;
+
+type ReadKind = "today" | "due" | "children" | "categories";
+
+export interface MarvinRouterOptions {
+	publicClient: MarvinApiClient;
+	localClient?: MarvinApiClient;
+	cache?: MarvinReadCache;
+	cachePolicies?: Partial<Record<ReadKind, MarvinCachePolicy>>;
+	now?: () => number;
+}
+
+interface RoutedValue<T> {
+	data: T;
+	origin: Exclude<MarvinOrigin, "mixed">;
+	warnings: MarvinErrorSummary[];
+}
+
+export function dedupeById<T extends BaseId>(items: Iterable<T>): T[] {
+	const byId = new Map<string, T>();
+	for (const item of items) {
+		if (!byId.has(item._id)) {
+			byId.set(item._id, item);
+		}
+	}
+	return Array.from(byId.values());
+}
+
+interface BaseId {
+	_id: string;
+}
+
+export function marvinDeepLink(item: Pick<MarvinItem, "_id" | "type">): string {
+	const isContainer = item.type === "project" || item.type === "category";
+	return `https://app.amazingmarvin.com/#${isContainer ? "p" : "t"}=${item._id}`;
+}
+
+export class MarvinRouter {
+	private readonly publicClient: MarvinApiClient;
+	private readonly localClient: MarvinApiClient | undefined;
+	private readonly cache: MarvinReadCache;
+	private readonly policies: Record<ReadKind, MarvinCachePolicy>;
+	private readonly now: () => number;
+	private readonly inFlight = new Map<string, Promise<MarvinReadResult<unknown>>>();
+	private publicBlockedUntil = 0;
+
+	constructor(options: MarvinRouterOptions) {
+		this.publicClient = options.publicClient;
+		this.localClient = options.localClient;
+		this.cache = options.cache ?? new MarvinReadCache();
+		this.policies = {
+			...DEFAULT_CACHE_POLICIES,
+			...options.cachePolicies,
+		};
+		this.now = options.now ?? Date.now;
+	}
+
+	getTodayItems(date?: string): Promise<MarvinReadResult<TaskOrProject[]>> {
+		return this.readThrough(
+			`today:${date ?? "server-today"}`,
+			this.policies.today,
+			"today items",
+			(client) => client.getTodayItems(date),
+		);
+	}
+
+	getDueItems(by?: string): Promise<MarvinReadResult<TaskOrProject[]>> {
+		return this.readThrough(
+			`due:${by ?? "server-today"}`,
+			this.policies.due,
+			"due items",
+			(client) => client.getDueItems(by),
+		);
+	}
+
+	getCategories(): Promise<MarvinReadResult<(Category | Project)[]>> {
+		return this.readThrough(
+			"categories",
+			this.policies.categories,
+			"categories",
+			(client) => client.getCategories(),
+		);
+	}
+
+	getChildren(parentId: string): Promise<MarvinReadResult<(Task | Project)[]>> {
+		return this.readThrough(
+			`children:${parentId}`,
+			this.policies.children,
+			"children",
+			(client) => client.getChildren(parentId),
+		);
+	}
+
+	async getTodayAndDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>> {
+		const [today, due] = await Promise.all([
+			this.getTodayItems(date),
+			this.getDueItems(date),
+		]);
+		const fetchedAt = Math.min(today.fetchedAt, due.fetchedAt);
+
+		return {
+			data: dedupeById([...today.data, ...due.data]),
+			freshness: this.leastFresh(today.freshness, due.freshness),
+			origin: today.origin === due.origin ? today.origin : "mixed",
+			fetchedAt,
+			ageMs: Math.max(0, this.now() - fetchedAt),
+			warnings: [...today.warnings, ...due.warnings],
+		};
+	}
+
+	async addTask(task: AddTaskRequest): Promise<Task> {
+		try {
+			return await this.runPublic("add task", (client) => client.addTask(task));
+		} finally {
+			this.invalidateTaskLists();
+		}
+	}
+
+	async markDone(itemId: string, timeZoneOffset?: number): Promise<MarkDoneResult> {
+		try {
+			return await this.runPublic(
+				"mark done",
+				(client) => client.markDone(itemId, timeZoneOffset),
+			);
+		} finally {
+			this.invalidateTaskLists();
+		}
+	}
+
+	clearCache(): void {
+		this.cache.clear();
+	}
+
+	private invalidateTaskLists(): void {
+		this.cache.invalidatePrefixes(["today:", "due:", "children:"]);
+	}
+
+	private async readThrough<T>(
+		key: string,
+		policy: MarvinCachePolicy,
+		operation: string,
+		read: (client: MarvinApiClient) => Promise<T>,
+	): Promise<MarvinReadResult<T>> {
+		const startedAt = this.now();
+		const cached = this.cache.get<T>(key, startedAt);
+		if (cached && cached.expiresAt > startedAt) {
+			return {
+				data: cached.data,
+				freshness: "cached",
+				origin: cached.origin,
+				fetchedAt: cached.fetchedAt,
+				ageMs: Math.max(0, startedAt - cached.fetchedAt),
+				warnings: cached.warnings,
+			};
+		}
+
+		const existing = this.inFlight.get(key) as Promise<MarvinReadResult<T>> | undefined;
+		if (existing) {
+			return existing;
+		}
+
+		const pending = this.fetchAndCache(
+			key,
+			policy,
+			operation,
+			read,
+			cached,
+		).finally(() => {
+			this.inFlight.delete(key);
+		});
+		this.inFlight.set(key, pending as Promise<MarvinReadResult<unknown>>);
+		return pending;
+	}
+
+	private async fetchAndCache<T>(
+		key: string,
+		policy: MarvinCachePolicy,
+		operation: string,
+		read: (client: MarvinApiClient) => Promise<T>,
+		stale: ReturnType<MarvinReadCache["get"]> | undefined,
+	): Promise<MarvinReadResult<T>> {
+		try {
+			const routed = await this.routeRead(operation, read);
+			const fetchedAt = this.now();
+			this.cache.set(key, { ...routed, fetchedAt }, policy);
+			return {
+				...routed,
+				freshness: "fresh",
+				fetchedAt,
+				ageMs: 0,
+			};
+		} catch (error) {
+			const routeError = error instanceof MarvinRouteError
+				? error
+				: new MarvinRouteError(operation, [
+					asMarvinError(error, { operation, origin: "public" }),
+				]);
+			const now = this.now();
+			if (stale && stale.staleUntil > now && routeError.isTransient()) {
+				return {
+					data: stale.data as T,
+					freshness: "stale",
+					origin: stale.origin,
+					fetchedAt: stale.fetchedAt,
+					ageMs: Math.max(0, now - stale.fetchedAt),
+					warnings: [
+						...stale.warnings,
+						...routeError.attempts.map((attempt) => attempt.toSummary()),
+					],
+				};
+			}
+			throw routeError;
+		}
+	}
+
+	private async routeRead<T>(
+		operation: string,
+		read: (client: MarvinApiClient) => Promise<T>,
+	): Promise<RoutedValue<T>> {
+		const attempts: MarvinError[] = [];
+
+		if (this.localClient) {
+			try {
+				return {
+					data: await read(this.localClient),
+					origin: "local",
+					warnings: [],
+				};
+			} catch (error) {
+				const localError = asMarvinError(error, {
+					operation,
+					origin: "local",
+				});
+				attempts.push(localError);
+				if (!this.mayFallBackFromLocal(localError)) {
+					throw new MarvinRouteError(operation, attempts);
+				}
+			}
+		}
+
+		try {
+			return {
+				data: await this.runPublic(operation, read),
+				origin: "public",
+				warnings: attempts.map((attempt) => attempt.toSummary()),
+			};
+		} catch (error) {
+			attempts.push(asMarvinError(error, { operation, origin: "public" }));
+			throw new MarvinRouteError(operation, attempts);
+		}
+	}
+
+	private mayFallBackFromLocal(error: MarvinError): boolean {
+		return error.kind === "transport"
+			|| (error.status !== undefined && LOCAL_FALLBACK_STATUSES.has(error.status));
+	}
+
+	private async runPublic<T>(
+		operation: string,
+		call: (client: MarvinApiClient) => Promise<T>,
+	): Promise<T> {
+		const now = this.now();
+		if (this.publicBlockedUntil > now) {
+			throw new MarvinError({
+				kind: "throttle",
+				message: `Amazing Marvin public API is throttled for ${this.publicBlockedUntil - now}ms`,
+				operation,
+				origin: "public",
+				status: 429,
+				retryAfterMs: this.publicBlockedUntil - now,
+			});
+		}
+
+		try {
+			return await call(this.publicClient);
+		} catch (error) {
+			const marvinError = asMarvinError(error, {
+				operation,
+				origin: "public",
+			});
+			if (marvinError.status === 429) {
+				this.publicBlockedUntil = now
+					+ (marvinError.retryAfterMs ?? DEFAULT_THROTTLE_BLOCK_MS);
+			}
+			throw marvinError;
+		}
+	}
+
+	private leastFresh(
+		left: MarvinReadResult<unknown>["freshness"],
+		right: MarvinReadResult<unknown>["freshness"],
+	): MarvinReadResult<unknown>["freshness"] {
+		const score = { fresh: 0, cached: 1, stale: 2 } as const;
+		return score[left] >= score[right] ? left : right;
+	}
+}

--- a/packages/marvin-client/src/test-helpers.ts
+++ b/packages/marvin-client/src/test-helpers.ts
@@ -1,0 +1,45 @@
+import type {
+	MarvinTransport,
+	MarvinTransportRequest,
+	MarvinTransportResponse,
+} from "./types";
+
+type QueuedResult = MarvinTransportResponse | Error;
+
+export function jsonResponse(
+	status: number,
+	value: unknown,
+	headers: Record<string, string> = {},
+): MarvinTransportResponse {
+	return {
+		status,
+		statusText: status >= 200 && status < 300 ? "OK" : "Error",
+		headers,
+		text: JSON.stringify(value),
+	};
+}
+
+export class QueueTransport implements MarvinTransport {
+	readonly requests: MarvinTransportRequest[] = [];
+	private readonly queue: QueuedResult[];
+
+	constructor(...results: QueuedResult[]) {
+		this.queue = [...results];
+	}
+
+	push(...results: QueuedResult[]): void {
+		this.queue.push(...results);
+	}
+
+	async request(request: MarvinTransportRequest): Promise<MarvinTransportResponse> {
+		this.requests.push(request);
+		const next = this.queue.shift();
+		if (!next) {
+			throw new Error(`No fake response queued for ${request.method} ${request.url}`);
+		}
+		if (next instanceof Error) {
+			throw next;
+		}
+		return next;
+	}
+}

--- a/packages/marvin-client/src/transport.ts
+++ b/packages/marvin-client/src/transport.ts
@@ -1,0 +1,47 @@
+import type {
+	MarvinTransport,
+	MarvinTransportRequest,
+	MarvinTransportResponse,
+} from "./types.js";
+
+export type FetchLike = (
+	input: string | URL | Request,
+	init?: RequestInit,
+) => Promise<Response>;
+
+function responseHeaders(headers: Headers): Record<string, string> {
+	return Object.fromEntries(
+		Array.from(headers.entries()).map(([key, value]) => [key.toLowerCase(), value]),
+	);
+}
+
+export class FetchTransport implements MarvinTransport {
+	constructor(private readonly fetch: FetchLike = globalThis.fetch) {
+		if (!fetch) {
+			throw new Error("A fetch implementation is required");
+		}
+	}
+
+	async request(request: MarvinTransportRequest): Promise<MarvinTransportResponse> {
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), request.timeoutMs);
+
+		try {
+			const response = await this.fetch(request.url, {
+				method: request.method,
+				headers: request.headers,
+				...(request.body === undefined ? {} : { body: request.body }),
+				signal: controller.signal,
+			});
+
+			return {
+				status: response.status,
+				statusText: response.statusText,
+				headers: responseHeaders(response.headers),
+				text: await response.text(),
+			};
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+}

--- a/packages/marvin-client/src/types.ts
+++ b/packages/marvin-client/src/types.ts
@@ -1,0 +1,146 @@
+export type MarvinOrigin = "local" | "public" | "mixed";
+export type MarvinFreshness = "fresh" | "cached" | "stale";
+
+export interface BaseMarvinItem {
+	_id: string;
+	_rev?: string;
+	createdAt?: number;
+	updatedAt?: number;
+}
+
+export interface Subtask {
+	_id: string;
+	title: string;
+	done: boolean;
+	rank?: number;
+	timeEstimate?: number;
+}
+
+export interface Task extends BaseMarvinItem {
+	title: string;
+	done: boolean;
+	type?: "task";
+	parentId?: string;
+	day?: string;
+	firstScheduled?: string;
+	startDate?: string;
+	dueDate?: string;
+	endDate?: string;
+	doneAt?: number;
+	completedAt?: number;
+	note?: string;
+	labelIds?: string[];
+	timeEstimate?: number;
+	priority?: string;
+	recurring?: boolean;
+	isRecurring?: boolean;
+	subtasks?: Record<string, Subtask> | Subtask[];
+}
+
+export interface Project extends BaseMarvinItem {
+	title: string;
+	type: "project";
+	parentId?: string;
+	day?: string;
+	firstScheduled?: string;
+	startDate?: string;
+	dueDate?: string;
+	endDate?: string;
+	done?: boolean;
+	doneDate?: string;
+	note?: string;
+	labelIds?: string[];
+	timeEstimate?: number;
+	priority?: "low" | "mid" | "high";
+	recurring?: boolean;
+}
+
+export interface Category extends BaseMarvinItem {
+	title: string;
+	type?: "category";
+	parentId?: string;
+	startDate?: string;
+	dueDate?: string;
+	endDate?: string;
+	done?: boolean;
+	note?: string;
+	priority?: string;
+	rank?: number;
+	recurring?: boolean;
+	isRecurring?: boolean;
+}
+
+export type TaskOrProject = Task | Project;
+export type MarvinItem = Task | Project | Category;
+
+export interface AddTaskRequest {
+	title: string;
+	done?: boolean;
+	day?: string;
+	parentId?: string;
+	labelIds?: string[];
+	firstScheduled?: string;
+	rank?: number;
+	dailySection?: string;
+	bonusSection?: string;
+	customSection?: string;
+	timeBlockSection?: string;
+	note?: string;
+	dueDate?: string;
+	timeEstimate?: number;
+	isReward?: boolean;
+	isStarred?: boolean | number;
+	isFrogged?: boolean | number;
+	plannedWeek?: string;
+	plannedMonth?: string;
+	rewardPoints?: number;
+	rewardId?: string;
+	backburner?: boolean;
+	reviewDate?: string;
+	itemSnoozeTime?: number;
+	permaSnoozeTime?: string;
+	timeZoneOffset?: number;
+}
+
+export type MarkDoneResult = Record<string, unknown> | null;
+
+export interface MarvinErrorSummary {
+	kind: "http" | "throttle" | "transport" | "parse" | "validation" | "route";
+	message: string;
+	operation: string;
+	origin: Exclude<MarvinOrigin, "mixed">;
+	endpoint?: string;
+	method?: string;
+	status?: number;
+	statusText?: string;
+	responseBody?: string;
+	retryAfterMs?: number;
+}
+
+export interface MarvinReadResult<T> {
+	data: T;
+	freshness: MarvinFreshness;
+	origin: MarvinOrigin;
+	fetchedAt: number;
+	ageMs: number;
+	warnings: MarvinErrorSummary[];
+}
+
+export interface MarvinTransportRequest {
+	url: string;
+	method: "GET" | "POST";
+	headers: Record<string, string>;
+	body?: string;
+	timeoutMs: number;
+}
+
+export interface MarvinTransportResponse {
+	status: number;
+	statusText?: string;
+	headers: Record<string, string>;
+	text: string;
+}
+
+export interface MarvinTransport {
+	request(request: MarvinTransportRequest): Promise<MarvinTransportResponse>;
+}

--- a/packages/marvin-client/tsconfig.json
+++ b/packages/marvin-client/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "exactOptionalPropertyTypes": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/test-helpers.ts"
+  ]
+}

--- a/packages/marvin-client/tsconfig.test.json
+++ b/packages/marvin-client/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "types": [
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/marvin-mcp/package.json
+++ b/packages/marvin-mcp/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@open-horizon/marvin-mcp",
+  "version": "0.1.0",
+  "description": "In-repository MCP adapter for the shared Amazing Marvin client",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "amazing-marvin-mcp": "./dist/server.js"
+  },
+  "main": "./dist/server.js",
+  "types": "./dist/server.d.ts",
+  "scripts": {
+    "build": "npm run clean && esbuild src/server.ts --bundle --platform=node --target=node18 --format=esm --packages=external --banner:js='#!/usr/bin/env node' --outfile=dist/server.js && tsc --project tsconfig.json --emitDeclarationOnly",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "typecheck": "tsc --project tsconfig.test.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@open-horizon/marvin-client": "file:../marvin-client",
+    "zod": "^4.4.3"
+  },
+  "license": "MIT"
+}

--- a/packages/marvin-mcp/src/server.ts
+++ b/packages/marvin-mcp/src/server.ts
@@ -1,0 +1,64 @@
+import { pathToFileURL } from "node:url";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+	FetchTransport,
+	MarvinApiClient,
+	MarvinRouter,
+} from "@open-horizon/marvin-client";
+import { createMarvinMcpServer } from "./tools.js";
+
+export interface MarvinMcpEnvironment {
+	[key: string]: string | undefined;
+	AMAZING_MARVIN_API_TOKEN?: string;
+	AMAZING_MARVIN_PUBLIC_API_URL?: string;
+	AMAZING_MARVIN_USE_LOCAL?: string;
+	AMAZING_MARVIN_LOCAL_API_URL?: string;
+}
+
+export function createRouterFromEnvironment(
+	environment: MarvinMcpEnvironment = process.env,
+): MarvinRouter {
+	const apiToken = environment.AMAZING_MARVIN_API_TOKEN?.trim();
+	if (!apiToken) {
+		throw new Error("AMAZING_MARVIN_API_TOKEN is required");
+	}
+
+	const transport = new FetchTransport();
+	const publicClient = new MarvinApiClient({
+		apiToken,
+		baseUrl: environment.AMAZING_MARVIN_PUBLIC_API_URL
+			?? "https://serv.amazingmarvin.com/api",
+		origin: "public",
+		transport,
+	});
+	const localClient = environment.AMAZING_MARVIN_USE_LOCAL === "true"
+		? new MarvinApiClient({
+			apiToken,
+			baseUrl: environment.AMAZING_MARVIN_LOCAL_API_URL
+				?? "http://localhost:12082/api",
+			origin: "local",
+			transport,
+		})
+		: undefined;
+
+	return new MarvinRouter({
+		publicClient,
+		...(localClient === undefined ? {} : { localClient }),
+	});
+}
+
+export async function runMcpServer(
+	environment: MarvinMcpEnvironment = process.env,
+): Promise<void> {
+	const server = createMarvinMcpServer(createRouterFromEnvironment(environment));
+	await server.connect(new StdioServerTransport());
+	console.error("Amazing Marvin MCP server running on stdio");
+}
+
+const entry = process.argv[1];
+if (entry && import.meta.url === pathToFileURL(entry).href) {
+	runMcpServer().catch((error) => {
+		console.error("Amazing Marvin MCP server failed:", error);
+		process.exitCode = 1;
+	});
+}

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -1,0 +1,179 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+	MarvinError,
+	MarvinRouteError,
+	type MarvinReadResult,
+	type Task,
+	type TaskOrProject,
+} from "@open-horizon/marvin-client";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createMarvinMcpServer,
+	type MarvinOperations,
+} from "./tools.js";
+
+const todayResult: MarvinReadResult<TaskOrProject[]> = {
+	data: [{ _id: "task-1", title: "Decide", done: false }],
+	freshness: "fresh",
+	origin: "public",
+	fetchedAt: 1_721_753_600_000,
+	ageMs: 0,
+	warnings: [],
+};
+
+function operations(overrides: Partial<MarvinOperations> = {}): MarvinOperations {
+	return {
+		getTodayItems: async () => todayResult,
+		getDueItems: async () => ({ ...todayResult, data: [] }),
+		addTask: async (input): Promise<Task> => ({
+			_id: "created-1",
+			title: input.title,
+			done: false,
+		}),
+		markDone: async () => ({ success: true }),
+		...overrides,
+	};
+}
+
+describe("Amazing Marvin MCP", () => {
+	const close: Array<() => Promise<void>> = [];
+
+	afterEach(async () => {
+		await Promise.all(close.splice(0).map((callback) => callback()));
+	});
+
+	async function connect(ops: MarvinOperations) {
+		const server = createMarvinMcpServer(ops);
+		const client = new Client({ name: "test-client", version: "0.1.0" });
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+		close.push(() => client.close(), () => server.close());
+		return client;
+	}
+
+	it("exposes the bounded tool set and stable task IDs", async () => {
+		const client = await connect(operations());
+
+		const tools = await client.listTools();
+		const result = await client.callTool({
+			name: "marvin_today",
+			arguments: { date: "2026-07-23" },
+		});
+
+		expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
+			"marvin_create_task",
+			"marvin_due",
+			"marvin_mark_done",
+			"marvin_today",
+		]);
+		expect(result.isError).not.toBe(true);
+		expect(result.structuredContent).toMatchObject({
+			freshness: "fresh",
+			origin: "public",
+			items: [{
+				id: "task-1",
+				title: "Decide",
+				deepLink: "https://app.amazingmarvin.com/#t=task-1",
+			}],
+		});
+	});
+
+	it("returns actionable attempted-origin errors through MCP", async () => {
+		const routeError = new MarvinRouteError("today items", [
+			new MarvinError({
+				kind: "transport",
+				message: "ECONNREFUSED",
+				operation: "today items",
+				origin: "local",
+			}),
+			new MarvinError({
+				kind: "throttle",
+				message: "Rate limited",
+				operation: "today items",
+				origin: "public",
+				status: 429,
+				retryAfterMs: 30_000,
+			}),
+		]);
+		const client = await connect(operations({
+			getTodayItems: async () => {
+				throw routeError;
+			},
+		}));
+
+		const result = await client.callTool({
+			name: "marvin_today",
+			arguments: {},
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toMatchObject({
+			error: {
+				attempts: [
+					{ origin: "local", kind: "transport", message: "ECONNREFUSED" },
+					{
+						origin: "public",
+						kind: "throttle",
+						status: 429,
+						retryAfterMs: 30_000,
+					},
+				],
+			},
+		});
+	});
+
+	it("routes create and completion tools through the shared operations", async () => {
+		const calls: unknown[] = [];
+		const client = await connect(operations({
+			addTask: async (input) => {
+				calls.push(["addTask", input]);
+				return { _id: "created-1", title: input.title, done: false };
+			},
+			markDone: async (itemId, timeZoneOffset) => {
+				calls.push(["markDone", itemId, timeZoneOffset]);
+				return { success: true };
+			},
+		}));
+
+		const created = await client.callTool({
+			name: "marvin_create_task",
+			arguments: {
+				title: "Prepare application",
+				day: "2026-07-23",
+				parentId: "project-1",
+			},
+		});
+		const completed = await client.callTool({
+			name: "marvin_mark_done",
+			arguments: {
+				itemId: "created-1",
+				timeZoneOffset: -240,
+			},
+		});
+
+		expect(created.structuredContent).toMatchObject({
+			task: {
+				id: "created-1",
+				title: "Prepare application",
+				deepLink: "https://app.amazingmarvin.com/#t=created-1",
+			},
+		});
+		expect(completed.structuredContent).toMatchObject({
+			itemId: "created-1",
+			result: { success: true },
+		});
+		expect(calls).toMatchObject([
+			[
+				"addTask",
+				{
+					title: "Prepare application",
+					day: "2026-07-23",
+					parentId: "project-1",
+				},
+			],
+			["markDone", "created-1", -240],
+		]);
+	});
+});

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -1,0 +1,184 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+import {
+	MarvinError,
+	MarvinRouteError,
+	type MarvinRouter,
+	type TaskOrProject,
+	marvinDeepLink,
+} from "@open-horizon/marvin-client";
+
+export type MarvinOperations = Pick<
+	MarvinRouter,
+	"getTodayItems" | "getDueItems" | "addTask" | "markDone"
+>;
+
+const dateSchema = z.string()
+	.regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD")
+	.optional();
+
+function itemForTool(item: TaskOrProject) {
+	return {
+		id: item._id,
+		title: item.title,
+		type: item.type ?? "task",
+		done: item.done ?? false,
+		deepLink: marvinDeepLink(item),
+		...(item.parentId === undefined ? {} : { parentId: item.parentId }),
+		...(item.day === undefined ? {} : { day: item.day }),
+		...(item.dueDate === undefined ? {} : { dueDate: item.dueDate }),
+		...(item.startDate === undefined ? {} : { startDate: item.startDate }),
+		...(item.note === undefined ? {} : { note: item.note }),
+	};
+}
+
+function success(structuredContent: Record<string, unknown>) {
+	return {
+		content: [{
+			type: "text" as const,
+			text: JSON.stringify(structuredContent, null, 2),
+		}],
+		structuredContent,
+	};
+}
+
+function readSuccess(result: Awaited<ReturnType<MarvinOperations["getTodayItems"]>>) {
+	const { data, ...metadata } = result;
+	return success({
+		...metadata,
+		items: data.map(itemForTool),
+	});
+}
+
+function failure(error: unknown) {
+	const details = error instanceof MarvinRouteError
+		? {
+			message: error.message,
+			attempts: error.attempts.map((attempt) => attempt.toSummary()),
+		}
+		: error instanceof MarvinError
+			? error.toSummary()
+			: {
+				message: error instanceof Error ? error.message : String(error),
+			};
+
+	return {
+		isError: true,
+		content: [{
+			type: "text" as const,
+			text: JSON.stringify({ error: details }, null, 2),
+		}],
+		structuredContent: { error: details },
+	};
+}
+
+export function createMarvinMcpServer(
+	operations: MarvinOperations,
+): McpServer {
+	const server = new McpServer({
+		name: "amazing-marvin",
+		version: "0.1.0",
+	});
+
+	server.registerTool("marvin_today", {
+		title: "Amazing Marvin Today",
+		description: "Read tasks and projects scheduled for a date in Amazing Marvin.",
+		inputSchema: {
+			date: dateSchema.describe("Optional date; defaults to Marvin's server date"),
+		},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async ({ date }) => {
+		try {
+			return readSuccess(await operations.getTodayItems(date));
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_due", {
+		title: "Amazing Marvin Due",
+		description: "Read open tasks and projects due on or before a date.",
+		inputSchema: {
+			date: dateSchema.describe("Optional inclusive due date; defaults to Marvin's server date"),
+		},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async ({ date }) => {
+		try {
+			return readSuccess(await operations.getDueItems(date));
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_create_task", {
+		title: "Create Amazing Marvin Task",
+		description: "Create one task in Amazing Marvin with the limited API token.",
+		inputSchema: {
+			title: z.string().trim().min(1).describe("Task title; Marvin shortcuts are supported"),
+			parentId: z.string().trim().min(1).optional(),
+			day: dateSchema,
+			dueDate: dateSchema,
+			note: z.string().optional(),
+			timeEstimate: z.number().int().nonnegative().optional()
+				.describe("Estimated duration in milliseconds"),
+		},
+		annotations: {
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		},
+	}, async (input) => {
+		try {
+			const task = await operations.addTask({
+				title: input.title,
+				timeZoneOffset: new Date().getTimezoneOffset() * -1,
+				...(input.parentId === undefined ? {} : { parentId: input.parentId }),
+				...(input.day === undefined ? {} : { day: input.day }),
+				...(input.dueDate === undefined ? {} : { dueDate: input.dueDate }),
+				...(input.note === undefined ? {} : { note: input.note }),
+				...(input.timeEstimate === undefined ? {} : { timeEstimate: input.timeEstimate }),
+			});
+			return success({ task: itemForTool(task) });
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_mark_done", {
+		title: "Complete Amazing Marvin Task",
+		description: "Mark one Amazing Marvin task or project complete by stable ID.",
+		inputSchema: {
+			itemId: z.string().trim().min(1).describe("Stable Amazing Marvin item ID"),
+			timeZoneOffset: z.number().int().optional()
+				.describe("Minutes from UTC; defaults to the MCP process timezone"),
+		},
+		annotations: {
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		},
+	}, async ({ itemId, timeZoneOffset }) => {
+		try {
+			const result = await operations.markDone(
+				itemId,
+				timeZoneOffset ?? new Date().getTimezoneOffset() * -1,
+			);
+			return success({
+				itemId,
+				result,
+			});
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	return server;
+}

--- a/packages/marvin-mcp/tsconfig.json
+++ b/packages/marvin-mcp/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "exactOptionalPropertyTypes": true,
+    "lib": [
+      "DOM",
+      "ES2022"
+    ],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/marvin-mcp/tsconfig.test.json
+++ b/packages/marvin-mcp/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "types": [
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/src/amTaskWatcher.ts
+++ b/src/amTaskWatcher.ts
@@ -23,7 +23,9 @@ export function amTaskWatcher(_app: App, plugin: AmazingMarvinPlugin) {
           let line = update.state.doc.lineAt(fromA).text;
           const match = line.match(COMPLETED_AM_TASK);
           if (match && match[1]) {
-            plugin.markDone(match[1]);
+            void plugin.markDone(match[1]).catch((error) => {
+              console.error("Could not mark Amazing Marvin task as done:", error);
+            });
           }
         });
       }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,35 +1,14 @@
-export interface Category {
-	_id: string;
-	title: string;
-	type: string;
-	updatedAt: number;
-	parentId: string;
-	startDate: string;
-	endDate: string;
-	note: string;
-	isRecurring: boolean;
-	priority: string;
-	deepLink: string;
-	dueDate: string;
-	done: boolean;
-}
+import type {
+	Category as MarvinCategory,
+	Project as MarvinProject,
+	Task as MarvinTask,
+} from "@open-horizon/marvin-client";
 
-export interface Task {
-	done: boolean;
-	subtasks: Task[];
-	_id: string;
-	title: string;
-	updatedAt: number;
-	parentId: string;
-	day: string
-	firstScheduled: string;
-	startDate: string;
-	dueDate: string;
-	endDate: string;
-	note: string;
-	doneAt: number;
-	isRecurring: boolean;
-	priority: string;
-	type: string;
+export type Category = (
+	| (Omit<MarvinCategory, "type"> & { type?: "category" | "faux" })
+	| MarvinProject
+) & { deepLink: string };
+
+export type Task = MarvinTask & {
 	deepLink: string;
-}
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,22 @@ import {
 	Plugin,
 	normalizePath,
 	requestUrl,
-  stringifyYaml,
+	stringifyYaml,
 } from "obsidian";
 
 import {
 	Category,
 	Task
 } from "./interfaces";
+import {
+	type AddTaskRequest,
+	type MarvinItem,
+	type MarvinReadResult,
+	MarvinApiClient,
+	MarvinError,
+	MarvinRouter,
+	marvinDeepLink,
+} from "@open-horizon/marvin-client";
 
 import {
 	AmazingMarvinSettingsTab,
@@ -22,6 +31,7 @@ import {
 } from "obsidian-daily-notes-interface";
 import { amTaskWatcher } from "./amTaskWatcher";
 import { AddTaskModal } from "./addTaskModal";
+import { createObsidianTransport } from "./marvin/obsidianTransport";
 
 function getAMTimezoneOffset() {
 	return new Date().getTimezoneOffset() * -1;
@@ -45,18 +55,15 @@ const animateNotice = (notice: Notice) => {
 
 const CONSTANTS = {
 	baseDir: "AmazingMarvin",
-	categoriesEndpoint: '/api/categories',
-	childrenEndpoint: '/api/children',
-	scheduledOnDayEndpoint: '/api/todayItems',
-	dueOnDayEndpoint: '/api/dueItems',
-	addTaskEndpoint: '/api/addTask',
-}
+};
 
 
 export default class AmazingMarvinPlugin extends Plugin {
 
 	settings: AmazingMarvinPluginSettings;
 	categories: Category[] = [];
+	private marvinRouter?: MarvinRouter;
+	private marvinRouterKey = "";
 
 	createFolder = async (path: string) => {
 		try {
@@ -93,26 +100,20 @@ export default class AmazingMarvinPlugin extends Plugin {
               const task = await this.addMarvinTask('', editor.getSelection(), view.file?.path, this.app.vault.getName());
               editor.replaceSelection(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`);
             } catch (error) {
-              new Notice('Could not create Marvin task: ' + error.message);
+              console.error('Could not create Marvin task:', error);
             }
             return;
           }
 
-          const categories = await this.fetchTasksAndCategories(CONSTANTS.categoriesEndpoint);
-          // Ensure categories are fetched before initializing the modal
-          if (categories.length > 0) {
-            new AddTaskModal(this.app, categories, async (taskDetails: { catId: string, task: string }) => {
-              try {
-                const task = await this.addMarvinTask(taskDetails.catId, taskDetails.task, view.file?.path, this.app.vault.getName());
-                editor.replaceRange(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`, editor.getCursor());
-              } catch (error) {
-                new Notice('Could not create Marvin task: ' + error.message);
-              }
-            }).open();
-          } else {
-            // Handle the case where categories could not be loaded
-            new Notice('Failed to load categories from Amazing Marvin.');
-          }
+          const categories = await this.getCategories();
+          new AddTaskModal(this.app, categories, async (taskDetails: { catId: string, task: string }) => {
+            try {
+              const task = await this.addMarvinTask(taskDetails.catId, taskDetails.task, view.file?.path, this.app.vault.getName());
+              editor.replaceRange(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`, editor.getCursor());
+            } catch (error) {
+              console.error('Could not create Marvin task:', error);
+            }
+          }).open();
         } catch (error) {
           console.error('Error fetching categories:', error);
           new Notice('Failed to load categories from Amazing Marvin.');
@@ -144,17 +145,18 @@ export default class AmazingMarvinPlugin extends Plugin {
 					const fileDate = view.file ? getDateFromFile(view.file, "day")?.format("YYYY-MM-DD") : today;
 
 					const date = fileDate ? fileDate : today;
-					let tasks = new Set<Task | Category>();
-					if (this.settings.todayTasksToShow === 'due' || this.settings.todayTasksToShow === 'both') {
-						const dueTasks = await this.getDueTasks(date);
-						dueTasks.forEach(task => tasks.add(task));;
-					}
-					if (this.settings.todayTasksToShow === 'scheduled' || this.settings.todayTasksToShow === 'both') {
-						const scheduledTasks = await this.getScheduledTasks(date);
-						scheduledTasks.forEach(task => tasks.add(task));;
+					let tasks: (Task | Category)[];
+					if (this.settings.todayTasksToShow === 'both') {
+						const result = await this.getMarvinRouter().getTodayAndDue(date);
+						this.reportReadState(result, "today and due tasks");
+						tasks = result.data.map(item => this.decorateWithDeepLink(item));
+					} else if (this.settings.todayTasksToShow === 'due') {
+						tasks = await this.getDueTasks(date);
+					} else {
+						tasks = await this.getScheduledTasks(date);
 					}
 
-					editor.replaceRange(this.formatItems(Array.from(tasks), 0, false), editor.getCursor());
+					editor.replaceRange(this.formatItems(tasks, 0, false), editor.getCursor());
 				} catch (error) {
 					new Notice(`Error importing scheduled tasks: ${error}`);
 					console.error(`Error importing scheduled tasks: ${error}`);
@@ -164,9 +166,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 	}
 	async addMarvinTask(catId: string, taskTitle: string, notePath: string = '', vaultName: string = ''): Promise<Task> {
-		const opt = this.settings;
-
-		let requestBody: any = {
+		const requestBody: AddTaskRequest = {
 			title: taskTitle,
 			timeZoneOffset: getAMTimezoneOffset(),
 		};
@@ -185,45 +185,19 @@ export default class AmazingMarvinPlugin extends Plugin {
 	}
 
 		try {
-			const remoteResponse = await requestUrl({
-				url: `https://serv.amazingmarvin.com/api/addTask`,
-				method: 'POST',
-				headers: {
-					'X-API-Token': opt.apiKey,
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify(requestBody)
-			});
-
-			if (remoteResponse.status === 200) {
-				new Notice("Task added in Amazing Marvin.");
-				return this.decorateWithDeepLink(remoteResponse.json) as Task;
-			} else if (remoteResponse.status === 429) {
-
-				const errorNote = document.createDocumentFragment();
-				errorNote.appendText('Your request was throttled by Amazing Marvin. Wait a few minutes and try again. Or do it ');
-				const a = document.createElement('a');
-				a.href = 'https://app.amazingmarvin.com/';
-				a.text = 'manually';
-				a.target = '_blank';
-				errorNote.appendChild(a);
-				errorNote.appendText('.');
-				new Notice(errorNote,);
-			}
+			const task = await this.getMarvinRouter().addTask(requestBody);
+			new Notice("Task added in Amazing Marvin.");
+			return this.decorateWithDeepLink(task) as Task;
 		} catch (error) {
-			const errorNote = document.createDocumentFragment();
-			errorNote.appendText('Error creating task in Amazing Marvin. You can try again or do it ');
 			console.error('Error creating task:', error);
-			const a = document.createElement('a');
-			a.href = 'https://app.amazingmarvin.com/';
-			a.text = 'manually';
-			a.target = '_blank';
-			errorNote.appendChild(a);
-			errorNote.appendText('.');
-
-			new Notice(errorNote, 0);
+			this.showManualActionError(
+				this.isThrottle(error)
+					? 'Your request was throttled by Amazing Marvin. Wait before trying again, or do it '
+					: 'Error creating task in Amazing Marvin. You can try again or do it ',
+				'https://app.amazingmarvin.com/',
+			);
+			throw error;
 		}
-		return Promise.reject(new Error('Error creating task'));
 	}
 
 	onunload() { }
@@ -235,183 +209,91 @@ export default class AmazingMarvinPlugin extends Plugin {
 		);
 	}
 
-	saveSettings() {
-		this.saveData(this.settings);
+	async saveSettings() {
+		this.marvinRouter = undefined;
+		this.marvinRouterKey = "";
+		await this.saveData(this.settings);
 	}
 
 	async markDone(taskId: string) {
-		const opt = this.settings;
-		const requestBody = {
-			itemId: taskId,
-			timeZoneOffset: getAMTimezoneOffset()
-		};
-
 		try {
-			const remoteResponse = await requestUrl({
-				url: `https://serv.amazingmarvin.com/api/markDone`,
-				method: 'POST',
-				headers: {
-					'X-API-Token': opt.apiKey,
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify(requestBody)
-			});
-
+			const result = await this.getMarvinRouter().markDone(
+				taskId,
+				getAMTimezoneOffset(),
+			);
 			const note = document.createDocumentFragment();
 			const a = document.createElement('a');
 			a.href = 'https://app.amazingmarvin.com/#t=' + taskId;
-
 			a.target = '_blank';
-
-			if (remoteResponse.status === 200) {
-				a.text = 'Task';
-				note.append(a);
-				note.appendText(' marked as done in Amazing Marvin.');
-				new Notice(note, 5000);
-				return remoteResponse.json;
-			} else if (remoteResponse.status === 429) {
-				a.text = 'manually';
-				note.appendText('Your request was throttled by Amazing Marvin. Do it manually at ');
-				console.error('Your request was throttled by Amazing Marvin. Wait a few minutes and try again. Or do it manually.');
-				note.appendChild(a);
-
-				new Notice(note, 0);
-			}
+			a.text = 'Task';
+			note.append(a);
+			note.appendText(' marked as done in Amazing Marvin.');
+			new Notice(note, 5000);
+			return result;
 		} catch (error) {
-			const errorNote = document.createDocumentFragment();
-			errorNote.appendText('Error marking task as done in Amazing Marvin. You should do it ');
 			console.error('Error marking task as done:', error);
-
-			const a = document.createElement('a');
-			a.href = 'https://app.amazingmarvin.com/#t=' + taskId;
-			a.text = 'manually';
-			a.target = '_blank';
-			errorNote.appendChild(a);
-
-			new Notice(errorNote, 0);
+			this.showManualActionError(
+				this.isThrottle(error)
+					? 'Your request was throttled by Amazing Marvin. Wait before trying again, or do it '
+					: 'Error marking task as done in Amazing Marvin. You should do it ',
+				'https://app.amazingmarvin.com/#t=' + taskId,
+			);
+			throw error;
 		}
-	}
-
-
-	async fetchMarvinData(endpoint: string) {
-		const opt = this.settings;
-		let response;
-		let errorMessage = '';
-
-		const url = `http://${opt.localServerHost}:${opt.localServerPort}${endpoint}`;
-		try {
-			response = await requestUrl({
-				url: url,
-				headers: { 'X-API-Token': opt.apiKey }
-			});
-
-			if (response.status === 200) {
-				return response.json;
-			}
-
-			errorMessage = `[${response.status}] ${await response.text}`;
-		} catch (err) {
-			errorMessage = err.message;
-			console.debug('Failed while fetching from local server, will try the public server next:', err);
-		}
-
-		if (!opt.useLocalServer || errorMessage) {
-			try {
-				response = await requestUrl({
-          url: `https://serv.amazingmarvin.com${endpoint}`,
-					headers: { 'X-API-Token': opt.apiKey }
-				});
-
-				if (response.status === 200) {
-					return response.json;
-				}
-
-				errorMessage = `[${response.status}] ${await response.text}`;
-			} catch (err) {
-				if (response?.status === 429) {
-					errorMessage = 'Your request was throttled by Amazing Marvin.';
-				} else {
-					errorMessage = err.message;
-				}
-			}
-		}
-
-		throw new Error(`Error fetching data: ${errorMessage}`);
 	}
 
 
 	async sync() {
-		try {
-			const baseDirPath = normalizePath(CONSTANTS.baseDir);
-        const baseDir = this.app.vault.getAbstractFileByPath(baseDirPath);
-        if (baseDir) {
-            await this.app.vault.delete(baseDir, true);
-        }
-
-			this.categories = await this.fetchTasksAndCategories(CONSTANTS.categoriesEndpoint);
-
-			this.processCategories();
-			this.processInbox();
-		} catch (error) {
-			console.error('Error syncing Amazing Marvin data:', error);
+		const categories = await this.getCategories();
+		const baseDirPath = normalizePath(CONSTANTS.baseDir);
+		const baseDir = this.app.vault.getAbstractFileByPath(baseDirPath);
+		if (baseDir) {
+			await this.app.vault.delete(baseDir, true);
 		}
+
+		this.categories = categories;
+		await this.processCategories();
+		await this.processInbox();
 	}
 
-	async fetchTasksAndCategories(url: string): Promise<(Task | Category)[]> {
-		try {
-			const items = await this.fetchMarvinData(url) as (Task | Category)[];
-			return items.map(item => this.decorateWithDeepLink(item));
-		} catch (error) {
-			console.error('Error fetching data from:', url, error);
-			return [];
-		}
+	async getCategories(): Promise<Category[]> {
+		const result = await this.getMarvinRouter().getCategories();
+		this.reportReadState(result, "categories");
+		return result.data.map(item => this.decorateWithDeepLink(item, "category") as Category);
 	}
 
-	getScheduledTasks(date: string): Promise<(Task | Category)[]> {
-		let errorMessages = [];
-
-		try {
-			return this.fetchTasksAndCategories(`${CONSTANTS.scheduledOnDayEndpoint}?date=${date}`);
-		} catch (error) {
-			console.error(`Error fetching scheduled tasks: ${error}`);
-			errorMessages.push(`Error fetching scheduled tasks`);
-		}
-
-		if (errorMessages.length > 0) {
-			const message = `Encountered errors while fetching tasks:\n\n${errorMessages.join('\n')}\nSee console for details.`;
-			new Notice(message);
-		}
-		return Promise.resolve([]);
+	async getChildren(parentId: string): Promise<(Task | Category)[]> {
+		const result = await this.getMarvinRouter().getChildren(parentId);
+		this.reportReadState(result, `children of ${parentId}`);
+		return result.data.map(item => this.decorateWithDeepLink(item));
 	}
 
-	getDueTasks(date: string): Promise<(Task | Category)[]> {
-		let errorMessages = [];
-
-		try {
-			return this.fetchTasksAndCategories(`${CONSTANTS.dueOnDayEndpoint}?date=${date}`);
-		} catch (error) {
-			console.error(`Error fetching scheduled tasks: ${error}`);
-			errorMessages.push(`Error fetching scheduled tasks`);
-		}
-
-		if (errorMessages.length > 0) {
-			const message = `Encountered errors while fetching tasks:\n\n${errorMessages.join('\n')}\nSee console for details.`;
-			new Notice(message);
-		}
-		return Promise.resolve([]);
+	async getScheduledTasks(date: string): Promise<(Task | Category)[]> {
+		const result = await this.getMarvinRouter().getTodayItems(date);
+		this.reportReadState(result, "scheduled tasks");
+		return result.data.map(item => this.decorateWithDeepLink(item));
 	}
 
-	decorateWithDeepLink(item: Task | Category): Task | Category {
-		const isTask = !item.type || item.type === 'task';
+	async getDueTasks(date: string): Promise<(Task | Category)[]> {
+		const result = await this.getMarvinRouter().getDueItems(date);
+		this.reportReadState(result, "due tasks");
+		return result.data.map(item => this.decorateWithDeepLink(item));
+	}
+
+	decorateWithDeepLink(
+		item: MarvinItem,
+		defaultType: "task" | "category" = "task",
+	): Task | Category {
+		const type = item.type ?? defaultType;
 		return {
 			...item,
-			deepLink: `https://app.amazingmarvin.com/#${isTask ? 't' : 'p'}=${item._id}`,
-			type: isTask ? 'task' : item.type
-		};
+			deepLink: marvinDeepLink({ ...item, type }),
+			type,
+		} as Task | Category;
 	}
 
 	async processInbox() {
-		const inboxItems = await this.fetchTasksAndCategories(`${CONSTANTS.childrenEndpoint}?parentId=unassigned`);
+		const inboxItems = await this.getChildren("unassigned");
 		const content = this.formatItems(inboxItems);
 
 		// Define the path for the Inbox file
@@ -474,12 +356,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		for (const category of this.categories) {
 			const path = this.getPathForCategory(category);
 			const content = this.createContentForCategory(category);
-
-			try {
-				await this.createOrUpdate(path, await content);
-			} catch (e) {
-				console.error(`Error creating file for ${path}:`, e);
-			}
+			await this.createOrUpdate(path, await content);
 		}
 	}
 
@@ -506,7 +383,11 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 				// Recursively format sub-tasks if any
 				if ('subtasks' in item && item.subtasks && Object.keys(item.subtasks).length > 0) {
-					const subtasks = Object.values(item.subtasks);
+					const subtasks = Object.values(item.subtasks).map(subtask => ({
+						...subtask,
+						type: "task" as const,
+						deepLink: "",
+					})) as Task[];
 					taskContent += this.formatItems(subtasks, level + 1, true); // Pass true for isSubtask
 				}
 			}
@@ -564,10 +445,76 @@ export default class AmazingMarvinPlugin extends Plugin {
 			}
 		}
 		// Fetch and format tasks
-		const children = await this.fetchTasksAndCategories(`${CONSTANTS.childrenEndpoint}?parentId=${category._id}`);
+		const children = await this.getChildren(category._id);
 		content += this.formatItems(children);
 
 		return yamlFrontmatter + content;
+	}
+
+	private getMarvinRouter(): MarvinRouter {
+		const key = [
+			this.settings.apiKey,
+			this.settings.useLocalServer,
+			this.settings.localServerHost,
+			this.settings.localServerPort,
+		].join("\u0000");
+		if (this.marvinRouter && this.marvinRouterKey === key) {
+			return this.marvinRouter;
+		}
+
+		const transport = createObsidianTransport(requestUrl);
+		const publicClient = new MarvinApiClient({
+			apiToken: this.settings.apiKey,
+			baseUrl: "https://serv.amazingmarvin.com/api",
+			origin: "public",
+			transport,
+		});
+		const localClient = this.settings.useLocalServer
+			? new MarvinApiClient({
+				apiToken: this.settings.apiKey,
+				baseUrl: `http://${this.settings.localServerHost}:${this.settings.localServerPort}/api`,
+				origin: "local",
+				transport,
+			})
+			: undefined;
+
+		this.marvinRouter = new MarvinRouter({
+			publicClient,
+			...(localClient === undefined ? {} : { localClient }),
+		});
+		this.marvinRouterKey = key;
+		return this.marvinRouter;
+	}
+
+	private reportReadState<T>(result: MarvinReadResult<T>, description: string) {
+		if (result.freshness === "stale") {
+			new Notice(
+				`Amazing Marvin is unavailable. Showing stale ${description} from ${new Date(result.fetchedAt).toLocaleTimeString()}.`,
+				8000,
+			);
+			console.warn(`Using stale Amazing Marvin ${description}`, result.warnings);
+		} else if (result.warnings.length > 0) {
+			console.debug(
+				`Amazing Marvin ${description} loaded via ${result.origin} fallback`,
+				result.warnings,
+			);
+		}
+	}
+
+	private isThrottle(error: unknown): boolean {
+		return error instanceof MarvinError && error.status === 429;
+	}
+
+	private showManualActionError(message: string, href: string) {
+		const errorNote = document.createDocumentFragment();
+		errorNote.appendText(message);
+		const link = document.createElement('a');
+		link.href = href;
+		link.text = 'manually';
+		link.target = '_blank';
+		errorNote.appendChild(link);
+		errorNote.appendText('.');
+		new Notice(errorNote, 0);
 	}
 
 }

--- a/src/marvin/obsidianTransport.test.ts
+++ b/src/marvin/obsidianTransport.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+	FetchTransport,
+	MarvinApiClient,
+	type FetchLike,
+} from "@open-horizon/marvin-client";
+import { createObsidianTransport } from "./obsidianTransport";
+
+describe("shared transport contract", () => {
+	it("returns the same client result through Obsidian and fetch adapters", async () => {
+		const payload = [{ _id: "task-1", title: "Shared", done: false }];
+		const obsidianRequests: unknown[] = [];
+		const obsidianTransport = createObsidianTransport(async (request) => {
+			obsidianRequests.push(request);
+			return {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+				arrayBuffer: new ArrayBuffer(0),
+				json: payload,
+				text: JSON.stringify(payload),
+			};
+		});
+		const fetchCalls: unknown[] = [];
+		const fetch: FetchLike = async (input, init) => {
+			fetchCalls.push([input, init]);
+			return new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		const obsidianClient = new MarvinApiClient({
+			apiToken: "token",
+			baseUrl: "https://example.test/api",
+			origin: "public",
+			transport: obsidianTransport,
+		});
+		const nodeClient = new MarvinApiClient({
+			apiToken: "token",
+			baseUrl: "https://example.test/api",
+			origin: "public",
+			transport: new FetchTransport(fetch),
+		});
+
+		await expect(obsidianClient.getTodayItems("2026-07-23")).resolves.toEqual(
+			payload,
+		);
+		await expect(nodeClient.getTodayItems("2026-07-23")).resolves.toEqual(payload);
+		expect(obsidianRequests).toMatchObject([
+			{
+				url: "https://example.test/api/todayItems?date=2026-07-23",
+				throw: false,
+			},
+		]);
+		expect(fetchCalls).toHaveLength(1);
+	});
+});

--- a/src/marvin/obsidianTransport.ts
+++ b/src/marvin/obsidianTransport.ts
@@ -1,0 +1,46 @@
+import type {
+	RequestUrlParam,
+	RequestUrlResponse,
+} from "obsidian";
+import type {
+	MarvinTransport,
+	MarvinTransportResponse,
+} from "@open-horizon/marvin-client";
+
+export type ObsidianRequestUrl = (
+	request: RequestUrlParam,
+) => Promise<RequestUrlResponse>;
+
+function normalizeHeaders(headers: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+	);
+}
+
+/**
+ * Adapts Obsidian's CORS-free request API to the shared Marvin transport.
+ *
+ * Obsidian does not expose request cancellation, so timeoutMs is advisory for
+ * this adapter. Automatic retries remain disabled to avoid duplicate writes.
+ */
+export function createObsidianTransport(
+	requestUrl: ObsidianRequestUrl,
+): MarvinTransport {
+	return {
+		async request(request): Promise<MarvinTransportResponse> {
+			const response = await requestUrl({
+				url: request.url,
+				method: request.method,
+				headers: request.headers,
+				...(request.body === undefined ? {} : { body: request.body }),
+				throw: false,
+			});
+
+			return {
+				status: response.status,
+				headers: normalizeHeaders(response.headers),
+				text: response.text,
+			};
+		},
+	};
+}

--- a/src/marvin/sharedContract.test.ts
+++ b/src/marvin/sharedContract.test.ts
@@ -1,0 +1,74 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+	FetchTransport,
+	MarvinApiClient,
+	MarvinRouter,
+	type FetchLike,
+} from "@open-horizon/marvin-client";
+import { describe, expect, it } from "vitest";
+import { createMarvinMcpServer } from "../../packages/marvin-mcp/src/tools";
+import { createObsidianTransport } from "./obsidianTransport";
+
+describe("plugin and MCP shared contract fixture", () => {
+	it("projects the same Marvin response through both runtime adapters", async () => {
+		const payload = [{ _id: "shared-1", title: "One contract", done: false }];
+		const pluginRouter = new MarvinRouter({
+			publicClient: new MarvinApiClient({
+				apiToken: "token",
+				baseUrl: "https://example.test/api",
+				origin: "public",
+				transport: createObsidianTransport(async () => ({
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+					arrayBuffer: new ArrayBuffer(0),
+					json: payload,
+					text: JSON.stringify(payload),
+				})),
+			}),
+		});
+		const fetch: FetchLike = async () => new Response(JSON.stringify(payload), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+		const mcpRouter = new MarvinRouter({
+			publicClient: new MarvinApiClient({
+				apiToken: "token",
+				baseUrl: "https://example.test/api",
+				origin: "public",
+				transport: new FetchTransport(fetch),
+			}),
+		});
+
+		const mcpServer = createMarvinMcpServer(mcpRouter);
+		const mcpClient = new Client({ name: "fixture-client", version: "0.1.0" });
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		await mcpServer.connect(serverTransport);
+		await mcpClient.connect(clientTransport);
+
+		try {
+			const pluginResult = await pluginRouter.getTodayItems("2026-07-23");
+			const mcpResult = await mcpClient.callTool({
+				name: "marvin_today",
+				arguments: { date: "2026-07-23" },
+			});
+
+			expect(pluginResult).toMatchObject({
+				data: payload,
+				freshness: "fresh",
+				origin: "public",
+			});
+			expect(mcpResult.structuredContent).toMatchObject({
+				items: [{
+					id: "shared-1",
+					title: "One contract",
+				}],
+				freshness: pluginResult.freshness,
+				origin: pluginResult.origin,
+			});
+		} finally {
+			await mcpClient.close();
+			await mcpServer.close();
+		}
+	});
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,10 +3,10 @@ import AmazingMarvinPlugin from "./main";
 
 export interface AmazingMarvinPluginSettings {
 	linkBackToObsidianText: string;
-	attemptToMarkTasksAsDone: any;
+	attemptToMarkTasksAsDone: boolean;
 	useLocalServer: boolean;
 	localServerHost: string;
-	localServerPort: any;
+	localServerPort: number | string;
 	apiKey: string;
 	showDueDate: boolean;
 	showStartDate: boolean;
@@ -202,4 +202,3 @@ private a(href: string, text: string) {
 		}
 	}
 }
-

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: [
+			"packages/**/*.test.ts",
+			"src/**/*.test.ts",
+		],
+	},
+});


### PR DESCRIPTION
## Summary

- derive an internal, typed Marvin client from the evaluated upstream package while preserving provenance and fixing its retry/ESM shortcomings
- add explicit local-first routing, bounded caching, throttle protection, stable-ID deduplication, and structured errors shared by Obsidian and Node
- migrate the Obsidian plugin to the shared client and add a small stdio MCP for today, due, create-task, and mark-done operations
- document the package boundary and the idempotent source/action + bounded daily-note seam for #51

This is stacked on #54 (`issue/53`) so the diff contains only the implementation selected by that evaluation.

## Verification

- `npm ci`
- `npm test` (24 tests)
- `npm run build`
- `npm run typecheck`
- `node --test evaluations/issue-53/local-first-router.test.mjs`
- `npm pack --dry-run --workspace @open-horizon/marvin-client`
- native ESM and CommonJS package import smoke tests
- MCP startup fails actionably when `AMAZING_MARVIN_API_TOKEN` is absent
- `git diff --check`

## Review notes

Live verification still needs a real limited Marvin token and Obsidian desktop session, especially local-endpoint coverage, write response shapes, and the Obsidian adapter behavior for a stalled endpoint. No live account behavior is claimed here.

`npm audit --omit=dev` reports two moderate findings through `@hono/node-server`, pulled by the current MCP SDK. This server is stdio-only and does not import or expose Hono/static serving; downgrading the SDK reintroduced high-severity direct SDK advisories, so the current version is the safer tradeoff.

Closes #52