### PR TITLE
Preserve imported Marvin notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,18 @@ The Obsidian Amazing Marvin Plugin currently supports unidirectional synchroniza
 
 ### Sync Behavior
 
-Each import updates only the Amazing Marvin-managed region in an existing note. Your frontmatter properties and prose before or after that region are preserved. The first import of an older note adopts its recognizable generated category/project or Inbox task section; future imports use explicit markers.
+Each import updates only the Amazing Marvin-managed region in an existing note.
+Custom frontmatter properties and prose before or after that region are
+preserved. The first import of an older note adopts its recognizable generated
+category/project or Inbox task section; future imports use explicit markers.
+The importer also repairs the known malformed legacy list syntax before
+writing native YAML arrays such as `labelIds`.
 
-The managed folder defaults to `AmazingMarvin` and can be changed in plugin settings. Existing imported categories, projects, and Inbox notes are moved by their Marvin ID when possible; empty folders from an earlier location are left in place.
+The managed folder defaults to `AmazingMarvin` and can be changed in plugin
+settings. Existing imported categories, projects, and Inbox notes are moved by
+their Marvin ID when possible; empty folders from an earlier location are left
+in place. Notes for Marvin items no longer returned by the API are also left in
+place rather than deleted automatically.
 
 ### Running a Sync
 
@@ -135,6 +144,7 @@ Now, when you check off a task with an Amazing Marvin Link in an Obsidian note, 
 
 - **Managed regions**: Changes inside an Amazing Marvin-managed category, project, or Inbox region are refreshed on the next import. Keep lasting notes outside the marked region.
 - **Conflicting moves**: If a destination file already exists or multiple notes claim the same Marvin item, import stops rather than overwriting either note.
+- **Recoverable stale notes**: Notes for removed or hidden Marvin items are not automatically deleted. Review and remove them manually.
 
 By following these guidelines, you can ensure your Amazing Marvin data is accurately reflected in Obsidian while being mindful of the plugin's current limitations.
 

--- a/README.md
+++ b/README.md
@@ -26,20 +26,19 @@ The Obsidian Amazing Marvin Plugin currently supports unidirectional synchroniza
 
 ### Sync Behavior
 
-Each sync operation performs a fresh import:
+Each import updates only the Amazing Marvin-managed region in an existing note. Your frontmatter properties and prose before or after that region are preserved. The first import of an older note adopts its recognizable generated category/project or Inbox task section; future imports use explicit markers.
 
-- The plugin first removes the existing category/project notes and folders that were previously synchronized.
-- It then creates new notes and folders based on the latest data from Amazing Marvin.
+The managed folder defaults to `AmazingMarvin` and can be changed in plugin settings. Existing imported categories, projects, and Inbox notes are moved by their Marvin ID when possible; empty folders from an earlier location are left in place.
 
 ### Running a Sync
 
 To initiate a sync:
 
 1. Open Obsidian's Command Palette with `Ctrl/Cmd + P`.
-2. Search for and select the command `Sync Amazing Marvin categories and projects`.
+2. Search for and select `Import categories and tasks`.
 3. The plugin will then proceed to update your Obsidian vault with the current structure and content from Amazing Marvin.
 
-Once synced, your Obsidian vault will contain a new `AmazingMarvin` folder. Inside, you'll find the structured notes corresponding to your categories and projects from Amazing Marvin.
+Once imported, your Obsidian vault will contain the configured managed folder. Inside, you'll find the structured notes corresponding to your categories and projects from Amazing Marvin.
 
 ### Creating a Marvin Task
 
@@ -134,8 +133,8 @@ Now, when you check off a task with an Amazing Marvin Link in an Obsidian note, 
 
 ### Important Considerations
 
