### PR TITLE
Default tasks to their Marvin note context

### DIFF
--- a/src/addTaskModal.ts
+++ b/src/addTaskModal.ts
@@ -69,13 +69,18 @@ export class AddTaskModal extends Modal {
   onSubmit: (result: { catId: string, task: string }) => void;
   categories: Category[];
 
-  constructor(app: App, categories: Category[], onSubmit: (result: { catId: string; task: string; }) => void) {
+  constructor(
+    app: App,
+    categories: Category[],
+    onSubmit: (result: { catId: string; task: string; }) => void,
+    defaultCategoryId = inboxCategory._id,
+  ) {
     super(app);
     this.onSubmit = onSubmit;
     this.categories = categories.sort((a, b) => {
       return this.getFullPathToCategoryTitle(a, categories).localeCompare(this.getFullPathToCategoryTitle(b, categories));
     });
-    this.result = { catId: inboxCategory._id, task: '' };
+    this.result = { catId: defaultCategoryId, task: '' };
   }
 
   onOpen() {
@@ -88,8 +93,11 @@ export class AddTaskModal extends Modal {
       .setName("Category")
       .addText(text => {
         categoryInput = text.inputEl;
-        text.setValue(inboxCategory.title);
-        this.result.catId = inboxCategory._id;
+        const selectedCategory = this.categories.find(
+          category => category._id === this.result.catId,
+        ) ?? inboxCategory;
+        text.setValue(selectedCategory.title);
+        this.result.catId = selectedCategory._id;
         text.onChange(value => {
           const suggester = new CategorySuggesterModal(this.app, this.categories, (item: Category) => {
             categoryInput.value = item.title;

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,7 @@ import {
 	categoryNotePath,
 	normalizeManagedFolder,
 } from "./marvin/categoryPaths";
+import { marvinParentIdFromFrontmatter } from "./marvin/noteContext";
 import {
 	ObsidianSourceActionStore,
 } from "./marvin/obsidianSourceActions";
@@ -180,10 +181,11 @@ export default class AmazingMarvinPlugin extends Plugin {
 			editorCallback: async (editor, view) => {
         // Fetch categories first and make sure they are loaded
         try {
+			const defaultParentId = this.marvinParentIdForFile(view.file);
           // If a region of text is selected, at least 3 characters long, use that to add a new task and skip the modal
           if (editor.somethingSelected() && editor.getSelection().length > 2) {
             try {
-              const task = await this.addMarvinTask('', editor.getSelection(), view.file?.path, this.app.vault.getName());
+              const task = await this.addMarvinTask(defaultParentId ?? '', editor.getSelection(), view.file?.path, this.app.vault.getName());
               editor.replaceSelection(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`);
             } catch (error) {
               console.error('Could not create Marvin task:', error);
@@ -199,7 +201,7 @@ export default class AmazingMarvinPlugin extends Plugin {
             } catch (error) {
               console.error('Could not create Marvin task:', error);
             }
-          }).open();
+          }, defaultParentId).open();
         } catch (error) {
           console.error('Error fetching categories:', error);
           new Notice('Failed to load categories from Amazing Marvin.');
@@ -313,6 +315,15 @@ export default class AmazingMarvinPlugin extends Plugin {
 			);
 			throw error;
 		}
+	}
+
+	private marvinParentIdForFile(file: TFile | null): string | undefined {
+		if (!file) {
+			return undefined;
+		}
+		return marvinParentIdFromFrontmatter(
+			this.app.metadataCache.getFileCache(file)?.frontmatter,
+		);
 	}
 
 	onunload() { }

--- a/src/marvin/categoryProjection.test.ts
+++ b/src/marvin/categoryProjection.test.ts
@@ -52,6 +52,25 @@ describe("category/project managed regions", () => {
 		expect(result.content).toContain(CATEGORY_REGION_END);
 	});
 
+	it("does not adopt a legacy region for a similarly prefixed project ID", () => {
+		const original = [
+			"# [⚓](https://app.amazingmarvin.com/#p=project-10) Another project",
+			"",
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=old) Keep this task",
+		].join("\n");
+
+		const result = refreshCategoryRegion(original, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+
+		expect(result.content).toContain("Another project");
+		expect(result.content).toContain("Keep this task");
+		expect(result.content).toContain("Current task");
+	});
+
 	it("does not adopt a user checklist separated from generated tasks", () => {
 		const original = [
 			"# [⚓](https://app.amazingmarvin.com/#p=project-1) Project",

--- a/src/marvin/categoryProjection.ts
+++ b/src/marvin/categoryProjection.ts
@@ -311,7 +311,7 @@ function findLegacyRegion(
 		start = lines.findIndex((line, index) => (
 			index >= bodyStart
 			&& line.startsWith("# ")
-			&& line.includes(`https://app.amazingmarvin.com/#p=${itemId}`)
+			&& hasProjectAnchor(line, itemId)
 		));
 	} else {
 		start = lines.findIndex((line, index) => (
@@ -350,6 +350,12 @@ function findLegacyRegion(
 		end = Math.min(end, pendingBlank);
 	}
 	return { start, end };
+}
+
+function hasProjectAnchor(line: string, itemId: string): boolean {
+	return line.includes(
+		`[⚓](https://app.amazingmarvin.com/#p=${itemId})`,
+	);
 }
 
 function firstNonBlankLine(lines: string[], start: number): string | undefined {

--- a/src/marvin/noteContext.test.ts
+++ b/src/marvin/noteContext.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { marvinParentIdFromFrontmatter } from "./noteContext";
+
+describe("Marvin note context", () => {
+	it("uses an imported category or project as the task parent", () => {
+		expect(marvinParentIdFromFrontmatter({
+			_id: "project-1",
+			type: "project",
+			deepLink: "https://app.amazingmarvin.com/#p=project-1",
+		})).toBe("project-1");
+	});
+
+	it("does not treat unrelated frontmatter or tasks as a parent", () => {
+		expect(marvinParentIdFromFrontmatter({
+			_id: "task-1",
+			type: "task",
+			deepLink: "https://app.amazingmarvin.com/#t=task-1",
+		})).toBeUndefined();
+		expect(marvinParentIdFromFrontmatter({ _id: "project-1" })).toBeUndefined();
+		expect(marvinParentIdFromFrontmatter({
+			_id: "project-1",
+			type: "project",
+			deepLink: "https://app.amazingmarvin.com/#p=project-10",
+		})).toBeUndefined();
+	});
+});

--- a/src/marvin/noteContext.ts
+++ b/src/marvin/noteContext.ts
@@ -1,0 +1,16 @@
+export function marvinParentIdFromFrontmatter(
+	frontmatter: Record<string, unknown> | undefined,
+): string | undefined {
+	const itemId = frontmatter?._id;
+	const deepLink = frontmatter?.deepLink;
+	const type = frontmatter?.type;
+	if (
+		type !== "category" && type !== "project"
+		|| typeof itemId !== "string"
+		|| typeof deepLink !== "string"
+		|| deepLink !== `https://app.amazingmarvin.com/#p=${itemId}`
+	) {
+		return undefined;
+	}
+	return itemId;
+}


### PR DESCRIPTION
Closes #25

## What changed
- infer the parent category/project from a verified imported-note frontmatter identity
- preselect that parent in the task modal
- use it for selected-text task creation too
- fall back to Inbox when the context is absent or no longer in the category list

## Verification
- `npm test` (64 tests)
- `npm run typecheck`
- `npm run build`

## Needs human verification
- invoke Create task from an imported category/project note in Obsidian and confirm both the modal and selected-text shortcut create tasks under that item.