### PR TITLE
Add configurable task and label projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,28 @@ Additional object-returning methods are available for automation:
 - `getToday(date)`
 - `getDue(date)`
 - `getTodayAndDue(date)`
+- `getLabels()`
 - `createTask(task)`
 - `ensureTaskForSource(input)`
 - `refreshTodayTasks(input)`
+
+### Task formatting and labels
+
+The default projection remains the existing Dataview format. In settings,
+tasks can instead use Obsidian Tasks' Dataview fields or emoji date format.
+Tasks-compatible presets always put the readable title first; the current
+Dataview preset has a separate title-first option.
+
+Dataview date links use a configurable Moment format. For example,
+`YYYY-[W]WW` renders `2026-07-23` as `[[2026-W30|2026-07-23]]`, which lets a
+daily date alias resolve to a weekly note. An optional task tag supports an
+Obsidian Tasks global filter.
+
+Marvin labels can be projected as namespaced Obsidian tags such as
+`#marvin/Knowledge-work`. Label IDs are resolved through the limited `/labels`
+API and cached for an hour; unknown IDs are not exposed as opaque tags. If
+labels are enabled and cannot be read or recovered from the stale cache, the
+managed projection is left unchanged rather than silently removing tags.
 
 ### Auto-Mark as Done Feature
 
@@ -225,12 +244,15 @@ The initial tool surface is deliberately small:
 
 - `marvin_today`
 - `marvin_due`
+- `marvin_labels`
 - `marvin_create_task`
 - `marvin_mark_done`
 
 Read results identify whether data is fresh, cached, or stale. Errors retain
 the attempted local/public origins and throttling details. The server uses the
 limited API token only; it does not use Marvin's full-access CouchDB API.
+`marvin_create_task` accepts the stable label IDs returned by
+`marvin_labels`.
 
 The MCP owns Marvin-only operations and does not edit an Obsidian vault.
 Cross-system operations that must atomically persist a source/action

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -9,7 +9,7 @@ allow a later split without making separate repositories a prerequisite.
 | `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links; source/action state machine | Obsidian vault/UI behavior; MCP schemas; source-note storage |
 | `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection; non-destructive category/project projection | HTTP/API semantics, cache policy, or fallback decisions |
 | Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
-| `packages/marvin-mcp` | Stdio lifecycle, four tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
+| `packages/marvin-mcp` | Stdio lifecycle, five tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
 
 Both runtime adapters construct `MarvinApiClient` instances and one
 `MarvinRouter`. Writes use the public API only. Safe reads may use the desktop
@@ -25,6 +25,11 @@ The router caches successful reads in memory. Empty arrays are successful data;
 errors are never cached as empty results. Stale-on-error responses are marked
 `freshness: "stale"` and carry the current failure. Task creation and
 completion invalidate today, due, and children entries.
+
+The stable label list uses the same local-first route and a longer bounded
+cache. The plugin resolves task `labelIds` to namespaced Obsidian tags, while
+the MCP exposes the same IDs to `marvin_create_task`; neither consumer
+reimplements label API behavior.
 
 ## Source/action and Today projection
 

--- a/packages/marvin-client/src/client.test.ts
+++ b/packages/marvin-client/src/client.test.ts
@@ -56,6 +56,20 @@ describe("MarvinApiClient", () => {
 		});
 	});
 