-- **Data Loss**: Be cautious when editing Amazing Marvin-generated notes in Obsidian, as these changes will be overwritten by the next sync.
-- **Backup Recommended**: It's advisable to back up your Obsidian vault before running the sync, especially if you've made local modifications to the synchronized notes.
+- **Managed regions**: Changes inside an Amazing Marvin-managed category, project, or Inbox region are refreshed on the next import. Keep lasting notes outside the marked region.
+- **Conflicting moves**: If a destination file already exists or multiple notes claim the same Marvin item, import stops rather than overwriting either note.
 
 By following these guidelines, you can ensure your Amazing Marvin data is accurately reflected in Obsidian while being mindful of the plugin's current limitations.
 

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -7,7 +7,7 @@ allow a later split without making separate repositories a prerequisite.
 | Layer | Owns | Does not own |
 | --- | --- | --- |
 | `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links; source/action state machine | Obsidian vault/UI behavior; MCP schemas; source-note storage |
-| `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection | HTTP/API semantics, cache policy, or fallback decisions |
+| `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection; non-destructive category/project projection | HTTP/API semantics, cache policy, or fallback decisions |
 | Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
 | `packages/marvin-mcp` | Stdio lifecycle, four tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
 
@@ -43,6 +43,13 @@ The managed Today region stores its initial morning IDs in a versioned HTML
 comment. Refresh atomically replaces only that region against the latest note
 contents; new IDs render below the morning list, and content outside the
 markers is preserved.
+
+Category, project, and Inbox imports use a separate managed marker. Stable
+Marvin IDs locate notes when their generated path or configured root changes.
+Frontmatter updates are property-scoped, and the importer repairs the older
+malformed list representation before asking Obsidian to parse and rewrite it.
+Removed Marvin items are not inferred to be safe deletions, so their notes
+remain recoverable.
 
 Source/action identity is not a task title and does not belong in MCP prompt
 text. The Obsidian projection remains responsible for note mutation; the

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import {
 	Notice,
 	Plugin,
 	TFile,
+	TFolder,
 	moment,
 	normalizePath,
 	requestUrl,
@@ -50,6 +51,17 @@ import {
 	buildSourceActionTaskNote,
 } from "./marvin/obsidianLinks";
 import {
+	managedImportItemId,
+	marvinFrontmatter,
+	refreshCategoryRegion,
+	repairLegacyMarvinFrontmatter,
+	updateMarvinFrontmatter,
+} from "./marvin/categoryProjection";
+import {
+	categoryNotePath,
+	normalizeManagedFolder,
+} from "./marvin/categoryPaths";
+import {
 	ObsidianSourceActionStore,
 } from "./marvin/obsidianSourceActions";
 import { createObsidianTransport } from "./marvin/obsidianTransport";
@@ -81,11 +93,6 @@ const animateNotice = (notice: Notice) => {
 	notice.setMessage(message);
 	setTimeout(() => animateNotice(notice), 500);
 };
-
-const CONSTANTS = {
-	baseDir: "AmazingMarvin",
-};
-
 
 export default class AmazingMarvinPlugin extends Plugin {
 
@@ -555,15 +562,10 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 	async sync() {
 		const categories = await this.getCategories();
-		const baseDirPath = normalizePath(CONSTANTS.baseDir);
-		const baseDir = this.app.vault.getAbstractFileByPath(baseDirPath);
-		if (baseDir) {
-			await this.app.vault.delete(baseDir, true);
-		}
-
 		this.categories = categories;
-		await this.processCategories();
-		await this.processInbox();
+		const existingFiles = await this.findManagedImportFiles();
+		await this.processCategories(existingFiles);
+		await this.processInbox(existingFiles);
 	}
 
 	async getCategories(): Promise<Category[]> {
@@ -602,71 +604,85 @@ export default class AmazingMarvinPlugin extends Plugin {
 		} as Task | Category;
 	}
 
-	async processInbox() {
+	async processInbox(existingFiles: Map<string, TFile>) {
 		const inboxItems = await this.getChildren("unassigned");
 		const content = this.formatItems(inboxItems);
-
-		// Define the path for the Inbox file
-		const inboxFilePath = normalizePath("AmazingMarvin/Inbox.md");
-
-		await this.createOrUpdate(inboxFilePath, content);
+		const inboxFilePath = normalizePath(`${this.getSyncBaseDir()}/Inbox.md`);
+		await this.moveManagedFile(existingFiles.get("unassigned"), inboxFilePath);
+		await this.createOrUpdateManaged(
+			inboxFilePath,
+			"unassigned",
+			content,
+			"inbox",
+			{
+				_id: "unassigned",
+				type: "inbox",
+				title: "Inbox",
+			},
+		);
 	}
 
-	async createOrUpdate(path: string, content: string) {
+	async createOrUpdateManaged(
+		path: string,
+		itemId: string,
+		rendered: string,
+		legacyKind: "category" | "inbox",
+		item?: object,
+	) {
 		const normalizedPath = normalizePath(path);
-		let dirPath = normalizedPath.replace(/^(.+)\/[^\/]*?$/, '$1');
-
-		// Ensure the directory exists
-		if (!await this.app.vault.adapter.exists(dirPath)) {
-			await this.app.vault.createFolder(dirPath);
+		await this.ensureParentFolder(normalizedPath);
+		let file = this.app.vault.getAbstractFileByPath(normalizedPath);
+		if (file && !(file instanceof TFile)) {
+			throw new Error(`Cannot write Amazing Marvin note over folder: ${normalizedPath}`);
+		}
+		if (!file) {
+			const frontmatter = item
+				? `---\n${stringifyYaml(marvinFrontmatter({ ...item })).trimEnd()}\n---\n`
+				: "";
+			const projected = refreshCategoryRegion(frontmatter, {
+				itemId,
+				rendered,
+				legacyKind,
+			});
+			await this.app.vault.create(normalizedPath, projected.content);
+			return;
 		}
 
-		// Overwrite existing file
-		if (await this.app.vault.adapter.exists(normalizedPath)) {
-			const existingContent = await this.app.vault.adapter.remove(normalizedPath);
+		await this.app.vault.process(file, repairLegacyMarvinFrontmatter);
+		if (item) {
+			await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+				updateMarvinFrontmatter(frontmatter, { ...item });
+			});
 		}
-
-		await this.app.vault.create(normalizedPath, content);
+		await this.app.vault.process(file, (content) => (
+			refreshCategoryRegion(content, {
+				itemId,
+				rendered,
+				legacyKind,
+			}).content
+		));
 	}
 
 	getPathForCategory(category: Category) {
-		let pathSegments: string[] = [];
-
-		// Function to recursively build the path segments array
-		const buildPathSegments = (cat: Category) => {
-			const safeTitle = cat.title.replace(/[^a-zA-Z0-9 -]/g, "");
-			pathSegments.unshift(safeTitle); // Add at the beginning
-
-			if (cat.parentId && cat.parentId !== "root") {
-				const parentCat = this.categories.find(c => c._id === cat.parentId);
-				if (parentCat) {
-					buildPathSegments(parentCat);
-				}
-			}
-		};
-
-		buildPathSegments(category);
-
-		// Determine the filename and if the category should be a folder based on its children
-		const hasChildCategoriesOrProjects = this.categories.some(cat =>
-			cat.parentId === category._id && (cat.type === 'project' || cat.type === 'category')
-		);
-
-		// If the category has children that are categories or projects, make it a folder
-		const isFolder = hasChildCategoriesOrProjects;
-
-		// Construct the path
-		let path = `${CONSTANTS.baseDir}/${pathSegments.join('/')}`;
-		path = isFolder ? `${path}/${category.title}.md` : `${path}.md`;
-
-		return normalizePath(path);
+		return normalizePath(categoryNotePath(
+			category,
+			this.categories,
+			this.getSyncBaseDir(),
+		));
 	}
 
-	async processCategories() {
+	async processCategories(existingFiles: Map<string, TFile>) {
 		for (const category of this.categories) {
 			const path = this.getPathForCategory(category);
-			const content = this.createContentForCategory(category);
-			await this.createOrUpdate(path, await content);
+			await this.moveManagedFile(existingFiles.get(category._id), path);
+			const content = await this.createContentForCategory(category);
+			await this.createOrUpdateManaged(
+				path,
+				category._id,
+				content,
+				"category",
+				category,
+			);
 		}
 	}
 
@@ -681,7 +697,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 			if (isCategoryOrProject) {
 				// Handle category or project formatting
 				const path = this.getPathForCategory(item);
-				categoryContent += `${indentation}- [[${path}|${item.title}]] [⚓](${item.deepLink})\n`;
+				categoryContent += `${indentation}- [[${this.wikiTarget(path)}|${this.wikiAlias(item.title)}]] [⚓](${item.deepLink})\n`;
 			} else {
 				if (!isSubtask) { // Only add deep links to top-level tasks
 					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] [⚓](${item.deepLink}) ${this.formatTaskDetails(item as Task, indentation)}`;
