### PR TITLE
Return MCP date errors as structured content

### DIFF
--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -172,6 +172,24 @@ describe("Amazing Marvin MCP", () => {
 		});
 	});
 
+	it("returns malformed dates in the structured error envelope", async () => {
+		const client = await connect(operations());
+
+		const result = await client.callTool({
+			name: "marvin_today",
+			arguments: { date: "not-a-date" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toEqual({
+			error: {
+				kind: "input",
+				field: "date",
+				message: "Use YYYY-MM-DD",
+			},
+		});
+	});
+
 	it("routes create and completion tools through the shared operations", async () => {
 		const calls: unknown[] = [];
 		const client = await connect(operations({

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -21,9 +21,41 @@ export type MarvinOperations = Pick<
 	| "markDone"
 >;
 
-const dateSchema = z.string()
-	.regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD")
-	.optional();
+// Validate dates in the handler rather than the SDK schema path. MCP schema
+// failures are emitted as text-only protocol errors before a tool handler can
+// return the structured error envelope LLM callers rely on.
+const dateSchema = z.string().optional();
+
+class MarvinMcpInputError extends Error {
+	constructor(
+		readonly field: string,
+		message: string,
+	) {
+		super(message);
+		this.name = "MarvinMcpInputError";
+	}
+
+	toSummary() {
+		return {
+			kind: "input",
+			field: this.field,
+			message: this.message,
+		};
+	}
+}
+
+function requireOptionalDate(
+	value: string | undefined,
+	field: string,
+): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		throw new MarvinMcpInputError(field, "Use YYYY-MM-DD");
+	}
+	return value;
+}
 
 function itemForTool(item: MarvinItem) {
 	return {
@@ -72,7 +104,9 @@ function readSuccess(result: MarvinReadResult<MarvinItem[]>) {
 }
 
 function failure(error: unknown) {
-	const details = error instanceof MarvinRouteError
+	const details = error instanceof MarvinMcpInputError
+		? error.toSummary()
+		: error instanceof MarvinRouteError
 		? {
 			message: error.message,
 			attempts: error.attempts.map((attempt) => attempt.toSummary()),
@@ -113,7 +147,9 @@ export function createMarvinMcpServer(
 		},
 	}, async ({ date }) => {
 		try {
-			return readSuccess(await operations.getTodayItems(date));
+			return readSuccess(await operations.getTodayItems(
+				requireOptionalDate(date, "date"),
+			));
 		} catch (error) {
 			return failure(error);
 		}
@@ -131,7 +167,9 @@ export function createMarvinMcpServer(
 		},
 	}, async ({ date }) => {
 		try {
-			return readSuccess(await operations.getDueItems(date));
+			return readSuccess(await operations.getDueItems(
+				requireOptionalDate(date, "date"),
+			));
 		} catch (error) {
 			return failure(error);
 		}
@@ -214,13 +252,15 @@ export function createMarvinMcpServer(
 		},
 	}, async (input) => {
 		try {
+			const day = requireOptionalDate(input.day, "day");
+			const dueDate = requireOptionalDate(input.dueDate, "dueDate");
 			const task = await operations.addTask({
 				title: input.title,
 				timeZoneOffset: new Date().getTimezoneOffset() * -1,
 				...(input.parentId === undefined ? {} : { parentId: input.parentId }),
 				...(input.labelIds === undefined ? {} : { labelIds: input.labelIds }),
-				...(input.day === undefined ? {} : { day: input.day }),
-				...(input.dueDate === undefined ? {} : { dueDate: input.dueDate }),
+				...(day === undefined ? {} : { day }),
+				...(dueDate === undefined ? {} : { dueDate }),
 				...(input.note === undefined ? {} : { note: input.note }),
 				...(input.timeEstimate === undefined ? {} : { timeEstimate: input.timeEstimate }),
 			});

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -24,7 +24,9 @@ export type MarvinOperations = Pick<
 // Validate dates in the handler rather than the SDK schema path. MCP schema
 // failures are emitted as text-only protocol errors before a tool handler can
 // return the structured error envelope LLM callers rely on.
-const dateSchema = z.string().optional();
+const dateSchema = z.string()
+	.describe("Date in YYYY-MM-DD format")
+	.optional();
 
 class MarvinMcpInputError extends Error {
 	constructor(
@@ -139,7 +141,9 @@ export function createMarvinMcpServer(
 		title: "Amazing Marvin Today",
 		description: "Read tasks and projects scheduled for a date in Amazing Marvin.",
 		inputSchema: {
-			date: dateSchema.describe("Optional date; defaults to Marvin's server date"),
+			date: dateSchema.describe(
+				"Optional YYYY-MM-DD date; defaults to Marvin's server date",
+			),
 		},
 		annotations: {
 			readOnlyHint: true,
@@ -159,7 +163,9 @@ export function createMarvinMcpServer(
 		title: "Amazing Marvin Due",
 		description: "Read open tasks and projects due on or before a date.",
 		inputSchema: {
-			date: dateSchema.describe("Optional inclusive due date; defaults to Marvin's server date"),
+			date: dateSchema.describe(
+				"Optional inclusive YYYY-MM-DD date; defaults to Marvin's server date",
+			),
 		},
 		annotations: {
 			readOnlyHint: true,


### PR DESCRIPTION
## What changed

- move semantic date validation into MCP tool handlers
- return malformed-date failures as isError: true plus structuredContent.error
- keep YYYY-MM-DD descriptions in the request schema while allowing an LLM caller to consume one uniform error envelope

marvin_categories and marvin_children are already provided by the #61 base branch, so agents can discover valid parent IDs before creating a task.

## Verification

- npm test (79 tests)
- npm run typecheck --workspace @open-horizon/marvin-mcp
- npm run build (verified on the combined #63 tip)

## Needs human verification

- rerun the direct stdio malformed-date check against this stacked tip and confirm both text and structured error fields are present.