### PR TITLE
Select category and project import roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ their Marvin ID when possible; empty folders from an earlier location are left
 in place. Notes for Marvin items no longer returned by the API are also left in
 place rather than deleted automatically.
 
+Imports can include all categories/projects or selected roots. A selected root
+includes all descendants; its ancestors remain as navigation-only notes so the
+Marvin hierarchy and backlinks stay intact, while sibling branches and
+ancestor tasks are excluded. Inbox import is controlled independently. An
+empty selected-root list intentionally imports no category/project notes, and
+changing the selection never deletes notes from an earlier import.
+
 ### Running a Sync
 
 To initiate a sync:
@@ -124,6 +131,8 @@ Additional object-returning methods are available for automation:
 - `getToday(date)`
 - `getDue(date)`
 - `getTodayAndDue(date)`
+- `getCategories()`
+- `getChildren(parentId)`
 - `getLabels()`
 - `createTask(task)`
 - `ensureTaskForSource(input)`
@@ -244,6 +253,8 @@ The initial tool surface is deliberately small:
 
 - `marvin_today`
 - `marvin_due`
+- `marvin_categories`
+- `marvin_children`
 - `marvin_labels`
 - `marvin_create_task`
 - `marvin_mark_done`

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -9,7 +9,7 @@ allow a later split without making separate repositories a prerequisite.
 | `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links; source/action state machine | Obsidian vault/UI behavior; MCP schemas; source-note storage |
 | `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection; non-destructive category/project projection | HTTP/API semantics, cache policy, or fallback decisions |
 | Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
-| `packages/marvin-mcp` | Stdio lifecycle, five tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
+| `packages/marvin-mcp` | Stdio lifecycle, seven tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
 
 Both runtime adapters construct `MarvinApiClient` instances and one
 `MarvinRouter`. Writes use the public API only. Safe reads may use the desktop
@@ -30,6 +30,12 @@ The stable label list uses the same local-first route and a longer bounded
 cache. The plugin resolves task `labelIds` to namespaced Obsidian tags, while
 the MCP exposes the same IDs to `marvin_create_task`; neither consumer
 reimplements label API behavior.
+
+Category and child reads are also exposed through the MCP and Obsidian object
+API. This lets an agent discover stable parent IDs instead of guessing them.
+Selective import remains a plugin projection concern: selected roots include
+descendants, ancestors are structure-only, and deselection never authorizes
+note deletion.
 
 ## Source/action and Today projection
 

--- a/packages/marvin-client/src/client.test.ts
+++ b/packages/marvin-client/src/client.test.ts
@@ -70,6 +70,20 @@ describe("MarvinApiClient", () => {
 		}]);
 	});
 