@@ -689,7 +705,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] `;
 				}
 
-				taskContent += `${item.title}\n`;
+				taskContent += `${this.inlineMarkdown(item.title)}\n`;
 
 				// Recursively format sub-tasks if any
 				if ('subtasks' in item && item.subtasks && Object.keys(item.subtasks).length > 0) {
@@ -734,31 +750,110 @@ export default class AmazingMarvinPlugin extends Plugin {
 	}
 
 	async createContentForCategory(category: Category): Promise<string> {
-		let yamlFrontmatter = "---\n";
-		// Iterate over category properties and add non-null values to YAML frontmatter
-		for (const [key, value] of Object.entries(category)) {
-			if (value !== null && value !== undefined) {
-				yamlFrontmatter += `${key}: ${stringifyYaml(value)}\n`;
-			}
-		}
-
-		// Close YAML frontmatter block
-		yamlFrontmatter += "---\n";
-
-		let content = `# [⚓](${category.deepLink}) ${category.title}\n\n`;
+		let content = `# [⚓](${category.deepLink}) ${this.inlineMarkdown(category.title)}\n\n`;
 
 		// Link to parent category, if it exists
 		if (category.parentId && category.parentId !== "root") {
 			const parentCategory = this.categories.find(cat => cat._id === category.parentId);
 			if (parentCategory) {
-				content += `Back to [[${parentCategory.title}]]\n\n`;
+				content += `Back to [[${this.wikiTarget(this.getPathForCategory(parentCategory))}|${this.wikiAlias(parentCategory.title)}]]\n\n`;
 			}
 		}
 		// Fetch and format tasks
 		const children = await this.getChildren(category._id);
 		content += this.formatItems(children);
 