+	it("reads labels through the limited API without retries", async () => {
+		const transport = new QueueTransport(
+			jsonResponse(200, [{ _id: "label-1", title: "Knowledge work" }]),
+		);
+
+		await expect(client(transport).getLabels()).resolves.toEqual([
+			{ _id: "label-1", title: "Knowledge work" },
+		]);
+		expect(transport.requests).toMatchObject([{
+			method: "GET",
+			url: "https://example.test/api/labels",
+		}]);
+	});
+
 	it("does not retry a throttled request", async () => {
 		const transport = new QueueTransport({
 			status: 429,

--- a/packages/marvin-client/src/client.ts
+++ b/packages/marvin-client/src/client.ts
@@ -2,6 +2,7 @@ import { asMarvinError, MarvinError } from "./errors.js";
 import type {
 	AddTaskRequest,
 	Category,
+	Label,
 	MarkDoneResult,
 	MarvinOrigin,
 	MarvinTransport,
@@ -117,6 +118,15 @@ export class MarvinApiClient {
 		return requireArray<Category | Project>(
 			value,
 			this.context("categories", endpoint, "GET"),
+		);
+	}
+
+	async getLabels(): Promise<Label[]> {
+		const endpoint = "/labels";
+		const value = await this.requestJson("labels", endpoint, "GET");
+		return requireArray<Label>(
+			value,
+			this.context("labels", endpoint, "GET"),
 		);
 	}
 

--- a/packages/marvin-client/src/router.test.ts
+++ b/packages/marvin-client/src/router.test.ts
@@ -151,6 +151,21 @@ describe("MarvinRouter", () => {
 		expect(publicApi.requests).toHaveLength(1);
 	});
 
+	it("routes and caches the stable label list", async () => {
+		const publicApi = new QueueTransport(
+			jsonResponse(200, [{ _id: "label-1", title: "Knowledge work" }]),
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		expect((await router.getLabels()).data).toEqual([
+			{ _id: "label-1", title: "Knowledge work" },
+		]);
+		expect((await router.getLabels()).freshness).toBe("cached");
+		expect(publicApi.requests).toHaveLength(1);
+	});
+
 	it("coalesces concurrent reads for the same key", async () => {
 		let release: ((value: MarvinTransportResponse) => void) | undefined;
 		let calls = 0;

--- a/packages/marvin-client/src/router.ts
+++ b/packages/marvin-client/src/router.ts
@@ -11,6 +11,7 @@ import {
 import type {
 	AddTaskRequest,
 	Category,
+	Label,
 	MarkDoneResult,
 	MarvinErrorSummary,
 	MarvinItem,
@@ -29,9 +30,10 @@ const DEFAULT_CACHE_POLICIES = {
 	due: { freshTtlMs: 30_000, staleIfErrorMs: 10 * 60_000 },
 	children: { freshTtlMs: 60_000, staleIfErrorMs: 15 * 60_000 },
 	categories: { freshTtlMs: 5 * 60_000, staleIfErrorMs: 60 * 60_000 },
+	labels: { freshTtlMs: 60 * 60_000, staleIfErrorMs: 24 * 60 * 60_000 },
 } satisfies Record<ReadKind, MarvinCachePolicy>;
 
-type ReadKind = "today" | "due" | "children" | "categories";
+type ReadKind = "today" | "due" | "children" | "categories" | "labels";
 
 export interface MarvinRouterOptions {
 	publicClient: MarvinApiClient;
@@ -110,6 +112,15 @@ export class MarvinRouter {
 			this.policies.categories,
 			"categories",
 			(client) => client.getCategories(),
+		);
+	}
+
+	getLabels(): Promise<MarvinReadResult<Label[]>> {
+		return this.readThrough(
+			"labels",
+			this.policies.labels,
+			"labels",
+			(client) => client.getLabels(),
 		);
 	}
 

--- a/packages/marvin-client/src/types.ts
+++ b/packages/marvin-client/src/types.ts
@@ -59,6 +59,7 @@ export interface Category extends BaseMarvinItem {
 	title: string;
 	type?: "category";
 	parentId?: string;
+	labelIds?: string[];
 	startDate?: string;
 	dueDate?: string;
 	endDate?: string;
@@ -68,6 +69,16 @@ export interface Category extends BaseMarvinItem {
 	rank?: number;
 	recurring?: boolean;
 	isRecurring?: boolean;
+}
+
+export interface Label extends BaseMarvinItem {
+	title: string;
+	groupId?: string;
+	color?: string;
+	icon?: string;
+	showAs?: "text" | "icon" | "both";
+	isAction?: boolean;
+	isHidden?: boolean;
 }
 
 export type TaskOrProject = Task | Project;

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -26,6 +26,10 @@ function operations(overrides: Partial<MarvinOperations> = {}): MarvinOperations
 	return {
 		getTodayItems: async () => todayResult,
 		getDueItems: async () => ({ ...todayResult, data: [] }),
+		getLabels: async () => ({
+			...todayResult,
+			data: [{ _id: "label-1", title: "Knowledge work" }],
+		}),
 		addTask: async (input): Promise<Task> => ({
 			_id: "created-1",
 			title: input.title,
@@ -61,10 +65,15 @@ describe("Amazing Marvin MCP", () => {
 			name: "marvin_today",
 			arguments: { date: "2026-07-23" },
 		});
+		const labels = await client.callTool({
+			name: "marvin_labels",
+			arguments: {},
+		});
 
 		expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
 			"marvin_create_task",
 			"marvin_due",
+			"marvin_labels",
 			"marvin_mark_done",
 			"marvin_today",
 		]);
@@ -76,6 +85,12 @@ describe("Amazing Marvin MCP", () => {
 				id: "task-1",
 				title: "Decide",
 				deepLink: "https://app.amazingmarvin.com/#t=task-1",
+			}],
+		});
+		expect(labels.structuredContent).toMatchObject({
+			labels: [{
+				id: "label-1",
+				title: "Knowledge work",
 			}],
 		});
 	});
@@ -143,6 +158,7 @@ describe("Amazing Marvin MCP", () => {
 				title: "Prepare application",
 				day: "2026-07-23",
 				parentId: "project-1",
+				labelIds: ["label-1"],
 			},
 		});
 		const completed = await client.callTool({
@@ -171,6 +187,7 @@ describe("Amazing Marvin MCP", () => {
 					title: "Prepare application",
 					day: "2026-07-23",
 					parentId: "project-1",
+					labelIds: ["label-1"],
 				},
 			],
 			["markDone", "created-1", -240],

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -3,6 +3,7 @@ import * as z from "zod/v4";
 import {
 	MarvinError,
 	MarvinRouteError,
+	type Label,
 	type MarvinRouter,
 	type TaskOrProject,
 	marvinDeepLink,
@@ -10,7 +11,7 @@ import {
 
 export type MarvinOperations = Pick<
 	MarvinRouter,
-	"getTodayItems" | "getDueItems" | "addTask" | "markDone"
+	"getTodayItems" | "getDueItems" | "getLabels" | "addTask" | "markDone"
 >;
 
 const dateSchema = z.string()
@@ -29,6 +30,18 @@ function itemForTool(item: TaskOrProject) {
 		...(item.dueDate === undefined ? {} : { dueDate: item.dueDate }),
 		...(item.startDate === undefined ? {} : { startDate: item.startDate }),
 		...(item.note === undefined ? {} : { note: item.note }),
+	};
+}
+
+function labelForTool(label: Label) {
+	return {
+		id: label._id,
+		title: label.title,
+		...(label.groupId === undefined ? {} : { groupId: label.groupId }),
+		...(label.color === undefined ? {} : { color: label.color }),
+		...(label.icon === undefined ? {} : { icon: label.icon }),
+		...(label.isAction === undefined ? {} : { isAction: label.isAction }),
+		...(label.isHidden === undefined ? {} : { isHidden: label.isHidden }),
 	};
 }
 
@@ -116,12 +129,34 @@ export function createMarvinMcpServer(
 		}
 	});
 
+	server.registerTool("marvin_labels", {
+		title: "Amazing Marvin Labels",
+		description: "Read stable label IDs and titles for task creation and filtering.",
+		inputSchema: {},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async () => {
+		try {
+			const { data, ...metadata } = await operations.getLabels();
+			return success({
+				...metadata,
+				labels: data.map(labelForTool),
+			});
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
 	server.registerTool("marvin_create_task", {
 		title: "Create Amazing Marvin Task",
 		description: "Create one task in Amazing Marvin with the limited API token.",
 		inputSchema: {
 			title: z.string().trim().min(1).describe("Task title; Marvin shortcuts are supported"),
 			parentId: z.string().trim().min(1).optional(),
+			labelIds: z.array(z.string().trim().min(1)).optional()
+				.describe("Stable IDs returned by marvin_labels"),
 			day: dateSchema,
 			dueDate: dateSchema,
 			note: z.string().optional(),
@@ -140,6 +175,7 @@ export function createMarvinMcpServer(
 				title: input.title,
 				timeZoneOffset: new Date().getTimezoneOffset() * -1,
 				...(input.parentId === undefined ? {} : { parentId: input.parentId }),
+				...(input.labelIds === undefined ? {} : { labelIds: input.labelIds }),
 				...(input.day === undefined ? {} : { day: input.day }),
 				...(input.dueDate === undefined ? {} : { dueDate: input.dueDate }),
 				...(input.note === undefined ? {} : { note: input.note }),

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import type {
 	AddTaskRequest,
 	EnsureSourceActionResult,
+	Label,
 	MarvinReadResult,
 	ResolvePendingSourceActionRequest,
 	TaskOrProject,
@@ -44,6 +45,7 @@ export interface AmazingMarvinApi {
 	getToday(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
 	getDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
 	getTodayAndDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	getLabels(): Promise<MarvinReadResult<Label[]>>;
 	createTask(task: AddTaskRequest): Promise<TaskOrProject>;
 	ensureTaskForSource(
 		input: EnsureTaskForSourceInput,

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
 } from "./interfaces";
 import {
 	type AddTaskRequest,
+	type Label,
 	type MarvinItem,
 	type MarvinReadResult,
 	type TaskOrProject,
@@ -71,6 +72,13 @@ import {
 	type TodayProjectionItem,
 } from "./marvin/todayProjection";
 import { runTodayProjection } from "./marvin/todayWorkflow";
+import {
+	formatTaskMetadata,
+	formatMarvinLabelTags,
+	orderTaskBody,
+	taskTitleComesFirst,
+	type TaskFormattingOptions,
+} from "./marvin/taskFormatting";
 
 function getAMTimezoneOffset() {
 	return new Date().getTimezoneOffset() * -1;
@@ -104,6 +112,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 	private sourceActionStore?: ObsidianSourceActionStore;
 	private sourceActionService?: SourceActionService;
 	private sourceActionRouter?: MarvinRouter;
+	private marvinLabelsById = new Map<string, Label>();
 	private readonly todayRefreshes = new Map<string, Promise<RefreshTodayTasksResult>>();
 	private lastAutomaticRefreshAt = 0;
 	private lastAutomaticRefreshError = "";
@@ -112,6 +121,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		getToday: (date) => this.getMarvinRouter().getTodayItems(date),
 		getDue: (date) => this.getMarvinRouter().getDueItems(date),
 		getTodayAndDue: (date) => this.getMarvinRouter().getTodayAndDue(date),
+		getLabels: () => this.getMarvinRouter().getLabels(),
 		createTask: async (task) => {
 			const created = await this.getMarvinRouter().addTask(task);
 			this.queueManagedTodayRefresh("creating a task");
@@ -182,11 +192,14 @@ export default class AmazingMarvinPlugin extends Plugin {
         // Fetch categories first and make sure they are loaded
         try {
 			const defaultParentId = this.marvinParentIdForFile(view.file);
+			await this.refreshLabelsForProjection();
           // If a region of text is selected, at least 3 characters long, use that to add a new task and skip the modal
           if (editor.somethingSelected() && editor.getSelection().length > 2) {
             try {
               const task = await this.addMarvinTask(defaultParentId ?? '', editor.getSelection(), view.file?.path, this.app.vault.getName());
-              editor.replaceSelection(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`);
+              editor.replaceSelection(
+				`- [${task.done ? 'x' : ' '}] ${this.renderTaskBody(task)}`,
+			  );
             } catch (error) {
               console.error('Could not create Marvin task:', error);
             }
@@ -197,7 +210,10 @@ export default class AmazingMarvinPlugin extends Plugin {
           new AddTaskModal(this.app, categories, async (taskDetails: { catId: string, task: string }) => {
             try {
               const task = await this.addMarvinTask(taskDetails.catId, taskDetails.task, view.file?.path, this.app.vault.getName());
-              editor.replaceRange(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`, editor.getCursor());
+              editor.replaceRange(
+				`- [${task.done ? 'x' : ' '}] ${this.renderTaskBody(task)}`,
+				editor.getCursor(),
+			  );
             } catch (error) {
               console.error('Could not create Marvin task:', error);
             }
@@ -422,6 +438,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		date: string,
 		file: TFile,
 	): Promise<RefreshTodayTasksResult> {
+		await this.refreshLabelsForProjection();
 		const workflow = await runTodayProjection({
 			date,
 			read: () => this.readTodaySelection(date),
@@ -455,7 +472,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 				type: item.type ?? "task",
 			});
 			const source = sourceLinks.get(item._id);
-			const details = this.formatTaskDetails(item as Task, "").trim();
+			const details = this.formatTaskDetails(item as Task);
 			return {
 				id: item._id,
 				title: item.title,
@@ -572,6 +589,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 
 	async sync() {
+		await this.refreshLabelsForProjection();
 		const categories = await this.getCategories();
 		this.categories = categories;
 		const existingFiles = await this.findManagedImportFiles();
@@ -711,12 +729,11 @@ export default class AmazingMarvinPlugin extends Plugin {
 				categoryContent += `${indentation}- [[${this.wikiTarget(path)}|${this.wikiAlias(item.title)}]] [⚓](${item.deepLink})\n`;
 			} else {
 				if (!isSubtask) { // Only add deep links to top-level tasks
-					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] [⚓](${item.deepLink}) ${this.formatTaskDetails(item as Task, indentation)}`;
+					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] ${this.renderTaskBody(item as Task)}`;
 				} else {
-					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] `;
+					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] ${this.inlineMarkdown(item.title)}`;
 				}
-
-				taskContent += `${this.inlineMarkdown(item.title)}\n`;
+				taskContent += "\n";
 
 				// Recursively format sub-tasks if any
 				if ('subtasks' in item && item.subtasks && Object.keys(item.subtasks).length > 0) {
@@ -743,25 +760,55 @@ export default class AmazingMarvinPlugin extends Plugin {
 		return content;
 	}
 
-	formatTaskDetails(task: Task, indentation: string) {
-		let details = '';
-		const settings = this.settings;
+	formatTaskDetails(task: Task): string {
+		return formatTaskMetadata(
+			task,
+			this.taskFormattingOptions(),
+			this.marvinLabelsById,
+		);
+	}
 
-		if (settings.showDueDate && task.dueDate) {
-			details += `Due Date:: [[${task.dueDate}]] `;
-		}
-		if (settings.showStartDate && task.startDate) {
-			details += `Start Date:: [[${task.startDate}]] `;
-		}
-		if (settings.showScheduledDate && task.day && task.day !== 'unassigned') {
-			details += `Scheduled Date:: [[${task.day}]] `;
-		}
+	private renderTaskBody(task: Task): string {
+		const options = this.taskFormattingOptions();
+		return orderTaskBody(
+			this.inlineMarkdown(task.title),
+			task.deepLink,
+			formatTaskMetadata(task, options, this.marvinLabelsById),
+			taskTitleComesFirst(options),
+		);
+	}
 
-		return details;
+	private taskFormattingOptions(): TaskFormattingOptions {
+		return {
+			format: this.settings.taskMetadataFormat,
+			titleFirst: this.settings.taskTitleFirst,
+			showDueDate: this.settings.showDueDate,
+			showStartDate: this.settings.showStartDate,
+			showScheduledDate: this.settings.showScheduledDate,
+			taskTag: this.settings.taskTag,
+			showMarvinLabelsAsTags: this.settings.showMarvinLabelsAsTags,
+			labelTagPrefix: this.settings.marvinLabelTagPrefix,
+			dateLinkTarget: (date) => {
+				const parsed = moment(date, "YYYY-MM-DD", true);
+				return parsed.isValid()
+					? parsed.format(this.settings.taskDateLinkFormat)
+					: date;
+			},
+		};
 	}
 
 	async createContentForCategory(category: Category): Promise<string> {
-		let content = `# [⚓](${category.deepLink}) ${this.inlineMarkdown(category.title)}\n\n`;
+		const labelTags = this.settings.showMarvinLabelsAsTags
+			? formatMarvinLabelTags(
+				category.labelIds,
+				this.settings.marvinLabelTagPrefix,
+				this.marvinLabelsById,
+			)
+			: [];
+		let content = [
+			`# [⚓](${category.deepLink}) ${this.inlineMarkdown(category.title)}`,
+			...labelTags,
+		].join(" ") + "\n\n";
 
 		// Link to parent category, if it exists
 		if (category.parentId && category.parentId !== "root") {
@@ -877,6 +924,18 @@ export default class AmazingMarvinPlugin extends Plugin {
 			byId.set(itemId, file);
 		}
 		return byId;
+	}
+
+	private async refreshLabelsForProjection(): Promise<void> {
+		if (!this.settings.showMarvinLabelsAsTags) {
+			this.marvinLabelsById.clear();
+			return;
+		}
+		const result = await this.getMarvinRouter().getLabels();
+		this.reportReadState(result, "labels");
+		this.marvinLabelsById = new Map(
+			result.data.map((label) => [label._id, label]),
+		);
 	}
 
 	private getMarvinRouter(): MarvinRouter {

--- a/src/marvin/taskFormatting.test.ts
+++ b/src/marvin/taskFormatting.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	formatTaskMetadata,
+	formatMarvinLabelTags,
+	orderTaskBody,
+	taskTitleComesFirst,
+	type TaskFormattingOptions,
+} from "./taskFormatting";
+
+const defaults: TaskFormattingOptions = {
+	format: "dataview",
+	titleFirst: false,
+	showDueDate: true,
+	showStartDate: true,
+	showScheduledDate: true,
+	taskTag: "",
+	showMarvinLabelsAsTags: false,
+	labelTagPrefix: "marvin",
+};
+
+const task = {
+	dueDate: "2026-07-25",
+	startDate: "2026-07-22",
+	day: "2026-07-23",
+	labelIds: ["knowledge", "numeric", "missing"],
+};
+
+describe("task formatting", () => {
+	it("preserves the current Dataview format by default", () => {
+		const metadata = formatTaskMetadata(task, defaults);
+
+		expect(metadata).toBe(
+			"Due Date:: [[2026-07-25]] "
+			+ "Start Date:: [[2026-07-22]] "
+			+ "Scheduled Date:: [[2026-07-23]]",
+		);
+		expect(orderTaskBody(
+			"Write brief",
+			"https://app.amazingmarvin.com/#t=task-1",
+			metadata,
+			taskTitleComesFirst(defaults),
+		)).toBe(
+			"[⚓](https://app.amazingmarvin.com/#t=task-1) "
+			+ `${metadata} Write brief`,
+		);
+	});
+
+	it("links Dataview dates to weekly notes with the date as alias", () => {
+		expect(formatTaskMetadata(task, {
+			...defaults,
+			dateLinkTarget: () => "2026-W30",
+		})).toContain("Due Date:: [[2026-W30|2026-07-25]]");
+	});
+
+	it("renders Tasks emoji and Dataview presets after the title", () => {
+		const emoji = {
+			...defaults,
+			format: "tasks-emoji" as const,
+		};
+		expect(formatTaskMetadata(task, emoji)).toBe(
+			"📅 2026-07-25 🛫 2026-07-22 ⏳ 2026-07-23",
+		);
+		expect(taskTitleComesFirst(emoji)).toBe(true);
+
+		expect(formatTaskMetadata(task, {
+			...defaults,
+			format: "tasks-dataview",
+		})).toBe(
+			"[due:: 2026-07-25] "
+			+ "[start:: 2026-07-22] "
+			+ "[scheduled:: 2026-07-23]",
+		);
+	});
+
+	it("adds a query tag and stable namespaced tags for known Marvin labels", () => {
+		const labels = new Map([
+			["knowledge", { _id: "knowledge", title: "Knowledge work" }],
+			["numeric", { _id: "numeric", title: "2026" }],
+			["empty", { _id: "empty", title: "!!!" }],
+		]);
+
+		const metadata = formatTaskMetadata({
+			...task,
+			labelIds: [...task.labelIds, "empty"],
+		}, {
+			...defaults,
+			taskTag: "#task",
+			showMarvinLabelsAsTags: true,
+			labelTagPrefix: "marvin/labels",
+		}, labels);
+		expect(metadata).toContain(
+			"#task #marvin/labels/Knowledge-work #marvin/labels/2026",
+		);
+		expect(metadata.endsWith("#marvin/labels")).toBe(false);
+		expect(formatMarvinLabelTags(
+			["knowledge"],
+			"marvin",
+			labels,
+		)).toEqual(["#marvin/Knowledge-work"]);
+	});
+
+	it("keeps untrusted configured values and labels on one line", () => {
+		const labels = new Map([
+			["unsafe", { _id: "unsafe", title: "A #tag\n<!-- injected -->" }],
+		]);
+
+		const metadata = formatTaskMetadata({
+			day: "2026-07-23",
+			labelIds: ["unsafe"],
+		}, {
+			...defaults,
+			dateLinkTarget: () => "Week|bad]\n<!-- boundary -->",
+			showMarvinLabelsAsTags: true,
+			labelTagPrefix: "marvin",
+		}, labels);
+
+		expect(metadata).not.toContain("\n");
+		expect(metadata).toContain("[[Week\\|bad\\] &lt;!-- boundary --&gt;|2026-07-23]]");
+		expect(metadata).toContain("#marvin/A-tag-injected");
+	});
+});

--- a/src/marvin/taskFormatting.ts
+++ b/src/marvin/taskFormatting.ts
@@ -1,0 +1,170 @@
+import type { Label, Task } from "@open-horizon/marvin-client";
+
+export type TaskMetadataFormat =
+	| "dataview"
+	| "tasks-dataview"
+	| "tasks-emoji";
+
+export interface TaskFormattingOptions {
+	format: TaskMetadataFormat;
+	titleFirst: boolean;
+	showDueDate: boolean;
+	showStartDate: boolean;
+	showScheduledDate: boolean;
+	taskTag: string;
+	showMarvinLabelsAsTags: boolean;
+	labelTagPrefix: string;
+	dateLinkTarget?: (date: string) => string;
+}
+
+export function formatTaskMetadata(
+	task: Pick<Task, "dueDate" | "startDate" | "day" | "labelIds">,
+	options: TaskFormattingOptions,
+	labelsById: ReadonlyMap<string, Pick<Label, "_id" | "title">> = new Map(),
+): string {
+	const tokens: string[] = [];
+	if (options.showDueDate && task.dueDate) {
+		tokens.push(formatDate("due", task.dueDate, options));
+	}
+	if (options.showStartDate && task.startDate) {
+		tokens.push(formatDate("start", task.startDate, options));
+	}
+	if (
+		options.showScheduledDate
+		&& task.day
+		&& task.day !== "unassigned"
+	) {
+		tokens.push(formatDate("scheduled", task.day, options));
+	}
+
+	const taskTag = tagFromPath(options.taskTag);
+	if (taskTag) {
+		tokens.push(taskTag);
+	}
+	if (options.showMarvinLabelsAsTags) {
+		tokens.push(...formatMarvinLabelTags(
+			task.labelIds,
+			options.labelTagPrefix,
+			labelsById,
+		));
+	}
+	return tokens.join(" ");
+}
+
+export function formatMarvinLabelTags(
+	labelIds: readonly string[] | undefined,
+	prefix: string,
+	labelsById: ReadonlyMap<string, Pick<Label, "_id" | "title">>,
+): string[] {
+	const tags: string[] = [];
+	const seen = new Set<string>();
+	for (const labelId of labelIds ?? []) {
+		const label = labelsById.get(labelId);
+		if (!label || !tagSegment(label.title)) {
+			continue;
+		}
+		const path = [prefix, label.title]
+			.filter((part) => part.trim())
+			.join("/");
+		const tag = tagFromPath(path);
+		if (tag && !seen.has(tag)) {
+			seen.add(tag);
+			tags.push(tag);
+		}
+	}
+	return tags;
+}
+
+export function taskTitleComesFirst(options: TaskFormattingOptions): boolean {
+	return options.format !== "dataview" || options.titleFirst;
+}
+
+export function orderTaskBody(
+	title: string,
+	deepLink: string,
+	metadata: string,
+	titleFirst: boolean,
+): string {
+	const anchor = `[⚓](${inlineText(deepLink)})`;
+	return (
+		titleFirst
+			? [title, anchor, metadata]
+			: [anchor, metadata, title]
+	)
+		.filter(Boolean)
+		.join(" ");
+}
+
+function formatDate(
+	kind: "due" | "start" | "scheduled",
+	date: string,
+	options: TaskFormattingOptions,
+): string {
+	if (options.format === "tasks-emoji") {
+		const emoji = {
+			due: "📅",
+			start: "🛫",
+			scheduled: "⏳",
+		}[kind];
+		return `${emoji} ${inlineText(date)}`;
+	}
+	if (options.format === "tasks-dataview") {
+		return `[${kind}:: ${inlineText(date)}]`;
+	}
+
+	const field = {
+		due: "Due Date",
+		start: "Start Date",
+		scheduled: "Scheduled Date",
+	}[kind];
+	return `${field}:: ${dateLink(date, options.dateLinkTarget)}`;
+}
+
+function dateLink(
+	date: string,
+	targetForDate: TaskFormattingOptions["dateLinkTarget"],
+): string {
+	const target = inlineText(targetForDate?.(date) || date);
+	const escapedTarget = escapeWiki(target);
+	const escapedDate = escapeWiki(inlineText(date));
+	return target === date
+		? `[[${escapedTarget}]]`
+		: `[[${escapedTarget}|${escapedDate}]]`;
+}
+
+function tagFromPath(value: string): string | undefined {
+	const segments = value
+		.replace(/^#+/, "")
+		.split("/")
+		.map(tagSegment)
+		.filter(Boolean);
+	if (segments.length === 0) {
+		return undefined;
+	}
+	let path = segments.join("/");
+	if (/^\d+$/.test(path)) {
+		path = `label-${path}`;
+	}
+	return `#${path}`;
+}
+
+function tagSegment(value: string): string {
+	return value
+		.normalize("NFKC")
+		.replace(/[\r\n\t ]+/g, "-")
+		.replace(/[\\/#\[\](){}<>|`"'!?.,:;=+*&^%$@~]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
+}
+
+function escapeWiki(value: string): string {
+	return value.replace(/\|/g, "\\|").replace(/\]/g, "\\]");
+}
+
+function inlineText(value: string): string {
+	return value
+		.replace(/[\r\n]+/g, " ")
+		.replace(/<!--/g, "&lt;!--")
+		.replace(/-->/g, "--&gt;")
+		.trim();
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, Platform, PluginSettingTab, Setting } from "obsidian";
 import AmazingMarvinPlugin from "./main";
 import type { ObsidianLinkFormat } from "./marvin/obsidianLinks";
+import type { TaskMetadataFormat } from "./marvin/taskFormatting";
 
 export interface AmazingMarvinPluginSettings {
 	linkBackToObsidianText: string;
@@ -12,6 +13,12 @@ export interface AmazingMarvinPluginSettings {
 	showDueDate: boolean;
 	showStartDate: boolean;
 	showScheduledDate: boolean;
+	taskMetadataFormat: TaskMetadataFormat;
+	taskTitleFirst: boolean;
+	taskDateLinkFormat: string;
+	taskTag: string;
+	showMarvinLabelsAsTags: boolean;
+	marvinLabelTagPrefix: string;
 	todayTasksToShow: 'due' | 'scheduled' | 'both';
 	autoRefreshTodayTasks: boolean;
 	todayRefreshIntervalMinutes: number;
@@ -28,6 +35,12 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	showDueDate: true,
 	showStartDate: true,
 	showScheduledDate: true,
+	taskMetadataFormat: "dataview",
+	taskTitleFirst: false,
+	taskDateLinkFormat: "YYYY-MM-DD",
+	taskTag: "",
+	showMarvinLabelsAsTags: false,
+	marvinLabelTagPrefix: "marvin",
 	todayTasksToShow: 'both',
 	autoRefreshTodayTasks: true,
 	todayRefreshIntervalMinutes: 5,
@@ -183,6 +196,79 @@ private a(href: string, text: string) {
 
 		new Setting(containerEl)
 			.setHeading().setName("Task formatting");
+
+		new Setting(containerEl)
+			.setName("Metadata format")
+			.setDesc("Keep the existing Dataview fields, or emit a format that Obsidian Tasks can query.")
+			.addDropdown(dropdown => dropdown
+				.addOption("dataview", "Dataview (current)")
+				.addOption("tasks-dataview", "Tasks Dataview")
+				.addOption("tasks-emoji", "Tasks emoji")
+				.setValue(this.plugin.settings.taskMetadataFormat)
+				.onChange(async (value: TaskMetadataFormat) => {
+					this.plugin.settings.taskMetadataFormat = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Put task title first")
+			.setDesc("For the current Dataview format, put readable task text before dates. Tasks-compatible formats always put the title first.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.taskTitleFirst)
+				.onChange(async (value) => {
+					this.plugin.settings.taskTitleFirst = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Date link format")
+			.setDesc("Moment format for Dataview date links. For example, YYYY-[W]WW links each date to its weekly note while keeping the date as the alias.")
+			.addText(text => text
+				.setPlaceholder("YYYY-MM-DD")
+				.setValue(this.plugin.settings.taskDateLinkFormat)
+				.onChange(async (value) => {
+					this.plugin.settings.taskDateLinkFormat = value.trim()
+						|| "YYYY-MM-DD";
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Task query tag")
+			.setDesc("Optional tag added to every projected Marvin task, such as #task for an Obsidian Tasks global filter.")
+			.addText(text => text
+				.setPlaceholder("#task")
+				.setValue(this.plugin.settings.taskTag)
+				.onChange(async (value) => {
+					this.plugin.settings.taskTag = value.trim();
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Marvin labels as tags")
+			.setDesc("Resolve Marvin label IDs through the limited API and add their names as Obsidian tags.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.showMarvinLabelsAsTags)
+				.onChange(async (value) => {
+					this.plugin.settings.showMarvinLabelsAsTags = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Marvin label tag prefix")
+			.setDesc("Optional tag namespace. The default turns “Knowledge work” into #marvin/Knowledge-work.")
+			.addText(text => text
+				.setPlaceholder("marvin")
+				.setValue(this.plugin.settings.marvinLabelTagPrefix)
+				.onChange(async (value) => {
+					this.plugin.settings.marvinLabelTagPrefix = value.trim();
+					await this.plugin.saveSettings();
+				})
+			);
 
 		new Setting(containerEl)
 			.setName("Show Due Date")


### PR DESCRIPTION
Closes #40
Closes #42
Closes #50

## What changed
- add current Dataview, Tasks Dataview, and Tasks emoji metadata presets
- add title-first rendering, weekly/custom Moment date-link targets, and an optional Tasks query tag
- resolve Marvin labels through the shared limited-API client and project them as managed Obsidian tags
- expose cached labels and label-aware task creation through the companion MCP and in-Obsidian API

## Verification
- `npm test` (71 tests)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Needs human verification
- switch each format in Obsidian and confirm Tasks/Dataview queries recognize the rendered lines
- use a real Marvin label and weekly-note format in a live vault
- complete a title-first projected task with the watcher enabled.