### PR TITLE
feat: keep daily notes current as Marvin tasks change

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The Amazing Marvin Plugin provides a way to bring your tasks and project structu
 - **Categories and Projects are folder notes**: Categories and projects are created as folder notes, compatible with [Obsidian folder notes](https://github.com/LostPaul/obsidian-folder-notes).
 - **Task Creation**: Users can create Amazing Marvin tasks directly within Obsidian, with support for standard Marvin shorthand notations like `+` for dates or `@` for labels.
 - **Deep Linking**: Each task and category is equipped with a deep link, providing quick navigation back to Amazing Marvin.
+- **Refreshable Daily Notes**: A bounded Today region keeps scheduled and due tasks current without rerunning the full daily-note template or overwriting surrounding prose.
+- **Automation API**: Templater, in-Obsidian agents, and other plugins can use the same typed operations as the UI, including idempotent source/action task creation.
 
 ## Usage Instructions
 
@@ -46,7 +48,11 @@ The task creation dialog is designed to mirror the task input experience in Amaz
 - Autocomplete for Categories and Projects using `#` syntax or a search sub-dialog.
 - Recognizes shorthand notations for properties like start date (`~`), due date (`@`), and labels (`+`).
 - Places a link to the Marvin task as a deep link in Obsidian at the cursor location upon task creation.
-- The created Marvin task contains an Advanced URI-friendly link back to the Obsidian note that instigated the task.
+- The created Marvin task links back to the Obsidian note that instigated the task.
+- The source note records the Marvin task ID and deep link in its
+  `amazing-marvin-actions` frontmatter property.
+- The link can use either Advanced URI (the default, for the Advanced URI
+  community plugin) or Obsidian's standard URI format.
 
 To create a task:
 
@@ -54,6 +60,65 @@ To create a task:
 2. Search for and select the command `Create Marvin Task`.
 3. Input the task details and select the appropriate category from the dropdown, which shows suggestions as you type.
 4. Upon task creation, a markdown checklist item with a link to the Marvin task is inserted at your cursor location in Obsidian.
+
+### Keeping Today's Tasks Current
+
+Run `Amazing Marvin: Refresh today's tasks` from a daily note. On the first
+run, the plugin adopts existing Marvin checklist entries under
+`## Today's tasks` as the morning set and surrounds only the generated task
+content with managed HTML-comment markers. It never rewrites content outside
+those markers.
+
+Later scheduled and due tasks appear under `### Added since morning`. Results
+are deduplicated by Marvin task ID, completion state is rerendered from Marvin,
+and a successful empty response remains visibly distinct from a fetch failure.
+A failed fetch leaves the existing note untouched.
+
+Once a note has a managed region, the plugin can refresh it on startup, when
+Obsidian regains focus, and at the configured interval. Automatic refresh does
+not initialize or adopt an unmarked note; run the command once (or use the API
+below) to establish the boundary.
+
+### Templater and In-Obsidian Automation
+
+The plugin exposes a stable object API at
+`app.plugins.plugins["cloudatlas-o-am"].api`. For example:
+
+```js
+const marvin = app.plugins.plugins["cloudatlas-o-am"].api;
+const sourcePath = tp.file.path(true);
+
+await marvin.ensureTaskForSource({
+  sourcePath,
+  actionKey: "decide-whether-to-pursue",
+  title: "Decide whether to pursue Titan AI",
+  day: tp.date.now("YYYY-MM-DD"),
+});
+
+await marvin.refreshTodayTasks({
+  date: tp.date.now("YYYY-MM-DD"),
+  filePath: tp.file.path(true),
+});
+```
+
+`actionKey` is a caller-owned stable identity for one action in one source
+note. Do not derive it from the mutable task title. Repeating the same
+`sourcePath` and `actionKey` returns the existing Marvin association.
+
+The API writes a pending source association before creating the Marvin task.
+If a connection drops at an ambiguous point, a repeat is stopped rather than
+silently creating a duplicate. After inspecting Marvin, callers can use
+`resolvePendingSourceAction({ sourcePath, actionKey, taskId })` or explicitly
+`clearPendingSourceAction({ sourcePath, actionKey })`.
+
+Additional object-returning methods are available for automation:
+
+- `getToday(date)`
+- `getDue(date)`
+- `getTodayAndDue(date)`
+- `createTask(task)`
+- `ensureTaskForSource(input)`
+- `refreshTodayTasks(input)`
 
 ### Auto-Mark as Done Feature
 
@@ -157,6 +222,12 @@ The initial tool surface is deliberately small:
 Read results identify whether data is fresh, cached, or stale. Errors retain
 the attempted local/public origins and throttling details. The server uses the
 limited API token only; it does not use Marvin's full-access CouchDB API.
+
+The MCP owns Marvin-only operations and does not edit an Obsidian vault.
+Cross-system operations that must atomically persist a source/action
+association and update a managed note region use the plugin API above. Both
+paths share the Marvin client, and the source/action state machine itself
+lives in that shared package rather than in prompt instructions.
 
 See
 [`docs/architecture/marvin-client-and-mcp.md`](docs/architecture/marvin-client-and-mcp.md)

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -6,8 +6,8 @@ allow a later split without making separate repositories a prerequisite.
 
 | Layer | Owns | Does not own |
 | --- | --- | --- |
-| `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links | Obsidian vault/UI behavior; MCP schemas; source-note identity |
-| `src/marvin` | Obsidian `requestUrl` transport adapter | HTTP/API semantics, cache policy, or fallback decisions |
+| `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links; source/action state machine | Obsidian vault/UI behavior; MCP schemas; source-note storage |
+| `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection | HTTP/API semantics, cache policy, or fallback decisions |
 | Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
 | `packages/marvin-mcp` | Stdio lifecycle, four tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
 
@@ -26,19 +26,27 @@ errors are never cached as empty results. Stale-on-error responses are marked
 `freshness: "stale"` and carry the current failure. Task creation and
 completion invalidate today, due, and children entries.
 
-## Extension seam for #51
+## Source/action and Today projection
 
-The next layer should add deterministic integration operations above this
-client:
+`SourceActionService` persists a pending association before calling Marvin.
+Ambiguous transport, 5xx, or invalid-success responses retain that pending
+record, so an unattended retry cannot create another task. Definite 4xx
+rejections clear the pending state. A successful write promotes it to a linked
+record containing the Marvin task ID and deep link.
 
-- ensure one Marvin task for a stable Obsidian source/action key;
-- persist the resulting Marvin ID/deep link back to the source note; and
-- refresh a bounded daily-note region by stable Marvin ID without overwriting
-  surrounding prose.
+The Obsidian adapter stores those records in the source note's
+`amazing-marvin-actions` frontmatter property. Daily-note refresh reads the
+linked task IDs to render a source wikilink when one exists. Tasks created
+directly in Marvin render normally without a synthetic source note.
 
-That source/action identity is not a task title and does not belong in MCP
-prompt text. The Obsidian projection remains responsible for note mutation;
-the shared client remains responsible for Marvin state and explicit failures.
+The managed Today region stores its initial morning IDs in a versioned HTML
+comment. Refresh atomically replaces only that region against the latest note
+contents; new IDs render below the morning list, and content outside the
+markers is preserved.
+
+Source/action identity is not a task title and does not belong in MCP prompt
+text. The Obsidian projection remains responsible for note mutation; the
+shared client remains responsible for Marvin state and explicit failures.
 
 ## Upstream and security boundary
 

--- a/packages/marvin-client/src/index.ts
+++ b/packages/marvin-client/src/index.ts
@@ -2,5 +2,6 @@ export * from "./cache.js";
 export * from "./client.js";
 export * from "./errors.js";
 export * from "./router.js";
+export * from "./sourceAction.js";
 export * from "./transport.js";
 export * from "./types.js";

--- a/packages/marvin-client/src/sourceAction.test.ts
+++ b/packages/marvin-client/src/sourceAction.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	SourceActionError,
+	SourceActionService,
+	type SourceActionKey,
+	type SourceActionRecord,
+	type SourceActionStore,
+} from "./sourceAction.js";
+import { MarvinError } from "./errors.js";
+import type { AddTaskRequest, Task } from "./types.js";
+
+class MemorySourceActionStore implements SourceActionStore {
+	readonly records = new Map<string, SourceActionRecord>();
+	failLinkedWrite = false;
+
+	async get(key: SourceActionKey): Promise<SourceActionRecord | undefined> {
+		return this.records.get(this.key(key));
+	}
+
+	async set(record: SourceActionRecord): Promise<void> {
+		if (record.state === "linked" && this.failLinkedWrite) {
+			throw new Error("disk full");
+		}
+		this.records.set(this.key(record), record);
+	}
+
+	async delete(key: SourceActionKey): Promise<void> {
+		this.records.delete(this.key(key));
+	}
+
+	private key(key: SourceActionKey): string {
+		return `${key.sourceKey}\u0000${key.actionKey}`;
+	}
+}
+
+const createdTask: Task = {
+	_id: "task-1",
+	title: "Decide whether to pursue Titan AI",
+	done: false,
+	day: "2026-07-23",
+};
+
+function createService(
+	store = new MemorySourceActionStore(),
+	addTask: (task: AddTaskRequest) => Promise<Task> = vi.fn(async () => createdTask),
+) {
+	return {
+		store,
+		addTask,
+		service: new SourceActionService({
+			router: { addTask },
+			store,
+			now: () => 1_000,
+			requestId: () => "request-1",
+		}),
+	};
+}
+
+describe("SourceActionService", () => {
+	it("creates once and reuses the persisted stable association", async () => {
+		const { service, addTask } = createService();
+		const request = {
+			sourceKey: "Opportunities/Titan AI.md",
+			actionKey: "decide-whether-to-pursue",
+			task: {
+				title: createdTask.title,
+				day: "2026-07-23",
+			},
+		};
+
+		const first = await service.ensure(request);
+		const second = await service.ensure(request);
+
+		expect(first).toMatchObject({
+			created: true,
+			taskId: "task-1",
+			deepLink: "https://app.amazingmarvin.com/#t=task-1",
+		});
+		expect(second).toMatchObject({
+			created: false,
+			taskId: "task-1",
+		});
+		expect(addTask).toHaveBeenCalledTimes(1);
+	});
+
+	it("coalesces concurrent calls for the same source and action", async () => {
+		let release: ((task: Task) => void) | undefined;
+		const addTask = vi.fn(() => new Promise<Task>((resolve) => {
+			release = resolve;
+		}));
+		const { service } = createService(new MemorySourceActionStore(), addTask);
+		const request = {
+			sourceKey: "note.md",
+			actionKey: "follow-up",
+			task: { title: "Follow up" },
+		};
+
+		const first = service.ensure(request);
+		const second = service.ensure(request);
+		await vi.waitFor(() => {
+			expect(release).toBeTypeOf("function");
+		});
+		release?.(createdTask);
+
+		expect(await first).toEqual(await second);
+		expect(addTask).toHaveBeenCalledTimes(1);
+	});
+
+	it("retains a pending record after an ambiguous creation failure", async () => {
+		const { service, store, addTask } = createService(
+			new MemorySourceActionStore(),
+			vi.fn(async () => {
+				throw new Error("connection reset after write");
+			}),
+		);
+		const request = {
+			sourceKey: "note.md",
+			actionKey: "follow-up",
+			task: { title: "Follow up" },
+		};
+
+		await expect(service.ensure(request)).rejects.toMatchObject({
+			code: "creation-uncertain",
+		});
+		await expect(service.ensure(request)).rejects.toMatchObject({
+			code: "pending",
+		});
+		expect(store.records.values().next().value).toMatchObject({
+			state: "pending",
+			requestId: "request-1",
+		});
+		expect(addTask).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears pending state after a definite API rejection so a later retry is possible", async () => {
+		const store = new MemorySourceActionStore();
+		const rejected = new MarvinError({
+			kind: "throttle",
+			message: "throttled",
+			operation: "add task",
+			origin: "public",
+			status: 429,
+		});
+		const addTask = vi.fn(async () => {
+			if (addTask.mock.calls.length === 1) {
+				throw rejected;
+			}
+			return createdTask;
+		});
+		const { service } = createService(store, addTask);
+		const request = {
+			sourceKey: "note.md",
+			actionKey: "follow-up",
+			task: { title: "Follow up" },
+		};
+
+		await expect(service.ensure(request)).rejects.toBe(rejected);
+		expect(await store.get(request)).toBeUndefined();
+		await expect(service.ensure(request)).resolves.toMatchObject({
+			created: true,
+			taskId: "task-1",
+		});
+		expect(addTask).toHaveBeenCalledTimes(2);
+	});
+
+	it("retains the created task ID when association persistence fails", async () => {
+		const store = new MemorySourceActionStore();
+		store.failLinkedWrite = true;
+		const { service } = createService(store);
+
+		const failure = await service.ensure({
+			sourceKey: "note.md",
+			actionKey: "follow-up",
+			task: { title: "Follow up" },
+		}).catch((error: unknown) => error);
+
+		expect(failure).toBeInstanceOf(SourceActionError);
+		expect(failure).toMatchObject({
+			code: "association-write-failed",
+			task: { _id: "task-1" },
+		});
+		expect(store.records.values().next().value).toMatchObject({
+			state: "pending",
+		});
+	});
+
+	it("can resolve or explicitly clear a pending record", async () => {
+		const { service, store } = createService(
+			new MemorySourceActionStore(),
+			vi.fn(async () => {
+				throw new Error("timeout");
+			}),
+		);
+		const key = { sourceKey: "note.md", actionKey: "follow-up" };
+
+		await service.ensure({ ...key, task: { title: "Follow up" } }).catch(() => undefined);
+		const resolved = await service.resolvePending({
+			...key,
+			taskId: "recovered-task",
+		});
+		expect(resolved).toMatchObject({
+			created: false,
+			taskId: "recovered-task",
+		});
+
+		await expect(service.clearPending(key)).rejects.toThrow(
+			"Refusing to clear linked Marvin task",
+		);
+		await store.set({
+			version: 1,
+			state: "pending",
+			...key,
+			title: "Follow up",
+			requestId: "request-2",
+			requestedAt: 2_000,
+		});
+		await service.clearPending(key);
+		expect(await store.get(key)).toBeUndefined();
+	});
+});

--- a/packages/marvin-client/src/sourceAction.ts
+++ b/packages/marvin-client/src/sourceAction.ts
@@ -1,0 +1,314 @@
+import type { MarvinRouter } from "./router.js";
+import { marvinDeepLink } from "./router.js";
+import { MarvinError } from "./errors.js";
+import type { AddTaskRequest, Task } from "./types.js";
+
+export interface SourceActionKey {
+	sourceKey: string;
+	actionKey: string;
+}
+
+export interface PendingSourceActionRecord extends SourceActionKey {
+	version: 1;
+	state: "pending";
+	title: string;
+	requestId: string;
+	requestedAt: number;
+}
+
+export interface LinkedSourceActionRecord extends SourceActionKey {
+	version: 1;
+	state: "linked";
+	title: string;
+	requestId: string;
+	requestedAt: number;
+	taskId: string;
+	deepLink: string;
+	linkedAt: number;
+}
+
+export type SourceActionRecord =
+	| PendingSourceActionRecord
+	| LinkedSourceActionRecord;
+
+export interface SourceActionStore {
+	get(key: SourceActionKey): Promise<SourceActionRecord | undefined>;
+	set(record: SourceActionRecord): Promise<void>;
+	delete(key: SourceActionKey): Promise<void>;
+}
+
+export interface EnsureSourceActionRequest extends SourceActionKey {
+	task: AddTaskRequest;
+}
+
+export interface EnsureSourceActionResult {
+	created: boolean;
+	taskId: string;
+	deepLink: string;
+	title: string;
+	record: LinkedSourceActionRecord;
+	task?: Task;
+}
+
+export interface ResolvePendingSourceActionRequest extends SourceActionKey {
+	taskId: string;
+	title?: string;
+}
+
+export type SourceActionErrorCode =
+	| "pending"
+	| "creation-uncertain"
+	| "association-write-failed";
+
+export class SourceActionError extends Error {
+	readonly code: SourceActionErrorCode;
+	readonly record: SourceActionRecord;
+	readonly task: Task | undefined;
+	override readonly cause: unknown;
+
+	constructor(options: {
+		code: SourceActionErrorCode;
+		message: string;
+		record: SourceActionRecord;
+		task?: Task;
+		cause?: unknown;
+	}) {
+		super(options.message);
+		this.name = "SourceActionError";
+		this.code = options.code;
+		this.record = options.record;
+		this.task = options.task;
+		this.cause = options.cause;
+	}
+}
+
+export interface SourceActionServiceOptions {
+	router: Pick<MarvinRouter, "addTask">;
+	store: SourceActionStore;
+	now?: () => number;
+	requestId?: () => string;
+}
+
+/**
+ * Coordinates one Marvin task with one stable external source/action key.
+ *
+ * The pending record is persisted before the network write. If the request or
+ * association write has an ambiguous outcome, subsequent calls stop at that
+ * record instead of creating a duplicate. A caller can resolve or explicitly
+ * clear the pending record after inspecting Marvin.
+ */
+export class SourceActionService {
+	private readonly router: Pick<MarvinRouter, "addTask">;
+	private readonly store: SourceActionStore;
+	private readonly now: () => number;
+	private readonly requestId: () => string;
+	private readonly inFlight = new Map<string, Promise<EnsureSourceActionResult>>();
+
+	constructor(options: SourceActionServiceOptions) {
+		this.router = options.router;
+		this.store = options.store;
+		this.now = options.now ?? Date.now;
+		this.requestId = options.requestId ?? defaultRequestId;
+	}
+
+	ensure(request: EnsureSourceActionRequest): Promise<EnsureSourceActionResult> {
+		const key = normalizeKey(request);
+		if (!request.task.title?.trim()) {
+			throw new Error("A source action task title is required");
+		}
+
+		const serializedKey = JSON.stringify([key.sourceKey, key.actionKey]);
+		const existing = this.inFlight.get(serializedKey);
+		if (existing) {
+			return existing;
+		}
+
+		const pending = this.ensureOnce({
+			...request,
+			...key,
+			task: {
+				...request.task,
+				title: request.task.title.trim(),
+			},
+		}).finally(() => {
+			this.inFlight.delete(serializedKey);
+		});
+		this.inFlight.set(serializedKey, pending);
+		return pending;
+	}
+
+	async resolvePending(
+		request: ResolvePendingSourceActionRequest,
+	): Promise<EnsureSourceActionResult> {
+		const key = normalizeKey(request);
+		const taskId = request.taskId.trim();
+		if (!taskId) {
+			throw new Error("A Marvin task ID is required to resolve a source action");
+		}
+		const existing = await this.store.get(key);
+		if (existing?.state === "linked") {
+			if (existing.taskId !== taskId) {
+				throw new Error(
+					`Source action is already linked to Marvin task ${existing.taskId}`,
+				);
+			}
+			return resultFromRecord(existing, false);
+		}
+		if (!existing) {
+			throw new Error("No pending source action exists to resolve");
+		}
+
+		const linked = this.linkedRecord(
+			existing,
+			taskId,
+			request.title?.trim() || existing.title,
+		);
+		await this.store.set(linked);
+		return resultFromRecord(linked, false);
+	}
+
+	async clearPending(keyInput: SourceActionKey): Promise<void> {
+		const key = normalizeKey(keyInput);
+		const existing = await this.store.get(key);
+		if (existing?.state === "linked") {
+			throw new Error(
+				`Refusing to clear linked Marvin task ${existing.taskId}; only pending source actions can be cleared`,
+			);
+		}
+		if (existing) {
+			await this.store.delete(key);
+		}
+	}
+
+	private async ensureOnce(
+		request: EnsureSourceActionRequest,
+	): Promise<EnsureSourceActionResult> {
+		const key = normalizeKey(request);
+		const existing = await this.store.get(key);
+		if (existing?.state === "linked") {
+			return resultFromRecord(existing, false);
+		}
+		if (existing) {
+			throw new SourceActionError({
+				code: "pending",
+				message:
+					`Source action ${existing.actionKey} has an unresolved Marvin creation attempt. `
+					+ "Inspect Marvin, then resolve or clear the pending association before retrying.",
+				record: existing,
+			});
+		}
+
+		const pending: PendingSourceActionRecord = {
+			version: 1,
+			state: "pending",
+			...key,
+			title: request.task.title,
+			requestId: this.requestId(),
+			requestedAt: this.now(),
+		};
+		await this.store.set(pending);
+
+		let task: Task;
+		try {
+			task = await this.router.addTask(request.task);
+		} catch (cause) {
+			if (isDefiniteRejection(cause)) {
+				try {
+					await this.store.delete(key);
+				} catch (deleteCause) {
+					throw new SourceActionError({
+						code: "creation-uncertain",
+						message:
+							"Marvin rejected task creation, but the pending association could not be cleared. Clear it before retrying.",
+						record: pending,
+						cause: deleteCause,
+					});
+				}
+				throw cause;
+			}
+			throw new SourceActionError({
+				code: "creation-uncertain",
+				message:
+					"Marvin task creation did not complete cleanly. The pending association was retained to prevent a duplicate.",
+				record: pending,
+				cause,
+			});
+		}
+
+		const linked = this.linkedRecord(pending, task._id, task.title);
+		try {
+			await this.store.set(linked);
+		} catch (cause) {
+			throw new SourceActionError({
+				code: "association-write-failed",
+				message:
+					`Marvin task ${task._id} was created, but its source association could not be persisted. `
+					+ "Resolve the pending association with this task ID before retrying.",
+				record: pending,
+				task,
+				cause,
+			});
+		}
+
+		return {
+			...resultFromRecord(linked, true),
+			task,
+		};
+	}
+
+	private linkedRecord(
+		pending: PendingSourceActionRecord,
+		taskId: string,
+		title: string,
+	): LinkedSourceActionRecord {
+		if (!taskId) {
+			throw new Error("A Marvin task ID is required to resolve a source action");
+		}
+		return {
+			...pending,
+			state: "linked",
+			title,
+			taskId,
+			deepLink: marvinDeepLink({ _id: taskId, type: "task" }),
+			linkedAt: this.now(),
+		};
+	}
+}
+
+function normalizeKey(key: SourceActionKey): SourceActionKey {
+	const sourceKey = key.sourceKey.trim();
+	const actionKey = key.actionKey.trim();
+	if (!sourceKey) {
+		throw new Error("A stable source key is required");
+	}
+	if (!actionKey) {
+		throw new Error("A stable action key is required");
+	}
+	return { sourceKey, actionKey };
+}
+
+function resultFromRecord(
+	record: LinkedSourceActionRecord,
+	created: boolean,
+): EnsureSourceActionResult {
+	return {
+		created,
+		taskId: record.taskId,
+		deepLink: record.deepLink,
+		title: record.title,
+		record,
+	};
+}
+
+function defaultRequestId(): string {
+	return globalThis.crypto?.randomUUID?.()
+		?? `source-action-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function isDefiniteRejection(error: unknown): boolean {
+	return error instanceof MarvinError
+		&& error.status !== undefined
+		&& error.status >= 400
+		&& error.status < 500
+		&& error.status !== 408;
+}

--- a/src/amTaskWatcher.ts
+++ b/src/amTaskWatcher.ts
@@ -5,8 +5,7 @@ import {
   ViewPlugin,
   ViewUpdate,
 } from '@codemirror/view';
-
-const COMPLETED_AM_TASK = /^\s*[-*+]\s\[[xX]\]\s\[⚓\]\(https:\/\/app\.amazingmarvin\.com\/#t=([^)\s]+)/;
+import { isNewlyCompletedMarvinTask } from "./marvin/taskLine";
 
 export function amTaskWatcher(_app: App, plugin: AmazingMarvinPlugin) {
   return ViewPlugin.fromClass(
@@ -18,12 +17,12 @@ export function amTaskWatcher(_app: App, plugin: AmazingMarvinPlugin) {
         if (!update.docChanged) {
           return;
         }
-        update.changes.iterChanges((fromA, _toA, _fromB, _toB, change) => {
-          //only match if the change is on an AM task and it's a completed task
-          let line = update.state.doc.lineAt(fromA).text;
-          const match = line.match(COMPLETED_AM_TASK);
-          if (match && match[1]) {
-            void plugin.markDone(match[1]).catch((error) => {
+        update.changes.iterChanges((fromA, _toA, fromB) => {
+          const before = update.startState.doc.lineAt(fromA).text;
+          const after = update.state.doc.lineAt(fromB).text;
+          const taskId = isNewlyCompletedMarvinTask(before, after);
+          if (taskId) {
+            void plugin.markDone(taskId).catch((error) => {
               console.error("Could not mark Amazing Marvin task as done:", error);
             });
           }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,63 @@
+import type {
+	AddTaskRequest,
+	EnsureSourceActionResult,
+	MarvinReadResult,
+	ResolvePendingSourceActionRequest,
+	TaskOrProject,
+} from "@open-horizon/marvin-client";
+
+export interface EnsureTaskForSourceInput {
+	sourcePath: string;
+	actionKey: string;
+	title: string;
+	parentId?: string;
+	day?: string;
+	dueDate?: string;
+	labelIds?: string[];
+	note?: string;
+}
+
+export interface RefreshTodayTasksInput {
+	date: string;
+	filePath?: string;
+}
+
+export interface RefreshTodayTasksResult {
+	date: string;
+	filePath: string;
+	changed: boolean;
+	createdRegion: boolean;
+	morningIds: string[];
+	lateIds: string[];
+	freshness: MarvinReadResult<unknown>["freshness"];
+	origin: MarvinReadResult<unknown>["origin"];
+	warnings: MarvinReadResult<unknown>["warnings"];
+}
+
+/**
+ * Stable automation surface for Templater and other in-Obsidian callers.
+ *
+ * Access it as:
+ * `app.plugins.plugins["cloudatlas-o-am"].api`
+ */
+export interface AmazingMarvinApi {
+	getToday(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	getDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	getTodayAndDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	createTask(task: AddTaskRequest): Promise<TaskOrProject>;
+	ensureTaskForSource(
+		input: EnsureTaskForSourceInput,
+	): Promise<EnsureSourceActionResult>;
+	resolvePendingSourceAction(
+		input: Omit<ResolvePendingSourceActionRequest, "sourceKey"> & {
+			sourcePath: string;
+		},
+	): Promise<EnsureSourceActionResult>;
+	clearPendingSourceAction(input: {
+		sourcePath: string;
+		actionKey: string;
+	}): Promise<void>;
+	refreshTodayTasks(
+		input: RefreshTodayTasksInput,
+	): Promise<RefreshTodayTasksResult>;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import {
 	Notice,
 	Plugin,
+	TFile,
+	moment,
 	normalizePath,
 	requestUrl,
 	stringifyYaml,
@@ -14,9 +16,14 @@ import {
 	type AddTaskRequest,
 	type MarvinItem,
 	type MarvinReadResult,
+	type TaskOrProject,
+	type EnsureSourceActionResult,
 	MarvinApiClient,
 	MarvinError,
+	MarvinRouteError,
 	MarvinRouter,
+	SourceActionError,
+	SourceActionService,
 	marvinDeepLink,
 } from "@open-horizon/marvin-client";
 
@@ -27,17 +34,39 @@ import {
 } from "./settings";
 
 import {
-	getDateFromFile
+	getAllDailyNotes,
+	getDailyNote,
+	getDateFromFile,
 } from "obsidian-daily-notes-interface";
 import { amTaskWatcher } from "./amTaskWatcher";
 import { AddTaskModal } from "./addTaskModal";
+import type {
+	AmazingMarvinApi,
+	EnsureTaskForSourceInput,
+	RefreshTodayTasksInput,
+	RefreshTodayTasksResult,
+} from "./api";
+import {
+	buildSourceActionTaskNote,
+} from "./marvin/obsidianLinks";
+import {
+	ObsidianSourceActionStore,
+} from "./marvin/obsidianSourceActions";
 import { createObsidianTransport } from "./marvin/obsidianTransport";
+import {
+	hasTodayRegion,
+	type TodayProjectionItem,
+} from "./marvin/todayProjection";
+import { runTodayProjection } from "./marvin/todayWorkflow";
 
 function getAMTimezoneOffset() {
 	return new Date().getTimezoneOffset() * -1;
 }
 
 const animateNotice = (notice: Notice) => {
+	if (!notice.noticeEl.isConnected) {
+		return;
+	}
 	let message = notice.noticeEl.innerText;
 	const dots = [...message].filter((c) => c === ".").length;
 	if (dots == 0) {
@@ -64,6 +93,41 @@ export default class AmazingMarvinPlugin extends Plugin {
 	categories: Category[] = [];
 	private marvinRouter?: MarvinRouter;
 	private marvinRouterKey = "";
+	private sourceActionStore?: ObsidianSourceActionStore;
+	private sourceActionService?: SourceActionService;
+	private sourceActionRouter?: MarvinRouter;
+	private readonly todayRefreshes = new Map<string, Promise<RefreshTodayTasksResult>>();
+	private lastAutomaticRefreshAt = 0;
+	private lastAutomaticRefreshError = "";
+
+	readonly api: AmazingMarvinApi = {
+		getToday: (date) => this.getMarvinRouter().getTodayItems(date),
+		getDue: (date) => this.getMarvinRouter().getDueItems(date),
+		getTodayAndDue: (date) => this.getMarvinRouter().getTodayAndDue(date),
+		createTask: async (task) => {
+			const created = await this.getMarvinRouter().addTask(task);
+			this.queueManagedTodayRefresh("creating a task");
+			return created;
+		},
+		ensureTaskForSource: (input) => this.ensureTaskForSource(input),
+		resolvePendingSourceAction: async (input) => {
+			const result = await this.getSourceActionService().resolvePending({
+				sourceKey: input.sourcePath,
+				actionKey: input.actionKey,
+				taskId: input.taskId,
+				...(input.title === undefined ? {} : { title: input.title }),
+			});
+			this.queueManagedTodayRefresh("resolving a contextual task");
+			return result;
+		},
+		clearPendingSourceAction: (input) => (
+			this.getSourceActionService().clearPending({
+				sourceKey: input.sourcePath,
+				actionKey: input.actionKey,
+			})
+		),
+		refreshTodayTasks: (input) => this.refreshTodayTasks(input),
+	};
 
 	createFolder = async (path: string) => {
 		try {
@@ -87,6 +151,21 @@ export default class AmazingMarvinPlugin extends Plugin {
 		if (this.settings.attemptToMarkTasksAsDone) {
 			this.registerEditorExtension(amTaskWatcher(this.app, this));
 		}
+		this.registerEvent(this.app.metadataCache.on("changed", (file, _data, cache) => {
+			if (
+				this.sourceActionStore?.shouldInvalidateFor(
+					file.path,
+					cache.frontmatter,
+				)
+			) {
+				this.sourceActionStore.invalidateIndex(true);
+			}
+		}));
+		this.registerEvent(this.app.metadataCache.on("deleted", (file) => {
+			if (this.sourceActionStore?.shouldInvalidateFor(file.path, undefined)) {
+				this.sourceActionStore.invalidateIndex(true);
+			}
+		}));
 
 		this.addCommand({
 			id: "create-task",
@@ -138,36 +217,46 @@ export default class AmazingMarvinPlugin extends Plugin {
       });
 		this.addCommand({
 			id: "import-today",
-			name: "Import today's tasks",
-			editorCallback: async (editor, view) => {
+			name: "Refresh today's tasks",
+			editorCallback: async (_editor, view) => {
 				try {
-					const today = new Date().toISOString().split('T')[0];
-					const fileDate = view.file ? getDateFromFile(view.file, "day")?.format("YYYY-MM-DD") : today;
-
-					const date = fileDate ? fileDate : today;
-					let tasks: (Task | Category)[];
-					if (this.settings.todayTasksToShow === 'both') {
-						const result = await this.getMarvinRouter().getTodayAndDue(date);
-						this.reportReadState(result, "today and due tasks");
-						tasks = result.data.map(item => this.decorateWithDeepLink(item));
-					} else if (this.settings.todayTasksToShow === 'due') {
-						tasks = await this.getDueTasks(date);
-					} else {
-						tasks = await this.getScheduledTasks(date);
+					if (!view.file) {
+						throw new Error("Open the daily note you want to refresh");
 					}
-
-					editor.replaceRange(this.formatItems(tasks, 0, false), editor.getCursor());
+					const fileDate = getDateFromFile(view.file, "day");
+					if (!fileDate) {
+						throw new Error(`${view.file.path} is not recognized as a daily note`);
+					}
+					const date = fileDate.format("YYYY-MM-DD");
+					const result = await this.refreshTodayTasks({
+						date,
+						filePath: view.file.path,
+					});
+					new Notice(
+						result.changed
+							? `Refreshed Amazing Marvin tasks for ${date}.`
+							: `Amazing Marvin tasks for ${date} are already current.`,
+					);
 				} catch (error) {
-					new Notice(`Error importing scheduled tasks: ${error}`);
-					console.error(`Error importing scheduled tasks: ${error}`);
+					new Notice(`Error refreshing today's tasks: ${this.errorMessage(error)}`);
+					console.error("Error refreshing today's tasks:", error);
 				}
 			}
 		});
 
+		this.registerDomEvent(window, "focus", () => {
+			void this.runAutomaticTodayRefresh("window focus");
+		});
+		this.registerInterval(window.setInterval(() => {
+			void this.runAutomaticTodayRefresh("interval");
+		}, 60_000));
+		this.app.workspace.onLayoutReady(() => {
+			void this.runAutomaticTodayRefresh("startup");
+		});
 	}
 	async addMarvinTask(catId: string, taskTitle: string, notePath: string = '', vaultName: string = ''): Promise<Task> {
 		const requestBody: AddTaskRequest = {
-			title: taskTitle,
+			title: taskTitle.trim(),
 			timeZoneOffset: getAMTimezoneOffset(),
 		};
 
@@ -175,21 +264,40 @@ export default class AmazingMarvinPlugin extends Plugin {
 			requestBody.parentId = catId;
 		}
 
-		if (notePath && notePath !== '') {
-			let link = `obsidian://open?file=${encodeURI(notePath)}${vaultName !== '' ? `&vault=${encodeURI(vaultName)}` : ''}`;
-			if (this.settings.linkBackToObsidianText !== '') {
-				requestBody.note = `[${this.settings.linkBackToObsidianText}](${link})`;
-			} else {
-				requestBody.note = link;
-			}
-	}
-
 		try {
-			const task = await this.getMarvinRouter().addTask(requestBody);
+			let task: TaskOrProject;
+			if (notePath) {
+				const actionKey = `manual-${this.newOperationId()}`;
+				requestBody.note = buildSourceActionTaskNote({
+					vaultName: vaultName || this.app.vault.getName(),
+					sourcePath: notePath,
+					actionKey,
+					linkText: this.settings.linkBackToObsidianText,
+					format: this.settings.obsidianLinkFormat,
+				});
+				const ensured = await this.getSourceActionService().ensure({
+					sourceKey: notePath,
+					actionKey,
+					task: requestBody,
+				});
+				if (!ensured.task) {
+					throw new Error(
+						`Manual source action unexpectedly reused Marvin task ${ensured.taskId}`,
+					);
+				}
+				task = ensured.task;
+			} else {
+				task = await this.getMarvinRouter().addTask(requestBody);
+			}
 			new Notice("Task added in Amazing Marvin.");
+			this.queueManagedTodayRefresh("creating a task");
 			return this.decorateWithDeepLink(task) as Task;
 		} catch (error) {
 			console.error('Error creating task:', error);
+			if (error instanceof SourceActionError) {
+				new Notice(error.message, 0);
+				throw error;
+			}
 			this.showManualActionError(
 				this.isThrottle(error)
 					? 'Your request was throttled by Amazing Marvin. Wait before trying again, or do it '
@@ -203,15 +311,18 @@ export default class AmazingMarvinPlugin extends Plugin {
 	onunload() { }
 
 	async loadSettings() {
-		this.settings = Object.assign(
-			DEFAULT_SETTINGS,
-			await this.loadData()
-		);
+		const stored = await this.loadData() as Partial<AmazingMarvinPluginSettings> | null;
+		this.settings = {
+			...DEFAULT_SETTINGS,
+			...(stored ?? {}),
+		};
 	}
 
 	async saveSettings() {
 		this.marvinRouter = undefined;
 		this.marvinRouterKey = "";
+		this.sourceActionService = undefined;
+		this.sourceActionRouter = undefined;
 		await this.saveData(this.settings);
 	}
 
@@ -229,6 +340,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 			note.append(a);
 			note.appendText(' marked as done in Amazing Marvin.');
 			new Notice(note, 5000);
+			this.queueManagedTodayRefresh("completing a task");
 			return result;
 		} catch (error) {
 			console.error('Error marking task as done:', error);
@@ -240,6 +352,204 @@ export default class AmazingMarvinPlugin extends Plugin {
 			);
 			throw error;
 		}
+	}
+
+	async ensureTaskForSource(
+		input: EnsureTaskForSourceInput,
+	): Promise<EnsureSourceActionResult> {
+		const request: AddTaskRequest = {
+			title: input.title.trim(),
+			timeZoneOffset: getAMTimezoneOffset(),
+			note: buildSourceActionTaskNote({
+				vaultName: this.app.vault.getName(),
+				sourcePath: input.sourcePath,
+				actionKey: input.actionKey,
+				linkText: this.settings.linkBackToObsidianText,
+				format: this.settings.obsidianLinkFormat,
+				...(input.note === undefined ? {} : { note: input.note }),
+			}),
+			...(input.parentId === undefined ? {} : { parentId: input.parentId }),
+			...(input.day === undefined ? {} : { day: input.day }),
+			...(input.dueDate === undefined ? {} : { dueDate: input.dueDate }),
+			...(input.labelIds === undefined ? {} : { labelIds: input.labelIds }),
+		};
+		const result = await this.getSourceActionService().ensure({
+			sourceKey: input.sourcePath,
+			actionKey: input.actionKey,
+			task: request,
+		});
+		this.queueManagedTodayRefresh("creating a contextual task");
+		return result;
+	}
+
+	async refreshTodayTasks(
+		input: RefreshTodayTasksInput,
+	): Promise<RefreshTodayTasksResult> {
+		const date = this.requireDate(input.date);
+		const file = this.resolveDailyNote(date, input.filePath);
+		const key = `${file.path}\u0000${date}`;
+		const existing = this.todayRefreshes.get(key);
+		if (existing) {
+			return existing;
+		}
+
+		const pending = this.refreshTodayTasksOnce(date, file).finally(() => {
+			this.todayRefreshes.delete(key);
+		});
+		this.todayRefreshes.set(key, pending);
+		return pending;
+	}
+
+	private async refreshTodayTasksOnce(
+		date: string,
+		file: TFile,
+	): Promise<RefreshTodayTasksResult> {
+		const workflow = await runTodayProjection({
+			date,
+			read: () => this.readTodaySelection(date),
+			project: (data) => this.toTodayProjectionItems(data),
+			process: async (update) => {
+				await this.app.vault.process(file, update);
+			},
+		});
+		const { read, projection } = workflow;
+		this.reportReadState(read, `tasks for ${date}`);
+		return {
+			date,
+			filePath: file.path,
+			changed: projection.changed,
+			createdRegion: projection.createdRegion,
+			morningIds: projection.morningIds,
+			lateIds: projection.lateIds,
+			freshness: read.freshness,
+			origin: read.origin,
+			warnings: read.warnings,
+		};
+	}
+
+	private toTodayProjectionItems(data: TaskOrProject[]): TodayProjectionItem[] {
+		const sourceLinks = this.getSourceActionStore().findLinkedTasks(
+			data.map((item) => item._id),
+		);
+		return data.map((item) => {
+			const deepLink = marvinDeepLink({
+				...item,
+				type: item.type ?? "task",
+			});
+			const source = sourceLinks.get(item._id);
+			const details = this.formatTaskDetails(item as Task, "").trim();
+			return {
+				id: item._id,
+				title: item.title,
+				done: Boolean(item.done),
+				deepLink,
+				...(details ? { details } : {}),
+				...(source === undefined
+					? {}
+					: {
+						sourcePath: source.sourcePath,
+						sourceTitle: item.title,
+					}),
+			};
+		});
+	}
+
+	private async readTodaySelection(
+		date: string,
+	): Promise<MarvinReadResult<TaskOrProject[]>> {
+		if (this.settings.todayTasksToShow === "due") {
+			return this.getMarvinRouter().getDueItems(date);
+		}
+		if (this.settings.todayTasksToShow === "scheduled") {
+			return this.getMarvinRouter().getTodayItems(date);
+		}
+		return this.getMarvinRouter().getTodayAndDue(date);
+	}
+
+	private resolveDailyNote(date: string, filePath?: string): TFile {
+		if (filePath) {
+			const file = this.app.vault.getAbstractFileByPath(filePath);
+			if (!(file instanceof TFile)) {
+				throw new Error(`Daily note not found: ${filePath}`);
+			}
+			return file;
+		}
+		const file = getDailyNote(
+			moment(date, "YYYY-MM-DD", true),
+			getAllDailyNotes(),
+		);
+		if (!file) {
+			throw new Error(`No daily note exists for ${date}`);
+		}
+		return file;
+	}
+
+	private requireDate(date: string): string {
+		const normalized = date.trim();
+		if (!moment(normalized, "YYYY-MM-DD", true).isValid()) {
+			throw new Error(`Expected a date in YYYY-MM-DD format, received: ${date}`);
+		}
+		return normalized;
+	}
+
+	private async runAutomaticTodayRefresh(reason: string): Promise<void> {
+		if (!this.settings.autoRefreshTodayTasks) {
+			return;
+		}
+		const now = Date.now();
+		const minimumDelay = reason === "interval"
+			? Math.max(1, this.settings.todayRefreshIntervalMinutes) * 60_000
+			: 15_000;
+		if (now - this.lastAutomaticRefreshAt < minimumDelay) {
+			return;
+		}
+		this.lastAutomaticRefreshAt = now;
+		try {
+			await this.refreshManagedTodayIfPresent();
+			this.lastAutomaticRefreshError = "";
+		} catch (error) {
+			const message = this.errorMessage(error);
+			console.warn(
+				`Could not automatically refresh Amazing Marvin tasks after ${reason}:`,
+				error,
+			);
+			if (message !== this.lastAutomaticRefreshError) {
+				this.lastAutomaticRefreshError = message;
+				new Notice(
+					`Amazing Marvin automatic refresh failed; the existing daily-note tasks were left unchanged. ${message}`,
+					10_000,
+				);
+			}
+		}
+	}
+
+	private async refreshManagedTodayIfPresent(): Promise<boolean> {
+		const date = moment().format("YYYY-MM-DD");
+		let file: TFile;
+		try {
+			file = this.resolveDailyNote(date);
+		} catch {
+			return false;
+		}
+		const content = await this.app.vault.cachedRead(file);
+		if (!hasTodayRegion(content, date)) {
+			return false;
+		}
+		await this.refreshTodayTasks({ date, filePath: file.path });
+		return true;
+	}
+
+	private queueManagedTodayRefresh(context: string): void {
+		void this.refreshManagedTodayIfPresent().catch((error) => {
+			console.warn(
+				`Amazing Marvin succeeded at ${context}, but the managed daily-note refresh failed:`,
+				error,
+			);
+			new Notice(
+				`Amazing Marvin succeeded at ${context}, but today's managed task region could not be refreshed. ${this.errorMessage(error)}`,
+				10_000,
+			);
+		});
 	}
 
 
@@ -486,6 +796,24 @@ export default class AmazingMarvinPlugin extends Plugin {
 		return this.marvinRouter;
 	}
 
+	private getSourceActionStore(): ObsidianSourceActionStore {
+		this.sourceActionStore ??= new ObsidianSourceActionStore(this.app);
+		return this.sourceActionStore;
+	}
+
+	private getSourceActionService(): SourceActionService {
+		const router = this.getMarvinRouter();
+		if (this.sourceActionService && this.sourceActionRouter === router) {
+			return this.sourceActionService;
+		}
+		this.sourceActionService = new SourceActionService({
+			router,
+			store: this.getSourceActionStore(),
+		});
+		this.sourceActionRouter = router;
+		return this.sourceActionService;
+	}
+
 	private reportReadState<T>(result: MarvinReadResult<T>, description: string) {
 		if (result.freshness === "stale") {
 			new Notice(
@@ -502,7 +830,25 @@ export default class AmazingMarvinPlugin extends Plugin {
 	}
 
 	private isThrottle(error: unknown): boolean {
-		return error instanceof MarvinError && error.status === 429;
+		if (error instanceof MarvinError) {
+			return error.status === 429;
+		}
+		if (error instanceof MarvinRouteError) {
+			return error.attempts.some((attempt) => attempt.status === 429);
+		}
+		if (error instanceof SourceActionError) {
+			return this.isThrottle(error.cause);
+		}
+		return false;
+	}
+
+	private newOperationId(): string {
+		return globalThis.crypto?.randomUUID?.()
+			?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	}
+
+	private errorMessage(error: unknown): string {
+		return error instanceof Error ? error.message : String(error);
 	}
 
 	private showManualActionError(message: string, href: string) {

--- a/src/marvin/dailyWorkflow.e2e.test.ts
+++ b/src/marvin/dailyWorkflow.e2e.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	SourceActionService,
+	type AddTaskRequest,
+	type SourceActionKey,
+	type SourceActionRecord,
+	type SourceActionStore,
+	type Task,
+} from "@open-horizon/marvin-client";
+
+import { buildSourceActionTaskNote } from "./obsidianLinks";
+import {
+	marvinIdsInMarkdown,
+	refreshTodayRegion,
+	type TodayProjectionItem,
+} from "./todayProjection";
+
+class FixtureSourceNote implements SourceActionStore {
+	readonly associations = new Map<string, SourceActionRecord>();
+
+	async get(key: SourceActionKey): Promise<SourceActionRecord | undefined> {
+		return this.associations.get(key.actionKey);
+	}
+
+	async set(record: SourceActionRecord): Promise<void> {
+		this.associations.set(record.actionKey, record);
+	}
+
+	async delete(key: SourceActionKey): Promise<void> {
+		this.associations.delete(key.actionKey);
+	}
+}
+
+describe("contextual daily-note workflow", () => {
+	it("links an opportunity note to one Marvin task and one safely refreshable checklist entry", async () => {
+		const sourcePath = "Opportunities/Titan AI.md";
+		const sourceNote = new FixtureSourceNote();
+		const createdTask: Task = {
+			_id: "titan-decision",
+			title: "Decide whether to pursue Titan AI",
+			done: false,
+			day: "2026-07-23",
+		};
+		const addTask = vi.fn(async (_request: AddTaskRequest) => createdTask);
+		const sourceActions = new SourceActionService({
+			router: { addTask },
+			store: sourceNote,
+			now: () => 1_000,
+			requestId: () => "opportunity-run-1",
+		});
+		const request: AddTaskRequest = {
+			title: createdTask.title,
+			day: "2026-07-23",
+			note: buildSourceActionTaskNote({
+				vaultName: "Work",
+				sourcePath,
+				actionKey: "decide-whether-to-pursue",
+				linkText: "Open opportunity note",
+				format: "advanced-uri",
+			}),
+		};
+
+		const first = await sourceActions.ensure({
+			sourceKey: sourcePath,
+			actionKey: "decide-whether-to-pursue",
+			task: request,
+		});
+		const repeatedCreation = await sourceActions.ensure({
+			sourceKey: sourcePath,
+			actionKey: "decide-whether-to-pursue",
+			task: request,
+		});
+
+		expect(first.created).toBe(true);
+		expect(repeatedCreation.created).toBe(false);
+		expect(addTask).toHaveBeenCalledTimes(1);
+		expect(request.note).toContain("obsidian://adv-uri?");
+		expect(sourceNote.associations.get("decide-whether-to-pursue")).toMatchObject({
+			state: "linked",
+			taskId: "titan-decision",
+		});
+
+		const morning: TodayProjectionItem = {
+			id: "morning-task",
+			title: "Existing morning task",
+			done: false,
+			deepLink: "https://app.amazingmarvin.com/#t=morning-task",
+		};
+		const initialDailyNote = [
+			"# Thursday",
+			"",
+			"## Today's tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=morning-task) Existing morning task",
+			"",
+			"## Notes",
+			"User-authored context survives.",
+		].join("\n");
+		const linkedTask: TodayProjectionItem = {
+			id: createdTask._id,
+			title: createdTask.title,
+			done: createdTask.done,
+			deepLink: first.deepLink,
+			sourcePath,
+			sourceTitle: createdTask.title,
+		};
+
+		// The duplicate models the same task appearing in both due and scheduled reads.
+		const firstRefresh = refreshTodayRegion(initialDailyNote, {
+			date: "2026-07-23",
+			items: [morning, linkedTask, linkedTask],
+		});
+		const repeatedRefresh = refreshTodayRegion(firstRefresh.content, {
+			date: "2026-07-23",
+			items: [morning, linkedTask, linkedTask],
+		});
+
+		expect(marvinIdsInMarkdown(firstRefresh.content)).toEqual([
+			"morning-task",
+			"titan-decision",
+		]);
+		expect(firstRefresh.content).toContain("### Added since morning");
+		expect(firstRefresh.content).toContain(
+			"[[Opportunities/Titan AI.md|Decide whether to pursue Titan AI]]",
+		);
+		expect(firstRefresh.content).toContain(
+			"[⚓](https://app.amazingmarvin.com/#t=titan-decision)",
+		);
+		expect(firstRefresh.content).toContain("User-authored context survives.");
+		expect(repeatedRefresh.changed).toBe(false);
+		expect(repeatedRefresh.content).toBe(firstRefresh.content);
+	});
+});

--- a/src/marvin/obsidianLinks.test.ts
+++ b/src/marvin/obsidianLinks.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	buildObsidianUri,
+	buildSourceActionTaskNote,
+} from "./obsidianLinks";
+
+describe("Obsidian source links", () => {
+	it("builds the Advanced URI format requested by existing workflows", () => {
+		expect(buildObsidianUri({
+			vaultName: "My Vault",
+			filePath: "Opportunities/Titan AI.md",
+			format: "advanced-uri",
+		})).toBe(
+			"obsidian://adv-uri?vault=My%20Vault&filepath=Opportunities%2FTitan%20AI.md",
+		);
+	});
+
+	it("retains an official Obsidian URI option", () => {
+		expect(buildObsidianUri({
+			vaultName: "My Vault",
+			filePath: "Notes/Source.md",
+			format: "standard",
+		})).toBe(
+			"obsidian://open?vault=My%20Vault&file=Notes%2FSource.md",
+		);
+	});
+
+	it("embeds a stable source/action marker without replacing caller notes", () => {
+		const note = buildSourceActionTaskNote({
+			vaultName: "My Vault",
+			sourcePath: "Opportunities/Titan AI.md",
+			actionKey: "decide whether/to pursue",
+			linkText: "Open source note",
+			format: "advanced-uri",
+			note: "Evidence captured by the automation.",
+		});
+
+		expect(note).toContain("Evidence captured by the automation.");
+		expect(note).toContain("[Open source note](obsidian://adv-uri?");
+		expect(note).toContain(
+			"source=Opportunities%2FTitan%20AI.md action=decide%20whether%2Fto%20pursue",
+		);
+	});
+});

--- a/src/marvin/obsidianLinks.ts
+++ b/src/marvin/obsidianLinks.ts
@@ -1,0 +1,49 @@
+export type ObsidianLinkFormat = "advanced-uri" | "standard";
+
+export interface ObsidianSourceLink {
+	vaultName: string;
+	filePath: string;
+	format: ObsidianLinkFormat;
+}
+
+export function buildObsidianUri(options: ObsidianSourceLink): string {
+	const vault = encodeURIComponent(options.vaultName);
+	const filePath = encodeURIComponent(options.filePath);
+	return options.format === "advanced-uri"
+		? `obsidian://adv-uri?vault=${vault}&filepath=${filePath}`
+		: `obsidian://open?vault=${vault}&file=${filePath}`;
+}
+
+export function buildSourceActionTaskNote(options: {
+	vaultName: string;
+	sourcePath: string;
+	actionKey: string;
+	linkText: string;
+	format: ObsidianLinkFormat;
+	note?: string;
+}): string {
+	const uri = buildObsidianUri({
+		vaultName: options.vaultName,
+		filePath: options.sourcePath,
+		format: options.format,
+	});
+	const link = options.linkText
+		? `[${escapeMarkdownLabel(options.linkText)}](${uri})`
+		: uri;
+	const marker = [
+		"<!-- obsidian-am:source-action",
+		"version=1",
+		`source=${encodeURIComponent(options.sourcePath)}`,
+		`action=${encodeURIComponent(options.actionKey)}`,
+		"-->",
+	].join(" ");
+	return [options.note?.trim(), link, marker].filter(Boolean).join("\n\n");
+}
+
+function escapeMarkdownLabel(value: string): string {
+	return value
+		.replace(/[\r\n]+/g, " ")
+		.replace(/\\/g, "\\\\")
+		.replace(/\]/g, "\\]")
+		.trim();
+}

--- a/src/marvin/obsidianSourceActions.test.ts
+++ b/src/marvin/obsidianSourceActions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { App } from "obsidian";
+
+import {
+	ObsidianSourceActionStore,
+	SOURCE_ACTIONS_FRONTMATTER_KEY,
+	readSourceActionRecords,
+} from "./obsidianSourceActions";
+
+describe("source action frontmatter", () => {
+	it("reads pending and linked associations using the note path as source identity", () => {
+		const records = readSourceActionRecords({
+			[SOURCE_ACTIONS_FRONTMATTER_KEY]: [
+				{
+					version: 1,
+					state: "pending",
+					actionKey: "decide",
+					title: "Decide",
+					requestId: "request-1",
+					requestedAt: 100,
+				},
+				{
+					version: 1,
+					state: "linked",
+					actionKey: "apply",
+					title: "Apply",
+					requestId: "request-2",
+					requestedAt: 200,
+					taskId: "task-2",
+					deepLink: "https://app.amazingmarvin.com/#t=task-2",
+					linkedAt: 300,
+				},
+			],
+		}, "Opportunities/Titan.md");
+
+		expect(records).toEqual([
+			expect.objectContaining({
+				state: "pending",
+				sourceKey: "Opportunities/Titan.md",
+				actionKey: "decide",
+			}),
+			expect.objectContaining({
+				state: "linked",
+				sourceKey: "Opportunities/Titan.md",
+				taskId: "task-2",
+			}),
+		]);
+	});
+
+	it("distinguishes no associations from malformed owned metadata", () => {
+		expect(readSourceActionRecords({}, "note.md")).toEqual([]);
+		expect(() => readSourceActionRecords({
+			[SOURCE_ACTIONS_FRONTMATTER_KEY]: "task-1",
+		}, "note.md")).toThrow("must be a list");
+	});
+
+	it("persists a linked association and discovers its source note by task ID", async () => {
+		const file = {
+			path: "Opportunities/Titan.md",
+			basename: "Titan",
+			extension: "md",
+		};
+		const frontmatter: Record<string, unknown> = {};
+		const app = {
+			vault: {
+				getAbstractFileByPath: (path: string) => path === file.path ? file : null,
+				getMarkdownFiles: () => [file],
+			},
+			metadataCache: {
+				getFileCache: () => ({ frontmatter }),
+			},
+			fileManager: {
+				processFrontMatter: async (
+					_file: unknown,
+					mutate: (value: Record<string, unknown>) => void,
+				) => mutate(frontmatter),
+			},
+		} as unknown as App;
+		const store = new ObsidianSourceActionStore(app);
+
+		await store.set({
+			version: 1,
+			state: "linked",
+			sourceKey: file.path,
+			actionKey: "decide",
+			title: "Decide whether to pursue",
+			requestId: "request-1",
+			requestedAt: 100,
+			taskId: "task-1",
+			deepLink: "https://app.amazingmarvin.com/#t=task-1",
+			linkedAt: 200,
+		});
+
+		expect(frontmatter[SOURCE_ACTIONS_FRONTMATTER_KEY]).toEqual([
+			expect.objectContaining({
+				actionKey: "decide",
+				taskId: "task-1",
+			}),
+		]);
+		expect(await store.get({
+			sourceKey: file.path,
+			actionKey: "decide",
+		})).toMatchObject({ state: "linked", taskId: "task-1" });
+		expect(store.findLinkedTasks(["task-1"]).get("task-1")).toEqual({
+			taskId: "task-1",
+			sourcePath: file.path,
+			sourceTitle: "Titan",
+			actionKey: "decide",
+			deepLink: "https://app.amazingmarvin.com/#t=task-1",
+		});
+		expect(store.shouldInvalidateFor(file.path, undefined)).toBe(true);
+		expect(store.shouldInvalidateFor("Daily/2026-07-23.md", {})).toBe(false);
+	});
+});

--- a/src/marvin/obsidianSourceActions.ts
+++ b/src/marvin/obsidianSourceActions.ts
@@ -1,0 +1,281 @@
+import type { App, TFile } from "obsidian";
+import type {
+	LinkedSourceActionRecord,
+	SourceActionKey,
+	SourceActionRecord,
+	SourceActionStore,
+} from "@open-horizon/marvin-client";
+
+export const SOURCE_ACTIONS_FRONTMATTER_KEY = "amazing-marvin-actions";
+
+interface StoredSourceActionRecord {
+	version: 1;
+	state: "pending" | "linked";
+	actionKey: string;
+	title: string;
+	requestId: string;
+	requestedAt: number;
+	taskId?: string;
+	deepLink?: string;
+	linkedAt?: number;
+}
+
+export interface SourceActionLink {
+	taskId: string;
+	sourcePath: string;
+	sourceTitle: string;
+	actionKey: string;
+	deepLink: string;
+}
+
+const DELETED = Symbol("deleted-source-action");
+
+export class ObsidianSourceActionStore implements SourceActionStore {
+	private readonly overlay = new Map<string, SourceActionRecord | typeof DELETED>();
+	private linkedIndex?: Map<string, SourceActionLink>;
+	private indexedSourcePaths = new Set<string>();
+
+	constructor(private readonly app: App) {}
+
+	async get(key: SourceActionKey): Promise<SourceActionRecord | undefined> {
+		const overlay = this.overlay.get(serializedKey(key));
+		if (overlay === DELETED) {
+			return undefined;
+		}
+		if (overlay) {
+			return overlay;
+		}
+		const file = this.requireMarkdownFile(key.sourceKey);
+		return readSourceActionRecords(
+			this.app.metadataCache.getFileCache(file)?.frontmatter,
+			file.path,
+		).find((record) => record.actionKey === key.actionKey);
+	}
+
+	async set(record: SourceActionRecord): Promise<void> {
+		const file = this.requireMarkdownFile(record.sourceKey);
+		await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+			const records = readSourceActionRecords(frontmatter, file.path);
+			const next = records.filter(
+				(candidate) => candidate.actionKey !== record.actionKey,
+			);
+			next.push(record);
+			frontmatter[SOURCE_ACTIONS_FRONTMATTER_KEY] = next.map(toStoredRecord);
+		});
+		this.overlay.set(serializedKey(record), record);
+		this.linkedIndex = undefined;
+	}
+
+	async delete(key: SourceActionKey): Promise<void> {
+		const file = this.requireMarkdownFile(key.sourceKey);
+		await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+			const records = readSourceActionRecords(frontmatter, file.path);
+			const next = records.filter(
+				(candidate) => candidate.actionKey !== key.actionKey,
+			);
+			if (next.length === 0) {
+				delete frontmatter[SOURCE_ACTIONS_FRONTMATTER_KEY];
+			} else {
+				frontmatter[SOURCE_ACTIONS_FRONTMATTER_KEY] = next.map(toStoredRecord);
+			}
+		});
+		this.overlay.set(serializedKey(key), DELETED);
+		this.linkedIndex = undefined;
+	}
+
+	findLinkedTasks(taskIds: Iterable<string>): Map<string, SourceActionLink> {
+		this.linkedIndex ??= this.buildLinkedIndex();
+		const links = new Map<string, SourceActionLink>();
+		for (const taskId of taskIds) {
+			const link = this.linkedIndex.get(taskId);
+			if (link) {
+				links.set(taskId, link);
+			}
+		}
+		return links;
+	}
+
+	invalidateIndex(clearOverlay = false): void {
+		this.linkedIndex = undefined;
+		if (clearOverlay) {
+			this.overlay.clear();
+		}
+	}
+
+	shouldInvalidateFor(
+		sourcePath: string,
+		frontmatter: Record<string, unknown> | undefined,
+	): boolean {
+		if (
+			frontmatter
+			&& Object.prototype.hasOwnProperty.call(
+				frontmatter,
+				SOURCE_ACTIONS_FRONTMATTER_KEY,
+			)
+		) {
+			return true;
+		}
+		if (this.indexedSourcePaths.has(sourcePath)) {
+			return true;
+		}
+		for (const key of this.overlay.keys()) {
+			const [overlaySource] = JSON.parse(key) as [string, string];
+			if (overlaySource === sourcePath) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private buildLinkedIndex(): Map<string, SourceActionLink> {
+		const links = new Map<string, SourceActionLink>();
+		this.indexedSourcePaths = new Set<string>();
+		const files = [...this.app.vault.getMarkdownFiles()]
+			.sort((left, right) => left.path.localeCompare(right.path));
+		for (const file of files) {
+			const records = this.recordsForFile(file);
+			if (records.length > 0) {
+				this.indexedSourcePaths.add(file.path);
+			}
+			for (const record of records) {
+				if (
+					record.state !== "linked"
+					|| links.has(record.taskId)
+				) {
+					continue;
+				}
+				links.set(record.taskId, {
+					taskId: record.taskId,
+					sourcePath: file.path,
+					sourceTitle: file.basename,
+					actionKey: record.actionKey,
+					deepLink: record.deepLink,
+				});
+			}
+		}
+		return links;
+	}
+
+	private recordsForFile(file: TFile): SourceActionRecord[] {
+		const records = new Map(
+			readSourceActionRecords(
+				this.app.metadataCache.getFileCache(file)?.frontmatter,
+				file.path,
+			).map((record) => [record.actionKey, record]),
+		);
+		for (const [key, overlay] of this.overlay) {
+			const [sourceKey, actionKey] = JSON.parse(key) as [string, string];
+			if (sourceKey !== file.path) {
+				continue;
+			}
+			if (overlay === DELETED) {
+				records.delete(actionKey);
+			} else {
+				records.set(actionKey, overlay);
+			}
+		}
+		return [...records.values()];
+	}
+
+	private requireMarkdownFile(path: string): TFile {
+		const file = this.app.vault.getAbstractFileByPath(path);
+		if (!file || !("extension" in file) || file.extension !== "md") {
+			throw new Error(`Obsidian source note not found: ${path}`);
+		}
+		return file as TFile;
+	}
+}
+
+export function readSourceActionRecords(
+	frontmatter: Record<string, unknown> | undefined,
+	sourceKey: string,
+): SourceActionRecord[] {
+	const value = frontmatter?.[SOURCE_ACTIONS_FRONTMATTER_KEY];
+	if (value === undefined) {
+		return [];
+	}
+	if (!Array.isArray(value)) {
+		throw new Error(
+			`${SOURCE_ACTIONS_FRONTMATTER_KEY} in ${sourceKey} must be a list`,
+		);
+	}
+	return value.map((entry, index) => fromStoredRecord(entry, sourceKey, index));
+}
+
+function fromStoredRecord(
+	value: unknown,
+	sourceKey: string,
+	index: number,
+): SourceActionRecord {
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| (value as Partial<StoredSourceActionRecord>).version !== 1
+		|| !["pending", "linked"].includes(
+			(value as Partial<StoredSourceActionRecord>).state ?? "",
+		)
+		|| typeof (value as Partial<StoredSourceActionRecord>).actionKey !== "string"
+		|| typeof (value as Partial<StoredSourceActionRecord>).title !== "string"
+		|| typeof (value as Partial<StoredSourceActionRecord>).requestId !== "string"
+		|| typeof (value as Partial<StoredSourceActionRecord>).requestedAt !== "number"
+	) {
+		throw new Error(
+			`Invalid ${SOURCE_ACTIONS_FRONTMATTER_KEY} entry ${index + 1} in ${sourceKey}`,
+		);
+	}
+	const stored = value as StoredSourceActionRecord;
+	const base = {
+		version: 1 as const,
+		sourceKey,
+		actionKey: stored.actionKey,
+		title: stored.title,
+		requestId: stored.requestId,
+		requestedAt: stored.requestedAt,
+	};
+	if (stored.state === "pending") {
+		return { ...base, state: "pending" };
+	}
+	if (
+		typeof stored.taskId !== "string"
+		|| typeof stored.deepLink !== "string"
+		|| typeof stored.linkedAt !== "number"
+	) {
+		throw new Error(
+			`Invalid linked ${SOURCE_ACTIONS_FRONTMATTER_KEY} entry ${index + 1} in ${sourceKey}`,
+		);
+	}
+	return {
+		...base,
+		state: "linked",
+		taskId: stored.taskId,
+		deepLink: stored.deepLink,
+		linkedAt: stored.linkedAt,
+	};
+}
+
+function toStoredRecord(record: SourceActionRecord): StoredSourceActionRecord {
+	const base: StoredSourceActionRecord = {
+		version: 1,
+		state: record.state,
+		actionKey: record.actionKey,
+		title: record.title,
+		requestId: record.requestId,
+		requestedAt: record.requestedAt,
+	};
+	if (record.state === "linked") {
+		base.taskId = record.taskId;
+		base.deepLink = record.deepLink;
+		base.linkedAt = record.linkedAt;
+	}
+	return base;
+}
+
+function serializedKey(key: SourceActionKey): string {
+	return JSON.stringify([key.sourceKey, key.actionKey]);
+}
+
+export function isLinkedSourceAction(
+	record: SourceActionRecord,
+): record is LinkedSourceActionRecord {
+	return record.state === "linked";
+}

--- a/src/marvin/taskLine.ts
+++ b/src/marvin/taskLine.ts
@@ -1,0 +1,39 @@
+const AM_TASK = /^\s*[-*+]\s\[([ xX])\].*?\[⚓\]\(https:\/\/app\.amazingmarvin\.com\/#t=([^)\s]+)/;
+
+interface MarvinTaskLine {
+	taskId: string;
+	done: boolean;
+}
+
+export function marvinTaskIdFromCompletedLine(line: string): string | undefined {
+	const task = parseMarvinTaskLine(line);
+	return task?.done ? task.taskId : undefined;
+}
+
+export function isNewlyCompletedMarvinTask(
+	before: string,
+	after: string,
+): string | undefined {
+	const previous = parseMarvinTaskLine(before);
+	const next = parseMarvinTaskLine(after);
+	return (
+		previous
+		&& next
+		&& previous.taskId === next.taskId
+		&& !previous.done
+		&& next.done
+	)
+		? next.taskId
+		: undefined;
+}
+
+function parseMarvinTaskLine(line: string): MarvinTaskLine | undefined {
+	const match = line.match(AM_TASK);
+	if (!match?.[1] || !match[2]) {
+		return undefined;
+	}
+	return {
+		taskId: match[2],
+		done: match[1].toLowerCase() === "x",
+	};
+}

--- a/src/marvin/taskWatcher.test.ts
+++ b/src/marvin/taskWatcher.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	isNewlyCompletedMarvinTask,
+	marvinTaskIdFromCompletedLine,
+} from "./taskLine";
+
+describe("Amazing Marvin completion line matching", () => {
+	it("recognizes both legacy and contextual task rendering", () => {
+		expect(marvinTaskIdFromCompletedLine(
+			"- [x] [⚓](https://app.amazingmarvin.com/#t=legacy) Legacy task",
+		)).toBe("legacy");
+		expect(marvinTaskIdFromCompletedLine(
+			"- [X] [[Source note|Contextual action]] [⚓](https://app.amazingmarvin.com/#t=contextual) Due Date:: [[2026-07-23]]",
+		)).toBe("contextual");
+	});
+
+	it("ignores unchecked tasks and Marvin projects", () => {
+		expect(marvinTaskIdFromCompletedLine(
+			"- [ ] Task [⚓](https://app.amazingmarvin.com/#t=open)",
+		)).toBeUndefined();
+		expect(marvinTaskIdFromCompletedLine(
+			"- [x] Project [⚓](https://app.amazingmarvin.com/#p=project)",
+		)).toBeUndefined();
+	});
+
+	it("only emits a completion for the same task changing from unchecked to checked", () => {
+		const open = "- [ ] Action [⚓](https://app.amazingmarvin.com/#t=task-1)";
+		const done = "- [x] Action [⚓](https://app.amazingmarvin.com/#t=task-1)";
+
+		expect(isNewlyCompletedMarvinTask(open, done)).toBe("task-1");
+		expect(isNewlyCompletedMarvinTask(done, done)).toBeUndefined();
+		expect(isNewlyCompletedMarvinTask("", done)).toBeUndefined();
+		expect(isNewlyCompletedMarvinTask(
+			"- [ ] Other [⚓](https://app.amazingmarvin.com/#t=task-2)",
+			done,
+		)).toBeUndefined();
+	});
+});

--- a/src/marvin/todayProjection.test.ts
+++ b/src/marvin/todayProjection.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	TODAY_REGION_END,
+	TodayProjectionError,
+	hasTodayRegion,
+	marvinIdsInMarkdown,
+	refreshTodayRegion,
+	type TodayProjectionItem,
+} from "./todayProjection";
+
+const morningTask: TodayProjectionItem = {
+	id: "morning",
+	title: "Existing morning task",
+	done: false,
+	deepLink: "https://app.amazingmarvin.com/#t=morning",
+};
+const manualLateTask: TodayProjectionItem = {
+	id: "manual-late",
+	title: "Manual Marvin task",
+	done: false,
+	deepLink: "https://app.amazingmarvin.com/#t=manual-late",
+};
+const contextualLateTask: TodayProjectionItem = {
+	id: "contextual-late",
+	title: "Decide whether to pursue Titan AI",
+	done: false,
+	deepLink: "https://app.amazingmarvin.com/#t=contextual-late",
+	sourcePath: "Opportunities/Titan AI.md",
+	sourceTitle: "Titan AI — Principal FDE",
+};
+
+describe("refreshTodayRegion", () => {
+	it("adopts an existing morning checklist and puts new tasks below it", () => {
+		const original = [
+			"# 2026-07-23",
+			"",
+			"## Today's tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=morning) Existing morning task",
+			"",
+			"Journal prose that must remain.",
+			"",
+		].join("\n");
+
+		const result = refreshTodayRegion(original, {
+			date: "2026-07-23",
+			items: [morningTask, manualLateTask, contextualLateTask],
+		});
+
+		expect(result.morningIds).toEqual(["morning"]);
+		expect(result.lateIds).toEqual(["manual-late", "contextual-late"]);
+		expect(result.content).toContain("- [ ] Existing morning task [⚓]");
+		expect(result.content).toContain(
+			"### Added since morning\n- [ ] Manual Marvin task [⚓]",
+		);
+		expect(result.content).toContain(
+			"[[Opportunities/Titan AI.md|Titan AI — Principal FDE]] [⚓]",
+		);
+		expect(result.content).toContain("Journal prose that must remain.");
+	});
+
+	it("is idempotent, deduplicates due/scheduled overlap, and reflects completion", () => {
+		const initial = refreshTodayRegion("", {
+			date: "2026-07-23",
+			items: [morningTask],
+		});
+		const completed = { ...morningTask, done: true };
+		const refreshed = refreshTodayRegion(initial.content, {
+			date: "2026-07-23",
+			items: [completed, completed],
+		});
+		const repeated = refreshTodayRegion(refreshed.content, {
+			date: "2026-07-23",
+			items: [completed, completed],
+		});
+
+		expect(marvinIdsInMarkdown(refreshed.content)).toEqual(["morning"]);
+		expect(refreshed.content).toContain("- [x] Existing morning task");
+		expect(repeated.changed).toBe(false);
+		expect(repeated.content).toBe(refreshed.content);
+	});
+
+	it("keeps the initial boundary while late tasks arrive and disappear", () => {
+		const morning = refreshTodayRegion("", {
+			date: "2026-07-23",
+			items: [morningTask],
+		});
+		const afternoon = refreshTodayRegion(morning.content, {
+			date: "2026-07-23",
+			items: [morningTask, manualLateTask],
+		});
+		const evening = refreshTodayRegion(afternoon.content, {
+			date: "2026-07-23",
+			items: [manualLateTask],
+		});
+
+		expect(afternoon.lateIds).toEqual(["manual-late"]);
+		expect(evening.morningIds).toEqual([]);
+		expect(evening.lateIds).toEqual(["manual-late"]);
+		expect(evening.content).not.toContain("Existing morning task");
+	});
+
+	it("preserves CRLF and content outside an existing marker", () => {
+		const original = [
+			"before",
+			`<!-- obsidian-am:today ${JSON.stringify({
+				version: 1,
+				date: "2026-07-23",
+				morningIds: ["morning"],
+			})} -->`,
+			"old generated content",
+			TODAY_REGION_END,
+			"after",
+			"",
+		].join("\r\n");
+
+		const result = refreshTodayRegion(original, {
+			date: "2026-07-23",
+			items: [morningTask],
+		});
+
+		expect(result.content.startsWith("before\r\n")).toBe(true);
+		expect(result.content.endsWith("\r\nafter\r\n")).toBe(true);
+		expect(result.content).not.toContain("old generated content");
+		expect(hasTodayRegion(result.content, "2026-07-23")).toBe(true);
+	});
+
+	it("does not replace the note when managed metadata is malformed", () => {
+		const original = [
+			"before",
+			"<!-- obsidian-am:today not-json -->",
+			"generated",
+			TODAY_REGION_END,
+			"after",
+		].join("\n");
+
+		expect(() => refreshTodayRegion(original, {
+			date: "2026-07-23",
+			items: [],
+		})).toThrow(TodayProjectionError);
+	});
+
+	it("refuses to nest a second date inside an existing managed region", () => {
+		const existing = refreshTodayRegion("", {
+			date: "2026-07-22",
+			items: [morningTask],
+		});
+
+		expect(() => refreshTodayRegion(existing.content, {
+			date: "2026-07-23",
+			items: [morningTask],
+		})).toThrow("another date");
+	});
+
+	it("keeps untrusted task text on one line inside the managed boundary", () => {
+		const result = refreshTodayRegion("", {
+			date: "2026-07-23",
+			items: [{
+				...morningTask,
+				title: `Task title\n${TODAY_REGION_END}\n## Injected`,
+				details: "Due\nDate",
+			}],
+		});
+
+		expect(
+			result.content.split("\n").filter((line) => line === TODAY_REGION_END),
+		).toHaveLength(1);
+		expect(result.content).toContain(
+			"Task title &lt;!-- /obsidian-am:today --&gt; ## Injected",
+		);
+		expect(result.content).toContain("Due Date");
+	});
+
+	it("records a successful empty result rather than treating it as failure", () => {
+		const result = refreshTodayRegion("User prose", {
+			date: "2026-07-23",
+			items: [],
+		});
+
+		expect(result.content).toContain("## Today's tasks");
+		expect(result.content).toContain("No Amazing Marvin tasks for this date.");
+		expect(result.morningIds).toEqual([]);
+		expect(result.lateIds).toEqual([]);
+	});
+});

--- a/src/marvin/todayProjection.ts
+++ b/src/marvin/todayProjection.ts
@@ -1,0 +1,297 @@
+export const TODAY_TASKS_HEADING = "## Today's tasks";
+export const TODAY_REGION_END = "<!-- /obsidian-am:today -->";
+
+const TODAY_REGION_PREFIX = "<!-- obsidian-am:today ";
+const MARVIN_ITEM_LINK = /https:\/\/app\.amazingmarvin\.com\/#(?:t|p)=([^)\s]+)/;
+
+export interface TodayProjectionItem {
+	id: string;
+	title: string;
+	done: boolean;
+	deepLink: string;
+	details?: string;
+	sourcePath?: string;
+	sourceTitle?: string;
+}
+
+export interface TodayRegionMetadata {
+	version: 1;
+	date: string;
+	morningIds: string[];
+}
+
+export interface RefreshTodayRegionOptions {
+	date: string;
+	items: TodayProjectionItem[];
+	heading?: string;
+}
+
+export interface RefreshTodayRegionResult {
+	content: string;
+	changed: boolean;
+	createdRegion: boolean;
+	morningIds: string[];
+	lateIds: string[];
+}
+
+export class TodayProjectionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "TodayProjectionError";
+	}
+}
+
+export function refreshTodayRegion(
+	original: string,
+	options: RefreshTodayRegionOptions,
+): RefreshTodayRegionResult {
+	const heading = options.heading ?? TODAY_TASKS_HEADING;
+	const newline = original.includes("\r\n") ? "\r\n" : "\n";
+	const hadTrailingNewline = original.endsWith("\n");
+	const lines = original === ""
+		? []
+		: original.replace(/\r\n/g, "\n").split("\n");
+	if (hadTrailingNewline) {
+		lines.pop();
+	}
+
+	const existingRegion = findManagedRegion(lines, options.date);
+	if (
+		!existingRegion
+		&& lines.some((line) => parseStartMarker(line) !== undefined)
+	) {
+		throw new TodayProjectionError(
+			`This note already contains a managed Amazing Marvin region for another date`,
+		);
+	}
+	const uniqueItems = dedupeItems(options.items);
+	let morningIds: string[];
+	let replaceFrom: number;
+	let replaceTo: number;
+	let createdRegion = false;
+
+	if (existingRegion) {
+		morningIds = existingRegion.metadata.morningIds;
+		replaceFrom = existingRegion.start;
+		replaceTo = existingRegion.end + 1;
+	} else {
+		const adoption = findLegacyMarvinItems(lines, heading);
+		morningIds = adoption.ids.length > 0
+			? adoption.ids
+			: uniqueItems.map((item) => item.id);
+		replaceFrom = adoption.start;
+		replaceTo = adoption.end;
+		createdRegion = true;
+	}
+
+	const currentIds = new Set(uniqueItems.map((item) => item.id));
+	morningIds = dedupeStrings(morningIds).filter((id) => currentIds.has(id));
+	const morningIdSet = new Set(morningIds);
+	const morning = uniqueItems.filter((item) => morningIdSet.has(item.id));
+	const late = uniqueItems.filter((item) => !morningIdSet.has(item.id));
+	const block = renderManagedBlock(options.date, morningIds, morning, late);
+
+	lines.splice(replaceFrom, replaceTo - replaceFrom, ...block);
+	const next = lines.join("\n") + (hadTrailingNewline ? "\n" : "");
+	const content = newline === "\n" ? next : next.replace(/\n/g, "\r\n");
+
+	return {
+		content,
+		changed: content !== original,
+		createdRegion,
+		morningIds,
+		lateIds: late.map((item) => item.id),
+	};
+}
+
+export function hasTodayRegion(content: string, date?: string): boolean {
+	const lines = content.replace(/\r\n/g, "\n").split("\n");
+	return date === undefined
+		? lines.some((line) => parseStartMarker(line) !== undefined)
+		: findManagedRegion(lines, date) !== undefined;
+}
+
+export function marvinIdsInMarkdown(content: string): string[] {
+	const ids: string[] = [];
+	for (const line of content.replace(/\r\n/g, "\n").split("\n")) {
+		const match = line.match(MARVIN_ITEM_LINK);
+		if (match?.[1]) {
+			ids.push(match[1]);
+		}
+	}
+	return dedupeStrings(ids);
+}
+
+function findManagedRegion(
+	lines: string[],
+	date: string,
+): { start: number; end: number; metadata: TodayRegionMetadata } | undefined {
+	for (let index = 0; index < lines.length; index += 1) {
+		const metadata = parseStartMarker(lines[index] ?? "");
+		if (!metadata || metadata.date !== date) {
+			continue;
+		}
+		const end = lines.indexOf(TODAY_REGION_END, index + 1);
+		if (end === -1) {
+			throw new TodayProjectionError(
+				`The managed Amazing Marvin region for ${date} has no closing marker`,
+			);
+		}
+		return { start: index, end, metadata };
+	}
+	return undefined;
+}
+
+function parseStartMarker(line: string): TodayRegionMetadata | undefined {
+	if (!line.startsWith(TODAY_REGION_PREFIX) || !line.endsWith(" -->")) {
+		return undefined;
+	}
+	const serialized = line.slice(TODAY_REGION_PREFIX.length, -4);
+	let value: unknown;
+	try {
+		value = JSON.parse(serialized);
+	} catch {
+		throw new TodayProjectionError("A managed Amazing Marvin region has invalid metadata");
+	}
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| (value as Partial<TodayRegionMetadata>).version !== 1
+		|| typeof (value as Partial<TodayRegionMetadata>).date !== "string"
+		|| !Array.isArray((value as Partial<TodayRegionMetadata>).morningIds)
+		|| !(value as TodayRegionMetadata).morningIds.every((id) => typeof id === "string")
+	) {
+		throw new TodayProjectionError("A managed Amazing Marvin region has unsupported metadata");
+	}
+	return value as TodayRegionMetadata;
+}
+
+function findLegacyMarvinItems(
+	lines: string[],
+	heading: string,
+): { start: number; end: number; ids: string[] } {
+	const headingIndex = lines.findIndex((line) => line.trim() === heading);
+	if (headingIndex === -1) {
+		const prefix: string[] = [];
+		if (lines.length > 0 && lines[lines.length - 1] !== "") {
+			prefix.push("");
+		}
+		prefix.push(heading);
+		lines.push(...prefix);
+		return {
+			start: lines.length,
+			end: lines.length,
+			ids: [],
+		};
+	}
+
+	let first = -1;
+	let last = -1;
+	const ids: string[] = [];
+	for (let index = headingIndex + 1; index < lines.length; index += 1) {
+		const line = lines[index] ?? "";
+		if (/^#{1,2}\s/.test(line)) {
+			break;
+		}
+		const match = line.match(MARVIN_ITEM_LINK);
+		if (match?.[1]) {
+			first = first === -1 ? index : first;
+			last = index;
+			ids.push(match[1]);
+			continue;
+		}
+		if (
+			first !== -1
+			&& line.trim() !== ""
+			&& !/^\s+[-*+]\s+\[[ xX]\]\s+/.test(line)
+		) {
+			break;
+		}
+		if (first !== -1 && /^\s*$/.test(line)) {
+			break;
+		}
+		if (first !== -1) {
+			last = index;
+		}
+	}
+
+	if (first !== -1) {
+		return {
+			start: first,
+			end: last + 1,
+			ids: dedupeStrings(ids),
+		};
+	}
+	return {
+		start: headingIndex + 1,
+		end: headingIndex + 1,
+		ids: [],
+	};
+}
+
+function renderManagedBlock(
+	date: string,
+	morningIds: string[],
+	morning: TodayProjectionItem[],
+	late: TodayProjectionItem[],
+): string[] {
+	const metadata: TodayRegionMetadata = {
+		version: 1,
+		date,
+		morningIds,
+	};
+	const lines = [
+		`${TODAY_REGION_PREFIX}${JSON.stringify(metadata)} -->`,
+		...morning.map(renderItem),
+	];
+	if (late.length > 0) {
+		if (morning.length > 0) {
+			lines.push("");
+		}
+		lines.push("### Added since morning", ...late.map(renderItem));
+	}
+	if (morning.length === 0 && late.length === 0) {
+		lines.push("<!-- No Amazing Marvin tasks for this date. -->");
+	}
+	lines.push(TODAY_REGION_END);
+	return lines;
+}
+
+function renderItem(item: TodayProjectionItem): string {
+	const status = item.done ? "x" : " ";
+	const title = item.sourcePath
+		? `[[${escapeWikiTarget(item.sourcePath)}|${escapeWikiAlias(item.sourceTitle ?? item.title)}]]`
+		: inlineText(item.title);
+	const details = inlineText(item.details ?? "");
+	return `- [${status}] ${title} [⚓](${item.deepLink})${details ? ` ${details}` : ""}`;
+}
+
+function escapeWikiTarget(value: string): string {
+	return inlineText(value).replace(/\|/g, "\\|").replace(/\]/g, "\\]");
+}
+
+function escapeWikiAlias(value: string): string {
+	return inlineText(value).replace(/\|/g, "\\|").replace(/\]/g, "\\]");
+}
+
+function inlineText(value: string): string {
+	return value
+		.replace(/[\r\n]+/g, " ")
+		.replace(/<!--/g, "&lt;!--")
+		.replace(/-->/g, "--&gt;")
+		.trim();
+}
+
+function dedupeItems(items: TodayProjectionItem[]): TodayProjectionItem[] {
+	const byId = new Map<string, TodayProjectionItem>();
+	for (const item of items) {
+		if (!byId.has(item.id)) {
+			byId.set(item.id, item);
+		}
+	}
+	return [...byId.values()];
+}
+
+function dedupeStrings(values: string[]): string[] {
+	return [...new Set(values)];
+}

--- a/src/marvin/todayWorkflow.test.ts
+++ b/src/marvin/todayWorkflow.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runTodayProjection } from "./todayWorkflow";
+
+describe("runTodayProjection", () => {
+	it("never mutates the note when the Marvin read fails", async () => {
+		const process = vi.fn(async (_update: (content: string) => string) => undefined);
+
+		await expect(runTodayProjection({
+			date: "2026-07-23",
+			read: async () => {
+				throw new Error("Marvin unavailable");
+			},
+			project: () => [],
+			process,
+		})).rejects.toThrow("Marvin unavailable");
+		expect(process).not.toHaveBeenCalled();
+	});
+
+	it("projects a successful empty result and retains read metadata", async () => {
+		let content = "Journal prose";
+		const result = await runTodayProjection({
+			date: "2026-07-23",
+			read: async () => ({
+				data: [],
+				freshness: "fresh" as const,
+				origin: "public" as const,
+				fetchedAt: 100,
+				ageMs: 0,
+				warnings: [],
+			}),
+			project: () => [],
+			process: async (update) => {
+				content = update(content);
+			},
+		});
+
+		expect(content).toContain("No Amazing Marvin tasks for this date.");
+		expect(content).toContain("Journal prose");
+		expect(result.read.freshness).toBe("fresh");
+	});
+});

--- a/src/marvin/todayWorkflow.ts
+++ b/src/marvin/todayWorkflow.ts
@@ -1,0 +1,42 @@
+import type { MarvinReadResult } from "@open-horizon/marvin-client";
+
+import {
+	refreshTodayRegion,
+	type TodayProjectionItem,
+} from "./todayProjection";
+
+export interface RunTodayProjectionOptions<T> {
+	date: string;
+	read: () => Promise<MarvinReadResult<T[]>>;
+	project: (items: T[]) => TodayProjectionItem[];
+	process: (update: (content: string) => string) => Promise<void>;
+}
+
+export interface TodayProjectionWorkflowResult<T> {
+	read: MarvinReadResult<T[]>;
+	projection: ReturnType<typeof refreshTodayRegion>;
+}
+
+/**
+ * Keeps the network read before the atomic note mutation. A failed read never
+ * invokes the note processor and therefore cannot be mistaken for an empty
+ * successful projection.
+ */
+export async function runTodayProjection<T>(
+	options: RunTodayProjectionOptions<T>,
+): Promise<TodayProjectionWorkflowResult<T>> {
+	const read = await options.read();
+	const items = options.project(read.data);
+	let projection: ReturnType<typeof refreshTodayRegion> | undefined;
+	await options.process((content) => {
+		projection = refreshTodayRegion(content, {
+			date: options.date,
+			items,
+		});
+		return projection.content;
+	});
+	if (!projection) {
+		throw new Error("The Today note processor did not run");
+	}
+	return { read, projection };
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { App, Platform, PluginSettingTab, Setting } from "obsidian";
 import AmazingMarvinPlugin from "./main";
+import type { ObsidianLinkFormat } from "./marvin/obsidianLinks";
 
 export interface AmazingMarvinPluginSettings {
 	linkBackToObsidianText: string;
@@ -12,6 +13,9 @@ export interface AmazingMarvinPluginSettings {
 	showStartDate: boolean;
 	showScheduledDate: boolean;
 	todayTasksToShow: 'due' | 'scheduled' | 'both';
+	autoRefreshTodayTasks: boolean;
+	todayRefreshIntervalMinutes: number;
+	obsidianLinkFormat: ObsidianLinkFormat;
 }
 
 export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
@@ -24,7 +28,10 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	showStartDate: true,
 	showScheduledDate: true,
 	todayTasksToShow: 'both',
-	attemptToMarkTasksAsDone: false
+	autoRefreshTodayTasks: true,
+	todayRefreshIntervalMinutes: 5,
+	obsidianLinkFormat: "advanced-uri",
+	attemptToMarkTasksAsDone: false,
 };
 
 export class AmazingMarvinSettingsTab extends PluginSettingTab {
@@ -96,6 +103,32 @@ private a(href: string, text: string) {
 			);
 
 		new Setting(containerEl)
+			.setName("Refresh managed Today tasks automatically")
+			.setDesc("Refresh an initialized managed region while Obsidian is open and when the window regains focus.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.autoRefreshTodayTasks)
+				.onChange(async (value) => {
+					this.plugin.settings.autoRefreshTodayTasks = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Refresh interval")
+			.setDesc("Minutes between background refreshes. Existing notes are only changed after their managed region has been initialized.")
+			.addText(text => text
+				.setPlaceholder("5")
+				.setValue(this.plugin.settings.todayRefreshIntervalMinutes.toString())
+				.onChange(async (value) => {
+					const parsed = Number.parseInt(value, 10);
+					if (Number.isFinite(parsed) && parsed > 0) {
+						this.plugin.settings.todayRefreshIntervalMinutes = parsed;
+						await this.plugin.saveSettings();
+					}
+				})
+			);
+
+		new Setting(containerEl)
 			.setHeading().setName("Task creation");
 
 
@@ -115,6 +148,19 @@ private a(href: string, text: string) {
 						this.plugin.settings.linkBackToObsidianText = value.trim();
 						await this.plugin.saveSettings();
 					})
+			);
+
+		new Setting(containerEl)
+			.setName("Obsidian link format")
+			.setDesc("Advanced URI restores links for workflows using the Advanced URI community plugin; Standard works with Obsidian itself.")
+			.addDropdown(dropdown => dropdown
+				.addOption("advanced-uri", "Advanced URI")
+				.addOption("standard", "Standard Obsidian URI")
+				.setValue(this.plugin.settings.obsidianLinkFormat)
+				.onChange(async (value: ObsidianLinkFormat) => {
+					this.plugin.settings.obsidianLinkFormat = value;
+					await this.plugin.saveSettings();
+				})
 			);
 
 


### PR DESCRIPTION
Closes #51
Closes #16
Closes #49

## Summary

- replace cursor-only Today imports with an atomic, bounded managed region that adopts the morning Marvin checklist and renders later task IDs below it
- add a shared source/action state machine that persists pending intent before the Marvin write, preventing ambiguous retries from silently creating duplicates
- persist linked task IDs/deep links in source-note frontmatter and render reciprocal source + Marvin links in the daily note
- expose object-returning Templater/in-Obsidian automation methods, including deterministic ensure/resolve/refresh operations
- restore Advanced URI as a selectable link format (and default) while retaining standard Obsidian URIs
- refresh initialized Today regions on startup, focus, interval, and plugin-originated task changes, with explicit stale/error behavior

This is stacked on #56 (issue/52) because it builds on the shared Marvin client and MCP foundation.

## Verification

- npm ci
- npm test (50 tests)
- npm run typecheck
- npm run build
- git diff --check

Coverage includes ambiguous and rejected creation outcomes, stable source/action reruns, concurrent ensures, source frontmatter persistence, manual and contextual late tasks, due/scheduled duplicates, completion rendering, failed-fetch note preservation, malformed/cross-date markers, CRLF preservation, untrusted multiline task text, and completion-watcher loop prevention.

## Human verification

A live Obsidian + Marvin pass should verify:

- limited-token addTask response shape and mark-done behavior against a real account
- cursor/selection preservation when processFrontMatter records a source association in the open editor
- initialization and automatic refresh in the configured Daily Notes format
- Advanced URI opening the intended source note when that community plugin is installed
- focus/interval refresh notices under real network and local-API failures

No live-account behavior is claimed by the automated fixture.