-		return yamlFrontmatter + content;
+		return content;
+	}
+
+	private getSyncBaseDir(): string {
+		return normalizePath(normalizeManagedFolder(this.settings.syncFolder));
+	}
+
+	private async ensureParentFolder(path: string): Promise<void> {
+		const separator = path.lastIndexOf("/");
+		if (separator === -1) {
+			return;
+		}
+		const segments = path.slice(0, separator).split("/");
+		let current = "";
+		for (const segment of segments) {
+			current = current ? `${current}/${segment}` : segment;
+			const existing = this.app.vault.getAbstractFileByPath(current);
+			if (existing && !(existing instanceof TFolder)) {
+				throw new Error(
+					`Cannot create Amazing Marvin folder ${current}; a vault file already exists there`,
+				);
+			}
+			if (!existing) {
+				await this.app.vault.createFolder(current);
+			}
+		}
+	}
+
+	private async moveManagedFile(
+		existing: TFile | undefined,
+		destination: string,
+	): Promise<void> {
+		if (!existing || existing.path === destination) {
+			return;
+		}
+		await this.ensureParentFolder(destination);
+		const collision = this.app.vault.getAbstractFileByPath(destination);
+		if (collision && collision !== existing) {
+			throw new Error(
+				`Cannot move ${existing.path} to ${destination}; another vault item already exists there`,
+			);
+		}
+		await this.app.fileManager.renameFile(existing, destination);
+	}
+
+	private inlineMarkdown(value: string): string {
+		return value
+			.replace(/[\r\n]+/g, " ")
+			.replace(/<!--/g, "&lt;!--")
+			.replace(/-->/g, "--&gt;")
+			.trim();
+	}
+
+	private wikiAlias(value: string): string {
+		return this.inlineMarkdown(value)
+			.replace(/\|/g, "\\|")
+			.replace(/\]/g, "\\]");
+	}
+
+	private wikiTarget(value: string): string {
+		return value.replace(/\|/g, "\\|").replace(/\]/g, "\\]");
+	}
+
+	private async findManagedImportFiles(): Promise<Map<string, TFile>> {
+		const byId = new Map<string, TFile>();
+		const rootsToInspect = new Set([
+			`${this.getSyncBaseDir()}/`,
+			"AmazingMarvin/",
+		]);
+		for (const file of this.app.vault.getMarkdownFiles()) {
+			const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+			let itemId = managedImportItemId("", frontmatter, file.path);
+			if (
+				!itemId
+				&& [...rootsToInspect].some((root) => file.path.startsWith(root))
+			) {
+				const content = await this.app.vault.cachedRead(file);
+				itemId = managedImportItemId(content, frontmatter, file.path);
+			}
+			if (!itemId) {
+				continue;
+			}
+			const duplicate = byId.get(itemId);
+			if (duplicate && duplicate.path !== file.path) {
+				throw new Error(
+					`Multiple Obsidian notes claim Amazing Marvin item ${itemId}: ${duplicate.path} and ${file.path}`,
+				);
+			}
+			byId.set(itemId, file);
+		}
+		return byId;
 	}
 
 	private getMarvinRouter(): MarvinRouter {

--- a/src/main.ts
+++ b/src/main.ts
@@ -834,13 +834,25 @@ export default class AmazingMarvinPlugin extends Plugin {
 		]);
 		for (const file of this.app.vault.getMarkdownFiles()) {
 			const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
-			let itemId = managedImportItemId("", frontmatter, file.path);
+			const isLegacyLocation = [...rootsToInspect].some(
+				(root) => file.path.startsWith(root),
+			);
+			let itemId = managedImportItemId(
+				"",
+				frontmatter,
+				file.path,
+			);
 			if (
 				!itemId
-				&& [...rootsToInspect].some((root) => file.path.startsWith(root))
+				&& isLegacyLocation
 			) {
 				const content = await this.app.vault.cachedRead(file);
-				itemId = managedImportItemId(content, frontmatter, file.path);
+				itemId = managedImportItemId(
+					content,
+					frontmatter,
+					file.path,
+					true,
+				);
 			}
 			if (!itemId) {
 				continue;

--- a/src/marvin/categoryPaths.test.ts
+++ b/src/marvin/categoryPaths.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	categoryNotePath,
+	normalizeManagedFolder,
+	safePathSegment,
+} from "./categoryPaths";
+
+const categories = [
+	{ _id: "work", title: "Work", type: "category", parentId: "root" },
+	{ _id: "project", title: "Agent / Work", type: "project", parentId: "work" },
+	{ _id: "child", title: "Research", type: "project", parentId: "project" },
+];
+
+describe("category/project paths", () => {
+	it("uses the configured folder and full Marvin hierarchy", () => {
+		expect(categoryNotePath(categories[1]!, categories, "Areas/Tasks")).toBe(
+			"Areas/Tasks/Work/Agent Work/Agent Work.md",
+		);
+		expect(categoryNotePath(categories[2]!, categories, "Areas/Tasks")).toBe(
+			"Areas/Tasks/Work/Agent Work/Research.md",
+		);
+	});
+
+	it("rejects unsafe roots and hierarchy cycles instead of writing elsewhere", () => {
+		expect(() => normalizeManagedFolder("../")).toThrow("Invalid");
+		expect(() => normalizeManagedFolder(".obsidian/Plugins")).toThrow("Invalid");
+		expect(() => categoryNotePath(
+			{ _id: "a", title: "A", type: "category", parentId: "b" },
+			[
+				{ _id: "a", title: "A", type: "category", parentId: "b" },
+				{ _id: "b", title: "B", type: "category", parentId: "a" },
+			],
+			"AmazingMarvin",
+		)).toThrow("cycle");
+	});
+
+	it("uses an ID when a title cannot form a safe path", () => {
+		expect(safePathSegment("///", "fallback-id")).toBe("fallback-id");
+	});
+});

--- a/src/marvin/categoryPaths.ts
+++ b/src/marvin/categoryPaths.ts
@@ -1,0 +1,70 @@
+export interface CategoryPathItem {
+	_id: string;
+	title: string;
+	type?: string;
+	parentId?: string;
+}
+
+export function normalizeManagedFolder(configured: string): string {
+	const value = configured.trim() || "AmazingMarvin";
+	const segments = value
+		.replace(/\\/g, "/")
+		.replace(/^\/+|\/+$/g, "")
+		.split("/");
+	if (
+		segments.length === 0
+		|| segments.some((segment) => !segment || segment === "." || segment === "..")
+		|| segments[0]?.toLowerCase() === ".obsidian"
+	) {
+		throw new Error(`Invalid Amazing Marvin managed folder: ${configured}`);
+	}
+	return segments.join("/");
+}
+
+export function categoryNotePath(
+	category: CategoryPathItem,
+	categories: CategoryPathItem[],
+	baseFolder: string,
+): string {
+	const byId = new Map(categories.map((item) => [item._id, item]));
+	const pathSegments: string[] = [];
+	const visited = new Set<string>();
+	let current: CategoryPathItem | undefined = category;
+	while (current) {
+		if (visited.has(current._id)) {
+			throw new Error(
+				`Amazing Marvin category hierarchy contains a cycle at ${current._id}`,
+			);
+		}
+		visited.add(current._id);
+		pathSegments.unshift(safePathSegment(current.title, current._id));
+		if (!current.parentId || current.parentId === "root") {
+			break;
+		}
+		const childId = current._id;
+		const parentId = current.parentId;
+		current = byId.get(parentId);
+		if (!current) {
+			throw new Error(
+				`Amazing Marvin parent ${parentId} for ${childId} was not returned by the API`,
+			);
+		}
+	}
+
+	const hasContainerChildren = categories.some((item) => (
+		item.parentId === category._id
+		&& (item.type === "project" || item.type === "category")
+	));
+	const path = `${normalizeManagedFolder(baseFolder)}/${pathSegments.join("/")}`;
+	return hasContainerChildren
+		? `${path}/${safePathSegment(category.title, category._id)}.md`
+		: `${path}.md`;
+}
+
+export function safePathSegment(title: string, fallback: string): string {
+	return title
+		.replace(/[\\/:*?"<>|#^\[\]]/g, "")
+		.replace(/\s+/g, " ")
+		.trim()
+		|| fallback;
+}

--- a/src/marvin/categoryProjection.test.ts
+++ b/src/marvin/categoryProjection.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	CATEGORY_REGION_END,
+	MANAGED_PROPERTIES_KEY,
+	CategoryProjectionError,
+	managedImportItemId,
+	marvinFrontmatter,
+	refreshCategoryRegion,
+	repairLegacyMarvinFrontmatter,
+	updateMarvinFrontmatter,
+} from "./categoryProjection";
+
+const rendered = [
+	"# [⚓](https://app.amazingmarvin.com/#p=project-1) Project One",
+	"",
+	"## Tasks",
+	"- [ ] [⚓](https://app.amazingmarvin.com/#t=task-2) Current task",
+].join("\n");
+
+describe("category/project managed regions", () => {
+	it("adopts legacy generated content without overwriting surrounding prose", () => {
+		const original = [
+			"---",
+			"_id: project-1",
+			"type: project",
+			"custom: keep me",
+			"---",
+			"Context before.",
+			"",
+			"# [⚓](https://app.amazingmarvin.com/#p=project-1) Old title",
+			"",
+			"Back to [[Parent]]",
+			"",
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=old) Old task",
+			"  - [ ] Old subtask",
+			"",
+			"Why and how notes remain here.",
+		].join("\n");
+
+		const result = refreshCategoryRegion(original, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+
+		expect(result.content).toContain("Context before.");
+		expect(result.content).toContain("Why and how notes remain here.");
+		expect(result.content).not.toContain("Old task");
+		expect(result.content).toContain("Current task");
+		expect(result.content).toContain(CATEGORY_REGION_END);
+	});
+
+	it("does not adopt a user checklist separated from generated tasks", () => {
+		const original = [
+			"# [⚓](https://app.amazingmarvin.com/#p=project-1) Project",
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=old) Old task",
+			"",
+			"  - [ ] User-authored nested checklist",
+		].join("\n");
+		const result = refreshCategoryRegion(original, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+
+		expect(result.content).toContain("User-authored nested checklist");
+	});
+
+	it("is idempotent and preserves CRLF outside an existing region", () => {
+		const initial = refreshCategoryRegion("Before\r\nAfter\r\n", {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+		const repeated = refreshCategoryRegion(initial.content, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+
+		expect(repeated.changed).toBe(false);
+		expect(repeated.content).toBe(initial.content);
+		expect(repeated.content).toContain("\r\n");
+		expect(repeated.content).toContain("Before\r\nAfter\r\n");
+	});
+
+	it("adopts a legacy Inbox task section", () => {
+		const result = refreshCategoryRegion([
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=old) Old inbox task",
+			"",
+			"Inbox notes.",
+		].join("\n"), {
+			itemId: "unassigned",
+			rendered: [
+				"## Tasks",
+				"- [ ] [⚓](https://app.amazingmarvin.com/#t=new) New inbox task",
+			].join("\n"),
+			legacyKind: "inbox",
+		});
+
+		expect(result.content).toContain("New inbox task");
+		expect(result.content).toContain("Inbox notes.");
+		expect(result.content).not.toContain("Old inbox task");
+	});
+
+	it("does not mistake a user-owned task section for legacy import content", () => {
+		const result = refreshCategoryRegion([
+			"## Tasks",
+			"- [ ] Write the project brief",
+			"",
+			"A helpful Marvin link follows in prose: https://app.amazingmarvin.com/#t=reference",
+		].join("\n"), {
+			itemId: "unassigned",
+			rendered: "## Tasks\n- [ ] [⚓](https://app.amazingmarvin.com/#t=new) New inbox task",
+			legacyKind: "inbox",
+		});
+
+		expect(result.content).toContain("Write the project brief");
+		expect(result.content).toContain("#t=reference");
+		expect(result.content).toContain("New inbox task");
+	});
+
+	it("refuses malformed or cross-item managed regions", () => {
+		expect(() => refreshCategoryRegion(
+			"<!-- obsidian-am:category no-json -->\nGenerated",
+			{ itemId: "project-1", rendered, legacyKind: "category" },
+		)).toThrow(CategoryProjectionError);
+
+		const other = refreshCategoryRegion("", {
+			itemId: "other",
+			rendered: "Other",
+			legacyKind: "category",
+		});
+		expect(() => refreshCategoryRegion(other.content, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		})).toThrow("another item");
+	});
+});
+
+describe("Marvin frontmatter migration", () => {
+	it("repairs the legacy invalid list syntax without touching the note body", () => {
+		const original = [
+			"---",
+			"_id: project-1",
+			"",
+			"labelIds: - label-a",
+			"- label-b",
+			"",
+			"title: Project",
+			"---",
+			"Body remains byte-for-byte.",
+		].join("\n");
+
+		const repaired = repairLegacyMarvinFrontmatter(original);
+
+		expect(repaired).toContain("labelIds:\n  - label-a\n  - label-b");
+		expect(repaired).toContain("Body remains byte-for-byte.");
+		expect(repairLegacyMarvinFrontmatter(repaired)).toBe(repaired);
+	});
+
+	it("updates owned fields as native values while preserving custom properties", () => {
+		const frontmatter: Record<string, unknown> = {
+			_id: "old",
+			dueDate: "yesterday",
+			custom: "keep",
+			removedApiField: true,
+			[MANAGED_PROPERTIES_KEY]: ["_id", "dueDate", "removedApiField"],
+		};
+		updateMarvinFrontmatter(frontmatter, {
+			_id: "project-1",
+			title: "Project",
+			type: "project",
+			labelIds: ["label-a", "label-b"],
+		});
+
+		expect(frontmatter).toMatchObject({
+			_id: "project-1",
+			title: "Project",
+			type: "project",
+			labelIds: ["label-a", "label-b"],
+			custom: "keep",
+		});
+		expect(frontmatter).not.toHaveProperty("dueDate");
+		expect(frontmatter).not.toHaveProperty("removedApiField");
+		expect(frontmatter[MANAGED_PROPERTIES_KEY]).toContain("labelIds");
+		expect(marvinFrontmatter({
+			_id: "project-1",
+			labelIds: ["label-a", "label-b"],
+		})).toMatchObject({
+			_id: "project-1",
+			labelIds: ["label-a", "label-b"],
+		});
+	});
+
+	it("finds managed IDs through cached, marker, malformed-legacy, and Inbox forms", () => {
+		expect(managedImportItemId("", {
+			_id: "cached",
+			deepLink: "https://app.amazingmarvin.com/#p=cached",
+		}, "Elsewhere.md")).toBe("cached");
+
+		const marked = refreshCategoryRegion("", {
+			itemId: "marked",
+			rendered,
+			legacyKind: "category",
+		});
+		expect(managedImportItemId(marked.content, undefined, "Moved.md")).toBe("marked");
+
+		expect(managedImportItemId([
+			"---",
+			"_id: legacy",
+			"labelIds: - broken",
+			"deepLink: https://app.amazingmarvin.com/#p=legacy",
+			"---",
+		].join("\n"), undefined, "Legacy.md")).toBe("legacy");
+
+		expect(managedImportItemId([
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=task) Task",
+		].join("\n"), undefined, "AmazingMarvin/Inbox.md")).toBe("unassigned");
+	});
+});

--- a/src/marvin/categoryProjection.test.ts
+++ b/src/marvin/categoryProjection.test.ts
@@ -198,11 +198,31 @@ describe("Marvin frontmatter migration", () => {
 		});
 	});
 