+	it("normalizes categories without a type discriminator", async () => {
+		const transport = new QueueTransport(
+			jsonResponse(200, [
+				{ _id: "category-1", title: "Work" },
+				{ _id: "project-1", title: "Book", type: "project" },
+			]),
+		);
+
+		await expect(client(transport).getCategories()).resolves.toEqual([
+			{ _id: "category-1", title: "Work", type: "category" },
+			{ _id: "project-1", title: "Book", type: "project" },
+		]);
+	});
+
 	it("does not retry a throttled request", async () => {
 		const transport = new QueueTransport({
 			status: 429,

--- a/packages/marvin-client/src/client.ts
+++ b/packages/marvin-client/src/client.ts
@@ -115,10 +115,15 @@ export class MarvinApiClient {
 	async getCategories(): Promise<(Category | Project)[]> {
 		const endpoint = "/categories";
 		const value = await this.requestJson("categories", endpoint, "GET");
-		return requireArray<Category | Project>(
+		const categories = requireArray<Category | Project>(
 			value,
 			this.context("categories", endpoint, "GET"),
 		);
+		return categories.map((item) => (
+			item.type === "project"
+				? item
+				: { ...item, type: "category" }
+		));
 	}
 
 	async getLabels(): Promise<Label[]> {

--- a/packages/marvin-client/src/types.ts
+++ b/packages/marvin-client/src/types.ts
@@ -57,7 +57,7 @@ export interface Project extends BaseMarvinItem {
 
 export interface Category extends BaseMarvinItem {
 	title: string;
-	type?: "category";
+	type: "category";
 	parentId?: string;
 	labelIds?: string[];
 	startDate?: string;

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -26,6 +26,19 @@ function operations(overrides: Partial<MarvinOperations> = {}): MarvinOperations
 	return {
 		getTodayItems: async () => todayResult,
 		getDueItems: async () => ({ ...todayResult, data: [] }),
+		getCategories: async () => ({
+			...todayResult,
+			data: [{
+				_id: "project-1",
+				title: "Knowledge work",
+				type: "project",
+				parentId: "root",
+			}],
+		}),
+		getChildren: async () => ({
+			...todayResult,
+			data: [{ _id: "child-1", title: "Draft", done: false }],
+		}),
 		getLabels: async () => ({
 			...todayResult,
 			data: [{ _id: "label-1", title: "Knowledge work" }],
@@ -69,8 +82,18 @@ describe("Amazing Marvin MCP", () => {
 			name: "marvin_labels",
 			arguments: {},
 		});
+		const categories = await client.callTool({
+			name: "marvin_categories",
+			arguments: {},
+		});
+		const children = await client.callTool({
+			name: "marvin_children",
+			arguments: { parentId: "project-1" },
+		});
 
 		expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
+			"marvin_categories",
+			"marvin_children",
 			"marvin_create_task",
 			"marvin_due",
 			"marvin_labels",
@@ -92,6 +115,16 @@ describe("Amazing Marvin MCP", () => {
 				id: "label-1",
 				title: "Knowledge work",
 			}],
+		});
+		expect(categories.structuredContent).toMatchObject({
+			items: [{
+				id: "project-1",
+				parentId: "root",
+				deepLink: "https://app.amazingmarvin.com/#p=project-1",
+			}],
+		});
+		expect(children.structuredContent).toMatchObject({
+			items: [{ id: "child-1", title: "Draft" }],
 		});
 	});
 

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -4,21 +4,28 @@ import {
 	MarvinError,
 	MarvinRouteError,
 	type Label,
+	type MarvinItem,
+	type MarvinReadResult,
 	type MarvinRouter,
-	type TaskOrProject,
 	marvinDeepLink,
 } from "@open-horizon/marvin-client";
 
 export type MarvinOperations = Pick<
 	MarvinRouter,
-	"getTodayItems" | "getDueItems" | "getLabels" | "addTask" | "markDone"
+	| "getTodayItems"
+	| "getDueItems"
+	| "getCategories"
+	| "getChildren"
+	| "getLabels"
+	| "addTask"
+	| "markDone"
 >;
 
 const dateSchema = z.string()
 	.regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD")
 	.optional();
 
-function itemForTool(item: TaskOrProject) {
+function itemForTool(item: MarvinItem) {
 	return {
 		id: item._id,
 		title: item.title,
@@ -26,10 +33,11 @@ function itemForTool(item: TaskOrProject) {
 		done: item.done ?? false,
 		deepLink: marvinDeepLink(item),
 		...(item.parentId === undefined ? {} : { parentId: item.parentId }),
-		...(item.day === undefined ? {} : { day: item.day }),
+		...(!("day" in item) || item.day === undefined ? {} : { day: item.day }),
 		...(item.dueDate === undefined ? {} : { dueDate: item.dueDate }),
 		...(item.startDate === undefined ? {} : { startDate: item.startDate }),
 		...(item.note === undefined ? {} : { note: item.note }),
+		...(item.labelIds === undefined ? {} : { labelIds: item.labelIds }),
 	};
 }
 
@@ -55,7 +63,7 @@ function success(structuredContent: Record<string, unknown>) {
 	};
 }
 
-function readSuccess(result: Awaited<ReturnType<MarvinOperations["getTodayItems"]>>) {
+function readSuccess(result: MarvinReadResult<MarvinItem[]>) {
 	const { data, ...metadata } = result;
 	return success({
 		...metadata,
@@ -124,6 +132,41 @@ export function createMarvinMcpServer(
 	}, async ({ date }) => {
 		try {
 			return readSuccess(await operations.getDueItems(date));
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_categories", {
+		title: "Amazing Marvin Categories and Projects",
+		description: "Read stable category/project IDs and their parent hierarchy.",
+		inputSchema: {},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async () => {
+		try {
+			return readSuccess(await operations.getCategories());
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_children", {
+		title: "Amazing Marvin Children",
+		description: "Read direct tasks and projects below one stable parent ID.",
+		inputSchema: {
+			parentId: z.string().trim().min(1)
+				.describe("Category/project ID, or unassigned for Inbox"),
+		},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async ({ parentId }) => {
+		try {
+			return readSuccess(await operations.getChildren(parentId));
 		} catch (error) {
 			return failure(error);
 		}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,9 +1,12 @@
 import type {
 	AddTaskRequest,
+	Category,
 	EnsureSourceActionResult,
 	Label,
 	MarvinReadResult,
+	Project,
 	ResolvePendingSourceActionRequest,
+	Task,
 	TaskOrProject,
 } from "@open-horizon/marvin-client";
 
@@ -45,6 +48,8 @@ export interface AmazingMarvinApi {
 	getToday(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
 	getDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
 	getTodayAndDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	getCategories(): Promise<MarvinReadResult<(Category | Project)[]>>;
+	getChildren(parentId: string): Promise<MarvinReadResult<(Task | Project)[]>>;
 	getLabels(): Promise<MarvinReadResult<Label[]>>;
 	createTask(task: AddTaskRequest): Promise<TaskOrProject>;
 	ensureTaskForSource(

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,11 @@ import {
 } from "./marvin/todayProjection";
 import { runTodayProjection } from "./marvin/todayWorkflow";
 import {
+	categoryProjectionItems,
+	planCategorySync,
+	type CategorySyncPlan,
+} from "./marvin/syncSelection";
+import {
 	formatTaskMetadata,
 	formatMarvinLabelTags,
 	orderTaskBody,
@@ -121,6 +126,8 @@ export default class AmazingMarvinPlugin extends Plugin {
 		getToday: (date) => this.getMarvinRouter().getTodayItems(date),
 		getDue: (date) => this.getMarvinRouter().getDueItems(date),
 		getTodayAndDue: (date) => this.getMarvinRouter().getTodayAndDue(date),
+		getCategories: () => this.getMarvinRouter().getCategories(),
+		getChildren: (parentId) => this.getMarvinRouter().getChildren(parentId),
 		getLabels: () => this.getMarvinRouter().getLabels(),
 		createTask: async (task) => {
 			const created = await this.getMarvinRouter().addTask(task);
@@ -592,9 +599,16 @@ export default class AmazingMarvinPlugin extends Plugin {
 		await this.refreshLabelsForProjection();
 		const categories = await this.getCategories();
 		this.categories = categories;
+		const plan = planCategorySync(
+			categories,
+			this.settings.syncSelectionMode,
+			this.settings.syncRoots.map((root) => root.id),
+		);
 		const existingFiles = await this.findManagedImportFiles();
-		await this.processCategories(existingFiles);
-		await this.processInbox(existingFiles);
+		await this.processCategories(existingFiles, plan);
+		if (this.settings.syncInbox) {
+			await this.processInbox(existingFiles);
+		}
 	}
 
 	async getCategories(): Promise<Category[]> {
@@ -700,11 +714,19 @@ export default class AmazingMarvinPlugin extends Plugin {
 		));
 	}
 
-	async processCategories(existingFiles: Map<string, TFile>) {
-		for (const category of this.categories) {
+	async processCategories(
+		existingFiles: Map<string, TFile>,
+		plan: CategorySyncPlan,
+	) {
+		for (const category of this.categories.filter(
+			(item) => plan.includedIds.has(item._id),
+		)) {
 			const path = this.getPathForCategory(category);
 			await this.moveManagedFile(existingFiles.get(category._id), path);
-			const content = await this.createContentForCategory(category);
+			const content = await this.createContentForCategory(
+				category,
+				plan,
+			);
 			await this.createOrUpdateManaged(
 				path,
 				category._id,
@@ -715,7 +737,12 @@ export default class AmazingMarvinPlugin extends Plugin {
 		}
 	}
 
-	formatItems(items: (Task | Category)[], level = 0, isSubtask = false) {
+	formatItems(
+		items: (Task | Category)[],
+		level = 0,
+		isSubtask = false,
+		allowedContainerIds?: ReadonlySet<string>,
+	) {
 		let taskContent = '';
 		let categoryContent = '';
 
@@ -724,6 +751,9 @@ export default class AmazingMarvinPlugin extends Plugin {
 			const isCategoryOrProject = item.type === 'category' || item.type === 'project';
 
 			if (isCategoryOrProject) {
+				if (allowedContainerIds && !allowedContainerIds.has(item._id)) {
+					continue;
+				}
 				// Handle category or project formatting
 				const path = this.getPathForCategory(item);
 				categoryContent += `${indentation}- [[${this.wikiTarget(path)}|${this.wikiAlias(item.title)}]] [⚓](${item.deepLink})\n`;
@@ -742,7 +772,12 @@ export default class AmazingMarvinPlugin extends Plugin {
 						type: "task" as const,
 						deepLink: "",
 					})) as Task[];
-					taskContent += this.formatItems(subtasks, level + 1, true); // Pass true for isSubtask
+					taskContent += this.formatItems(
+						subtasks,
+						level + 1,
+						true,
+						allowedContainerIds,
+					);
 				}
 			}
 		}
@@ -797,7 +832,10 @@ export default class AmazingMarvinPlugin extends Plugin {
 		};
 	}
 
-	async createContentForCategory(category: Category): Promise<string> {
+	async createContentForCategory(
+		category: Category,
+		plan: CategorySyncPlan,
+	): Promise<string> {
 		const labelTags = this.settings.showMarvinLabelsAsTags
 			? formatMarvinLabelTags(
 				category.labelIds,
@@ -818,8 +856,21 @@ export default class AmazingMarvinPlugin extends Plugin {
 			}
 		}
 		// Fetch and format tasks
-		const children = await this.getChildren(category._id);
-		content += this.formatItems(children);
+		const fetchedChildren = plan.contentIds.has(category._id)
+			? await this.getChildren(category._id)
+			: undefined;
+		const children = categoryProjectionItems(
+			category._id,
+			plan,
+			this.categories,
+			fetchedChildren,
+		);
+		content += this.formatItems(
+			children,
+			0,
+			false,
+			plan.includedIds,
+		);
 
 		return content;
 	}

--- a/src/marvin/syncSelection.test.ts
+++ b/src/marvin/syncSelection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	categoryProjectionItems,
+	planCategorySync,
+} from "./syncSelection";
+
+const categories = [
+	{ _id: "work", title: "Work", type: "category", parentId: "root" },
+	{ _id: "knowledge", title: "Knowledge", type: "category", parentId: "work" },
+	{ _id: "project", title: "Write book", type: "project", parentId: "knowledge" },
+	{ _id: "chapter", title: "Chapter one", type: "project", parentId: "project" },
+	{ _id: "garden", title: "Garden", type: "project", parentId: "work" },
+];
+
+describe("category sync selection", () => {
+	it("keeps the existing all-items behavior by default", () => {
+		const plan = planCategorySync(categories, "all", []);
+
+		expect([...plan.contentIds]).toEqual(categories.map((item) => item._id));
+		expect(plan.structuralIds.size).toBe(0);
+	});
+
+	it("includes selected roots and descendants with ancestors as structure only", () => {
+		const plan = planCategorySync(categories, "selected", ["project"]);
+
+		expect([...plan.contentIds]).toEqual(["project", "chapter"]);
+		expect([...plan.structuralIds]).toEqual(["knowledge", "work"]);
+		expect(plan.includedIds.has("garden")).toBe(false);
+	});
+
+	it("allows an intentionally empty selection without falling back to all", () => {
+		const plan = planCategorySync(categories, "selected", []);
+
+		expect(plan.includedIds.size).toBe(0);
+		expect(plan.contentIds.size).toBe(0);
+	});
+
+	it("fails closed for stale IDs, missing parents, and cycles", () => {
+		expect(() => planCategorySync(
+			categories,
+			"selected",
+			["missing"],
+		)).toThrow("was not returned");
+		expect(() => planCategorySync(
+			[{ _id: "child", title: "Child", parentId: "missing" }],
+			"selected",
+			["child"],
+		)).toThrow("parent missing");
+		expect(() => planCategorySync(
+			[
+				{ _id: "a", title: "A", parentId: "b" },
+				{ _id: "b", title: "B", parentId: "a" },
+			],
+			"selected",
+			["a"],
+		)).toThrow("cycle");
+	});
+
+	it("renders ancestors as structure only and filters unselected sibling links", () => {
+		const plan = planCategorySync(categories, "selected", ["project"]);
+		const fetchedWorkChildren = [
+			{ _id: "knowledge", title: "Knowledge", type: "category", parentId: "work" },
+			{ _id: "garden", title: "Garden", type: "project", parentId: "work" },
+			{ _id: "task", title: "Repair fence", type: "task", parentId: "work" },
+		];
+
+		expect(categoryProjectionItems(
+			"work",
+			plan,
+			fetchedWorkChildren,
+			fetchedWorkChildren,
+		).map((item) => item._id)).toEqual(["knowledge"]);
+
+		const selectedChildren = [
+			{ _id: "chapter", title: "Chapter one", type: "project", parentId: "project" },
+			{ _id: "draft", title: "Draft outline", type: "task", parentId: "project" },
+			{ _id: "excluded", title: "Excluded", type: "project", parentId: "project" },
+		];
+		expect(categoryProjectionItems(
+			"project",
+			plan,
+			categories,
+			selectedChildren,
+		).map((item) => item._id)).toEqual(["chapter", "draft"]);
+	});
+});

--- a/src/marvin/syncSelection.ts
+++ b/src/marvin/syncSelection.ts
@@ -1,0 +1,110 @@
+import type { CategoryPathItem } from "./categoryPaths";
+
+export type SyncSelectionMode = "all" | "selected";
+
+export interface SyncRootSelection {
+	id: string;
+	title: string;
+}
+
+export interface CategorySyncPlan {
+	includedIds: ReadonlySet<string>;
+	contentIds: ReadonlySet<string>;
+	structuralIds: ReadonlySet<string>;
+}
+
+export interface SyncProjectionItem extends CategoryPathItem {
+	type?: string;
+}
+
+export function planCategorySync(
+	categories: CategoryPathItem[],
+	mode: SyncSelectionMode,
+	rootIds: readonly string[],
+): CategorySyncPlan {
+	const byId = new Map(categories.map((item) => [item._id, item]));
+	if (mode === "all") {
+		const all = new Set(byId.keys());
+		return {
+			includedIds: all,
+			contentIds: all,
+			structuralIds: new Set(),
+		};
+	}
+
+	const contentIds = new Set<string>();
+	const queue: string[] = [];
+	for (const rootId of new Set(rootIds)) {
+		if (!byId.has(rootId)) {
+			throw new Error(
+				`Selected Amazing Marvin item ${rootId} was not returned by the API`,
+			);
+		}
+		contentIds.add(rootId);
+		queue.push(rootId);
+	}
+
+	for (let index = 0; index < queue.length; index += 1) {
+		const parentId = queue[index]!;
+		for (const item of categories) {
+			if (item.parentId === parentId && !contentIds.has(item._id)) {
+				contentIds.add(item._id);
+				queue.push(item._id);
+			}
+		}
+	}
+
+	const includedIds = new Set(contentIds);
+	for (const contentId of contentIds) {
+		let current = byId.get(contentId);
+		const visited = new Set<string>();
+		while (current?.parentId && current.parentId !== "root") {
+			if (visited.has(current._id)) {
+				throw new Error(
+					`Amazing Marvin category hierarchy contains a cycle at ${current._id}`,
+				);
+			}
+			visited.add(current._id);
+			const parent = byId.get(current.parentId);
+			if (!parent) {
+				throw new Error(
+					`Amazing Marvin parent ${current.parentId} for ${current._id} was not returned by the API`,
+				);
+			}
+			includedIds.add(parent._id);
+			current = parent;
+		}
+	}
+
+	return {
+		includedIds,
+		contentIds,
+		structuralIds: new Set(
+			[...includedIds].filter((id) => !contentIds.has(id)),
+		),
+	};
+}
+
+export function categoryProjectionItems<T extends SyncProjectionItem>(
+	parentId: string,
+	plan: CategorySyncPlan,
+	categories: readonly T[],
+	fetchedChildren?: readonly T[],
+): T[] {
+	if (!plan.contentIds.has(parentId)) {
+		return categories.filter((item) => (
+			item.parentId === parentId
+			&& plan.includedIds.has(item._id)
+		));
+	}
+	if (!fetchedChildren) {
+		throw new Error(
+			`Amazing Marvin children were not fetched for selected item ${parentId}`,
+		);
+	}
+	return fetchedChildren.filter((item) => (
+		item.type !== "category"
+		&& item.type !== "project"
+		|| plan.includedIds.has(item._id)
+	));
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,18 @@
-import { App, Platform, PluginSettingTab, Setting } from "obsidian";
+import {
+	App,
+	FuzzySuggestModal,
+	Notice,
+	Platform,
+	PluginSettingTab,
+	Setting,
+} from "obsidian";
 import AmazingMarvinPlugin from "./main";
+import type { Category } from "./interfaces";
 import type { ObsidianLinkFormat } from "./marvin/obsidianLinks";
+import type {
+	SyncRootSelection,
+	SyncSelectionMode,
+} from "./marvin/syncSelection";
 import type { TaskMetadataFormat } from "./marvin/taskFormatting";
 
 export interface AmazingMarvinPluginSettings {
@@ -24,6 +36,9 @@ export interface AmazingMarvinPluginSettings {
 	todayRefreshIntervalMinutes: number;
 	obsidianLinkFormat: ObsidianLinkFormat;
 	syncFolder: string;
+	syncSelectionMode: SyncSelectionMode;
+	syncRoots: SyncRootSelection[];
+	syncInbox: boolean;
 }
 
 export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
@@ -46,8 +61,58 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	todayRefreshIntervalMinutes: 5,
 	obsidianLinkFormat: "advanced-uri",
 	syncFolder: "AmazingMarvin",
+	syncSelectionMode: "all",
+	syncRoots: [],
+	syncInbox: true,
 	attemptToMarkTasksAsDone: false,
 };
+
+class SyncRootSuggestModal extends FuzzySuggestModal<Category> {
+	constructor(
+		app: App,
+		private readonly categories: Category[],
+		private readonly choose: (category: Category) => void,
+	) {
+		super(app);
+		this.setPlaceholder("Choose a category or project root");
+	}
+
+	getItems(): Category[] {
+		return this.categories;
+	}
+
+	getItemText(category: Category): string {
+		return categoryDisplayPath(category, this.categories);
+	}
+
+	onChooseItem(category: Category): void {
+		this.choose(category);
+	}
+}
+
+function categoryDisplayPath(
+	category: Category,
+	categories: Category[],
+): string {
+	const segments = [category.title];
+	const visited = new Set([category._id]);
+	let parentId = category.parentId;
+	while (parentId && parentId !== "root") {
+		if (visited.has(parentId)) {
+			segments.unshift("[cycle]");
+			break;
+		}
+		visited.add(parentId);
+		const parent = categories.find((item) => item._id === parentId);
+		if (!parent) {
+			segments.unshift("[missing parent]");
+			break;
+		}
+		segments.unshift(parent.title);
+		parentId = parent.parentId;
+	}
+	return segments.join(" / ");
+}
 
 export class AmazingMarvinSettingsTab extends PluginSettingTab {
 	plugin: AmazingMarvinPlugin;
@@ -111,6 +176,92 @@ private a(href: string, text: string) {
 				.setValue(this.plugin.settings.syncFolder)
 				.onChange(async (value) => {
 					this.plugin.settings.syncFolder = value.trim() || "AmazingMarvin";
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Items to import")
+			.setDesc("Import everything, or selected roots with their descendants. Ancestors are retained as navigation structure; excluded notes are never deleted.")
+			.addDropdown(dropdown => dropdown
+				.addOption("all", "All categories and projects")
+				.addOption("selected", "Selected roots")
+				.setValue(this.plugin.settings.syncSelectionMode)
+				.onChange(async (value: SyncSelectionMode) => {
+					this.plugin.settings.syncSelectionMode = value;
+					await this.plugin.saveSettings();
+					this.display();
+				})
+			);
+
+		if (this.plugin.settings.syncSelectionMode === "selected") {
+			for (const root of this.plugin.settings.syncRoots) {
+				new Setting(containerEl)
+					.setName(root.title)
+					.setDesc(`Marvin ID: ${root.id}`)
+					.addButton(button => button
+						.setButtonText("Remove")
+						.onClick(async () => {
+							this.plugin.settings.syncRoots = (
+								this.plugin.settings.syncRoots.filter(
+									(candidate) => candidate.id !== root.id,
+								)
+							);
+							await this.plugin.saveSettings();
+							this.display();
+						})
+					);
+			}
+
+			new Setting(containerEl)
+				.setName("Add import root")
+				.setDesc(
+					this.plugin.settings.syncRoots.length === 0
+						? "No roots selected. Category/project import will make no changes."
+						: "Selecting a root includes every category and project below it.",
+				)
+				.addButton(button => button
+					.setButtonText("Choose")
+					.onClick(async () => {
+						try {
+							const categories = await this.plugin.getCategories();
+							const selected = new Set(
+								this.plugin.settings.syncRoots.map((root) => root.id),
+							);
+							new SyncRootSuggestModal(
+								this.app,
+								categories.filter((category) => !selected.has(category._id)),
+								(category) => {
+									this.plugin.settings.syncRoots.push({
+										id: category._id,
+										title: categoryDisplayPath(category, categories),
+									});
+									void this.plugin.saveSettings()
+										.then(() => this.display())
+										.catch((error) => {
+											console.error(
+												"Could not save Amazing Marvin import root:",
+												error,
+											);
+											new Notice("Could not save the import root.");
+										});
+								},
+							).open();
+						} catch (error) {
+							console.error("Could not load Amazing Marvin import roots:", error);
+							new Notice("Could not load Amazing Marvin categories and projects.");
+						}
+					})
+				);
+		}
+
+		new Setting(containerEl)
+			.setName("Import Inbox")
+			.setDesc("Update the managed Inbox note independently of category/project selection.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.syncInbox)
+				.onChange(async (value) => {
+					this.plugin.settings.syncInbox = value;
 					await this.plugin.saveSettings();
 				})
 			);


### PR DESCRIPTION
Closes #46

## What changed
- add an all-items or selected-roots import mode with a searchable category/project chooser
- include selected descendants while keeping ancestors as navigation-only structure
- make Inbox import independent and retain every deselected/stale note instead of deleting it
- fail before note mutation for stale IDs, missing parents, or hierarchy cycles
- expose category and child discovery through the shared Obsidian API and companion MCP
- normalize categories without an API type discriminator before consumers build deep links

## Verification
- `npm test` (77 tests)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Needs human verification
- choose nested roots in Obsidian settings and import against a real Marvin hierarchy
- confirm ancestors contain only selected navigation, selected descendants contain tasks, and deselected notes remain untouched
- exercise `marvin_categories` and `marvin_children` against the local and public APIs.