-	it("finds managed IDs through cached, marker, malformed-legacy, and Inbox forms", () => {
+	it("finds owned IDs without claiming unrelated Marvin-linked notes", () => {
 		expect(managedImportItemId("", {
 			_id: "cached",
 			deepLink: "https://app.amazingmarvin.com/#p=cached",
+			[MANAGED_PROPERTIES_KEY]: ["_id", "deepLink"],
 		}, "Elsewhere.md")).toBe("cached");
+		expect(managedImportItemId("", {
+			_id: "personal",
+			deepLink: "https://app.amazingmarvin.com/#p=personal",
+		}, "Elsewhere.md")).toBeUndefined();
+		expect(managedImportItemId([
+			"---",
+			"_id: personal",
+			"deepLink: https://app.amazingmarvin.com/#p=personal",
+			"---",
+			"Personal notes without an imported heading.",
+		].join("\n"), {
+			_id: "personal",
+			deepLink: "https://app.amazingmarvin.com/#p=personal",
+		}, "AmazingMarvin/Personal.md", true)).toBeUndefined();
+		expect(managedImportItemId("", {
+			_id: "project-1",
+			deepLink: "https://app.amazingmarvin.com/#p=project-10",
+			[MANAGED_PROPERTIES_KEY]: ["_id", "deepLink"],
+		}, "Elsewhere.md")).toBeUndefined();
 
 		const marked = refreshCategoryRegion("", {
 			itemId: "marked",
@@ -217,11 +237,12 @@ describe("Marvin frontmatter migration", () => {
 			"labelIds: - broken",
 			"deepLink: https://app.amazingmarvin.com/#p=legacy",
 			"---",
-		].join("\n"), undefined, "Legacy.md")).toBe("legacy");
+			"# [⚓](https://app.amazingmarvin.com/#p=legacy) Legacy project",
+		].join("\n"), undefined, "Legacy.md", true)).toBe("legacy");
 
 		expect(managedImportItemId([
 			"## Tasks",
 			"- [ ] [⚓](https://app.amazingmarvin.com/#t=task) Task",
-		].join("\n"), undefined, "AmazingMarvin/Inbox.md")).toBe("unassigned");
+		].join("\n"), undefined, "AmazingMarvin/Inbox.md", true)).toBe("unassigned");
 	});
 });

--- a/src/marvin/categoryProjection.ts
+++ b/src/marvin/categoryProjection.ts
@@ -1,0 +1,369 @@
+export const CATEGORY_REGION_END = "<!-- /obsidian-am:category -->";
+export const MANAGED_PROPERTIES_KEY = "amazing-marvin-managed-properties";
+
+const CATEGORY_REGION_PREFIX = "<!-- obsidian-am:category ";
+const MARVIN_LINK = /https:\/\/app\.amazingmarvin\.com\/#(?:t|p)=([^)\s]+)/;
+const OWNED_FRONTMATTER_KEYS = [
+	"_id",
+	"_rev",
+	"createdAt",
+	"updatedAt",
+	"title",
+	"type",
+	"parentId",
+	"day",
+	"firstScheduled",
+	"startDate",
+	"dueDate",
+	"endDate",
+	"done",
+	"doneDate",
+	"doneAt",
+	"completedAt",
+	"note",
+	"labelIds",
+	"timeEstimate",
+	"priority",
+	"rank",
+	"recurring",
+	"isRecurring",
+	"deepLink",
+] as const;
+
+interface CategoryRegionMetadata {
+	version: 1;
+	itemId: string;
+}
+
+export interface RefreshCategoryRegionOptions {
+	itemId: string;
+	rendered: string;
+	legacyKind: "category" | "inbox";
+}
+
+export interface RefreshCategoryRegionResult {
+	content: string;
+	changed: boolean;
+	createdRegion: boolean;
+}
+
+export class CategoryProjectionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CategoryProjectionError";
+	}
+}
+
+export function refreshCategoryRegion(
+	original: string,
+	options: RefreshCategoryRegionOptions,
+): RefreshCategoryRegionResult {
+	const newline = original.includes("\r\n") ? "\r\n" : "\n";
+	const hadTrailingNewline = original.endsWith("\n");
+	const lines = original === ""
+		? []
+		: original.replace(/\r\n/g, "\n").split("\n");
+	if (hadTrailingNewline) {
+		lines.pop();
+	}
+
+	const existing = findManagedRegion(lines, options.itemId);
+	if (!existing && lines.some((line) => parseStartMarker(line) !== undefined)) {
+		throw new CategoryProjectionError(
+			"This note already contains a managed Amazing Marvin region for another item",
+		);
+	}
+	const legacy = existing
+		? undefined
+		: findLegacyRegion(lines, options.itemId, options.legacyKind);
+	const replaceFrom = existing?.start ?? legacy?.start ?? lines.length;
+	const replaceTo = existing
+		? existing.end + 1
+		: legacy?.end ?? lines.length;
+	const block = renderBlock(options.itemId, options.rendered);
+
+	if (!existing && !legacy && lines.length > 0 && lines[lines.length - 1] !== "") {
+		lines.push("");
+	}
+	const insertion = !existing && !legacy ? lines.length : replaceFrom;
+	lines.splice(insertion, replaceTo - replaceFrom, ...block);
+	const next = lines.join("\n") + (hadTrailingNewline ? "\n" : "");
+	const content = newline === "\n" ? next : next.replace(/\n/g, "\r\n");
+	return {
+		content,
+		changed: content !== original,
+		createdRegion: !existing,
+	};
+}
+
+export function updateMarvinFrontmatter(
+	frontmatter: Record<string, unknown>,
+	item: Record<string, unknown>,
+): void {
+	const owned = new Set<string>(OWNED_FRONTMATTER_KEYS);
+	const previous = frontmatter[MANAGED_PROPERTIES_KEY];
+	if (Array.isArray(previous)) {
+		for (const key of previous) {
+			if (typeof key === "string") {
+				owned.add(key);
+			}
+		}
+	}
+	for (const key of owned) {
+		delete frontmatter[key];
+	}
+
+	const next = Object.fromEntries(
+		Object.entries(item).filter(([, value]) => (
+			value !== undefined && value !== null
+		)),
+	);
+	for (const [key, value] of Object.entries(next)) {
+		frontmatter[key] = value;
+	}
+	frontmatter[MANAGED_PROPERTIES_KEY] = Object.keys(next).sort();
+}
+
+export function marvinFrontmatter(
+	item: Record<string, unknown>,
+): Record<string, unknown> {
+	const frontmatter: Record<string, unknown> = {};
+	updateMarvinFrontmatter(frontmatter, item);
+	return frontmatter;
+}
+
+/**
+ * Repairs the invalid list shape emitted by older versions:
+ * `labelIds: - first` followed by top-level `- next`.
+ */
+export function repairLegacyMarvinFrontmatter(content: string): string {
+	const newline = content.includes("\r\n") ? "\r\n" : "\n";
+	const lines = content.replace(/\r\n/g, "\n").split("\n");
+	if (lines[0]?.trim() !== "---") {
+		return content;
+	}
+	let closing = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+	if (closing === -1) {
+		return content;
+	}
+
+	let repairingList = false;
+	let changed = false;
+	for (let index = 1; index < closing; index += 1) {
+		const line = lines[index] ?? "";
+		const brokenStart = line.match(/^([^ \t#][^:]*):\s+-\s+(.+)$/);
+		if (brokenStart?.[1] && brokenStart[2]) {
+			lines.splice(
+				index,
+				1,
+				`${brokenStart[1]}:`,
+				`  - ${brokenStart[2]}`,
+			);
+			closing += 1;
+			index += 1;
+			repairingList = true;
+			changed = true;
+			continue;
+		}
+		if (repairingList && /^-\s+/.test(line)) {
+			lines[index] = `  ${line}`;
+			changed = true;
+			continue;
+		}
+		if (line.trim() && !/^\s/.test(line)) {
+			repairingList = false;
+		}
+	}
+	if (!changed) {
+		return content;
+	}
+	return lines.join(newline);
+}
+
+export function managedImportItemId(
+	content: string,
+	frontmatter: Record<string, unknown> | undefined,
+	path: string,
+): string | undefined {
+	const cachedId = frontmatter?._id;
+	const cachedLink = frontmatter?.deepLink;
+	if (
+		typeof cachedId === "string"
+		&& typeof cachedLink === "string"
+		&& cachedLink.includes(`/#p=${cachedId}`)
+	) {
+		return cachedId;
+	}
+	if (cachedId === "unassigned" && frontmatter?.type === "inbox") {
+		return "unassigned";
+	}
+
+	for (const line of content.replace(/\r\n/g, "\n").split("\n")) {
+		const metadata = parseStartMarker(line);
+		if (metadata) {
+			return metadata.itemId;
+		}
+	}
+
+	const frontmatterLines = frontmatterSlice(content);
+	const id = frontmatterLines.match(/^_id:\s*([^\s#]+)\s*$/m)?.[1];
+	const deepLink = frontmatterLines.match(
+		/^deepLink:\s*https:\/\/app\.amazingmarvin\.com\/#p=([^\s]+)\s*$/m,
+	)?.[1];
+	if (id && deepLink === id) {
+		return id;
+	}
+
+	if (
+		/(^|\/)AmazingMarvin\/Inbox\.md$/.test(path)
+		&& /^## Tasks$/m.test(content)
+		&& MARVIN_LINK.test(content)
+	) {
+		return "unassigned";
+	}
+	return undefined;
+}
+
+function findManagedRegion(
+	lines: string[],
+	itemId: string,
+): { start: number; end: number } | undefined {
+	for (let index = 0; index < lines.length; index += 1) {
+		const metadata = parseStartMarker(lines[index] ?? "");
+		if (!metadata || metadata.itemId !== itemId) {
+			continue;
+		}
+		const end = lines.indexOf(CATEGORY_REGION_END, index + 1);
+		if (end === -1) {
+			throw new CategoryProjectionError(
+				`The managed Amazing Marvin region for ${itemId} has no closing marker`,
+			);
+		}
+		return { start: index, end };
+	}
+	return undefined;
+}
+
+function parseStartMarker(line: string): CategoryRegionMetadata | undefined {
+	if (!line.startsWith(CATEGORY_REGION_PREFIX) || !line.endsWith(" -->")) {
+		return undefined;
+	}
+	let value: unknown;
+	try {
+		value = JSON.parse(line.slice(CATEGORY_REGION_PREFIX.length, -4));
+	} catch {
+		throw new CategoryProjectionError(
+			"A managed Amazing Marvin category region has invalid metadata",
+		);
+	}
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| (value as Partial<CategoryRegionMetadata>).version !== 1
+		|| typeof (value as Partial<CategoryRegionMetadata>).itemId !== "string"
+	) {
+		throw new CategoryProjectionError(
+			"A managed Amazing Marvin category region has unsupported metadata",
+		);
+	}
+	return value as CategoryRegionMetadata;
+}
+
+function findLegacyRegion(
+	lines: string[],
+	itemId: string,
+	kind: RefreshCategoryRegionOptions["legacyKind"],
+): { start: number; end: number } | undefined {
+	const bodyStart = frontmatterEnd(lines);
+	let start = -1;
+	if (kind === "category") {
+		start = lines.findIndex((line, index) => (
+			index >= bodyStart
+			&& line.startsWith("# ")
+			&& line.includes(`https://app.amazingmarvin.com/#p=${itemId}`)
+		));
+	} else {
+		start = lines.findIndex((line, index) => (
+			index >= bodyStart
+			&& line.trim() === "## Tasks"
+			&& firstNonBlankLine(lines, index + 1) !== undefined
+			&& MARVIN_LINK.test(firstNonBlankLine(lines, index + 1) ?? "")
+		));
+	}
+	if (start === -1) {
+		return undefined;
+	}
+
+	let end = start + 1;
+	let pendingBlank = -1;
+	let allowSubtask = false;
+	for (let index = start + 1; index < lines.length; index += 1) {
+		const line = lines[index] ?? "";
+		if (!line.trim()) {
+			pendingBlank = pendingBlank === -1 ? index : pendingBlank;
+			continue;
+		}
+		const isSubtask = /^\s+[-*+]\s+\[[ xX]\]\s+/.test(line);
+		if (isSubtask && allowSubtask && pendingBlank === -1) {
+			end = index + 1;
+			continue;
+		}
+		if (!isLegacyGeneratedLine(line, false)) {
+			break;
+		}
+		end = index + 1;
+		pendingBlank = -1;
+		allowSubtask = /https:\/\/app\.amazingmarvin\.com\/#t=/.test(line);
+	}
+	if (pendingBlank !== -1) {
+		end = Math.min(end, pendingBlank);
+	}
+	return { start, end };
+}
+
+function firstNonBlankLine(lines: string[], start: number): string | undefined {
+	for (let index = start; index < lines.length; index += 1) {
+		const line = lines[index] ?? "";
+		if (line.trim()) {
+			return line;
+		}
+	}
+	return undefined;
+}
+
+function isLegacyGeneratedLine(line: string, includeSubtasks = true): boolean {
+	return line.startsWith("Back to [[")
+		|| line === "## Categories and Projects"
+		|| line === "## Tasks"
+		|| MARVIN_LINK.test(line)
+		|| (includeSubtasks && /^\s+[-*+]\s+\[[ xX]\]\s+/.test(line));
+}
+
+function frontmatterEnd(lines: string[]): number {
+	if (lines[0]?.trim() !== "---") {
+		return 0;
+	}
+	const closing = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+	return closing === -1 ? 0 : closing + 1;
+}
+
+function frontmatterSlice(content: string): string {
+	const normalized = content.replace(/\r\n/g, "\n");
+	if (!normalized.startsWith("---\n")) {
+		return "";
+	}
+	const end = normalized.indexOf("\n---", 4);
+	return end === -1 ? "" : normalized.slice(4, end);
+}
+
+function renderBlock(itemId: string, rendered: string): string[] {
+	const metadata: CategoryRegionMetadata = {
+		version: 1,
+		itemId,
+	};
+	return [
+		`${CATEGORY_REGION_PREFIX}${JSON.stringify(metadata)} -->`,
+		...rendered.trim().split(/\r?\n/),
+		CATEGORY_REGION_END,
+	];
+}

--- a/src/marvin/categoryProjection.ts
+++ b/src/marvin/categoryProjection.ts
@@ -184,17 +184,26 @@ export function managedImportItemId(
 	content: string,
 	frontmatter: Record<string, unknown> | undefined,
 	path: string,
+	allowLegacyIdentity = false,
 ): string | undefined {
 	const cachedId = frontmatter?._id;
 	const cachedLink = frontmatter?.deepLink;
+	const hasManagedProperties = Array.isArray(
+		frontmatter?.[MANAGED_PROPERTIES_KEY],
+	);
 	if (
 		typeof cachedId === "string"
 		&& typeof cachedLink === "string"
-		&& cachedLink.includes(`/#p=${cachedId}`)
+		&& cachedLink === `https://app.amazingmarvin.com/#p=${cachedId}`
+		&& hasManagedProperties
 	) {
 		return cachedId;
 	}
-	if (cachedId === "unassigned" && frontmatter?.type === "inbox") {
+	if (
+		cachedId === "unassigned"
+		&& frontmatter?.type === "inbox"
+		&& hasManagedProperties
+	) {
 		return "unassigned";
 	}
 
@@ -205,21 +214,43 @@ export function managedImportItemId(
 		}
 	}
 
-	const frontmatterLines = frontmatterSlice(content);
-	const id = frontmatterLines.match(/^_id:\s*([^\s#]+)\s*$/m)?.[1];
-	const deepLink = frontmatterLines.match(
-		/^deepLink:\s*https:\/\/app\.amazingmarvin\.com\/#p=([^\s]+)\s*$/m,
-	)?.[1];
-	if (id && deepLink === id) {
-		return id;
-	}
+	if (allowLegacyIdentity) {
+		const frontmatterLines = frontmatterSlice(content);
+		const rawId = frontmatterLines.match(/^_id:\s*([^\s#]+)\s*$/m)?.[1];
+		const rawDeepLinkId = frontmatterLines.match(
+			/^deepLink:\s*https:\/\/app\.amazingmarvin\.com\/#p=([^\s]+)\s*$/m,
+		)?.[1];
+		const legacyId = (
+			typeof cachedId === "string"
+			&& typeof cachedLink === "string"
+			&& cachedLink === `https://app.amazingmarvin.com/#p=${cachedId}`
+		)
+			? cachedId
+			: rawId && rawDeepLinkId === rawId
+				? rawId
+				: undefined;
+		if (
+			legacyId
+			&& content
+				.replace(/\r\n/g, "\n")
+				.split("\n")
+				.some((line) => (
+					line.startsWith("# ")
+					&& line.includes(
+						`[⚓](https://app.amazingmarvin.com/#p=${legacyId})`,
+					)
+				))
+		) {
+			return legacyId;
+		}
 
-	if (
-		/(^|\/)AmazingMarvin\/Inbox\.md$/.test(path)
-		&& /^## Tasks$/m.test(content)
-		&& MARVIN_LINK.test(content)
-	) {
-		return "unassigned";
+		if (
+			/(^|\/)AmazingMarvin\/Inbox\.md$/.test(path)
+			&& /^## Tasks$/m.test(content)
+			&& MARVIN_LINK.test(content)
+		) {
+			return "unassigned";
+		}
 	}
 	return undefined;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export interface AmazingMarvinPluginSettings {
 	autoRefreshTodayTasks: boolean;
 	todayRefreshIntervalMinutes: number;
 	obsidianLinkFormat: ObsidianLinkFormat;
+	syncFolder: string;
 }
 
 export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
@@ -31,6 +32,7 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	autoRefreshTodayTasks: true,
 	todayRefreshIntervalMinutes: 5,
 	obsidianLinkFormat: "advanced-uri",
+	syncFolder: "AmazingMarvin",
 	attemptToMarkTasksAsDone: false,
 };
 
@@ -81,6 +83,21 @@ private a(href: string, text: string) {
 				.setValue(this.plugin.settings.attemptToMarkTasksAsDone)
 				.onChange(async (value) => {
 					this.plugin.settings.attemptToMarkTasksAsDone = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setHeading().setName("Category and project import");
+
+		new Setting(containerEl)
+			.setName("Managed folder")
+			.setDesc("Vault-relative folder for imported categories, projects, and Inbox. Existing category and project notes move when their Marvin ID can be identified; old empty folders are left in place.")
+			.addText(text => text
+				.setPlaceholder("AmazingMarvin")
+				.setValue(this.plugin.settings.syncFolder)
+				.onChange(async (value) => {
+					this.plugin.settings.syncFolder = value.trim() || "AmazingMarvin";
 					await this.plugin.saveSettings();
 				})
 			);


### PR DESCRIPTION
Closes #23
Closes #43
Closes #44
Closes #47

## What changed
- replace destructive imports with item-scoped managed regions
- preserve user prose and non-plugin frontmatter while repairing legacy list frontmatter
- add a configurable managed folder and collision-safe note moves
- retain legacy category/project/Inbox notes by Marvin identity before moving them

## Verification
- `npm test` (62 tests)
- `npm run typecheck`
- `npm run build`

## Needs human verification
- run import against a real vault containing edited legacy imported notes, including a custom managed-folder move, and confirm Obsidian frontmatter processing preserves the intended custom metadata.