### PR TITLE
Add opt-in incremental Marvin import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ data.json
 .DS_Store
 
 dist/**
+packages/*/dist/**

--- a/README.md
+++ b/README.md
@@ -26,9 +26,18 @@ The Obsidian Amazing Marvin Plugin currently supports unidirectional synchroniza
 
 ### Sync Behavior
 
-Each import updates only the Amazing Marvin-managed region in an existing note. Your frontmatter properties and prose before or after that region are preserved. The first import of an older note adopts its recognizable generated category/project or Inbox task section; future imports use explicit markers.
+Each import updates only the Amazing Marvin-managed region in an existing note.
+Custom frontmatter properties and prose before or after that region are
+preserved. The first import of an older note adopts its recognizable generated
+category/project or Inbox task section; future imports use explicit markers.
+The importer also repairs the known malformed legacy list syntax before
+writing native YAML arrays such as `labelIds`.
 
-The managed folder defaults to `AmazingMarvin` and can be changed in plugin settings. Existing imported categories, projects, and Inbox notes are moved by their Marvin ID when possible; empty folders from an earlier location are left in place.
+The managed folder defaults to `AmazingMarvin` and can be changed in plugin
+settings. Existing imported categories, projects, and Inbox notes are moved by
+their Marvin ID when possible; empty folders from an earlier location are left
+in place. Notes for Marvin items no longer returned by the API are also left in
+place rather than deleted automatically.
 
 ### Running a Sync
 
@@ -135,6 +144,7 @@ Now, when you check off a task with an Amazing Marvin Link in an Obsidian note, 
 
 - **Managed regions**: Changes inside an Amazing Marvin-managed category, project, or Inbox region are refreshed on the next import. Keep lasting notes outside the marked region.
 - **Conflicting moves**: If a destination file already exists or multiple notes claim the same Marvin item, import stops rather than overwriting either note.
+- **Recoverable stale notes**: Notes for removed or hidden Marvin items are not automatically deleted. Review and remove them manually.
 
 By following these guidelines, you can ensure your Amazing Marvin data is accurately reflected in Obsidian while being mindful of the plugin's current limitations.
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,66 @@ By following these guidelines, you can ensure your Amazing Marvin data is accura
 3. Run `npm install` to install the dependencies.
 4. Make your desired changes.
 5. Use `npm run dev` to watch for changes and compile the plugin to `dist/main.js`.
+6. Run `npm test` for the shared-client, plugin-adapter, and MCP contract tests.
+7. Run `npm run build` to build the shared client, Obsidian plugin, and MCP server.
 
 For more detailed development instructions, refer to the [sample plugin](https://github.com/obsidianmd/obsidian-sample-plugin) provided by Obsidian.
+
+## Companion MCP server
+
+The repository includes a local stdio MCP server for direct LLM access to
+Amazing Marvin. Marvin-only operations do not need to pass through Obsidian.
+The MCP and plugin use the same typed client, local/public routing, cache, and
+error behavior.
+
+Build it with:
+
+```sh
+npm install
+npm run build
+```
+
+Then configure an MCP host with an absolute path to the generated server:
+
+```json
+{
+  "mcpServers": {
+    "amazing-marvin": {
+      "command": "node",
+      "args": ["/absolute/path/to/obsidian-am/packages/marvin-mcp/dist/server.js"],
+      "env": {
+        "AMAZING_MARVIN_API_TOKEN": "your-limited-api-token",
+        "AMAZING_MARVIN_USE_LOCAL": "true"
+      }
+    }
+  }
+}
+```
+
+`AMAZING_MARVIN_USE_LOCAL` is optional and defaults to `false`. When enabled,
+reads try `http://localhost:12082/api` before the public API. Override the
+origins with `AMAZING_MARVIN_LOCAL_API_URL` and
+`AMAZING_MARVIN_PUBLIC_API_URL`.
+
+The initial tool surface is deliberately small:
+
+- `marvin_today`
+- `marvin_due`
+- `marvin_create_task`
+- `marvin_mark_done`
+
+Read results identify whether data is fresh, cached, or stale. Errors retain
+the attempted local/public origins and throttling details. The server uses the
+limited API token only; it does not use Marvin's full-access CouchDB API.
+
+See
+[`docs/architecture/marvin-client-and-mcp.md`](docs/architecture/marvin-client-and-mcp.md)
+for package boundaries and the #51 extension seam.
 
 ### Testing
 
 While you're testing, you're going to send a lot of requests to the Amazing Marvin API. To avoid hitting the rate limit, you can use the Desktop local API server. See [Desktop Local API Server](https://help.amazingmarvin.com/en/articles/5165191-desktop-local-api-server) for more information. Once setup, you can specify the local API server in the plugin settings.
 
-Note that the `/api/children` endpoint is not available in the local API server, always returning 404. I've followed up with the Amazing Marvin team to see if this can be added.
+The desktop API implements a subset of the public API. Unsupported local read
+endpoints, historically including `/api/children`, fall back to the public
+API. A valid empty local response does not trigger fallback.

--- a/README.md
+++ b/README.md
@@ -26,20 +26,19 @@ The Obsidian Amazing Marvin Plugin currently supports unidirectional synchroniza
 
 ### Sync Behavior
 
-Each sync operation performs a fresh import:
+Each import updates only the Amazing Marvin-managed region in an existing note. Your frontmatter properties and prose before or after that region are preserved. The first import of an older note adopts its recognizable generated category/project or Inbox task section; future imports use explicit markers.
 
-- The plugin first removes the existing category/project notes and folders that were previously synchronized.
-- It then creates new notes and folders based on the latest data from Amazing Marvin.
+The managed folder defaults to `AmazingMarvin` and can be changed in plugin settings. Existing imported categories, projects, and Inbox notes are moved by their Marvin ID when possible; empty folders from an earlier location are left in place.
 
 ### Running a Sync
 
 To initiate a sync:
 
 1. Open Obsidian's Command Palette with `Ctrl/Cmd + P`.
-2. Search for and select the command `Sync Amazing Marvin categories and projects`.
+2. Search for and select `Import categories and tasks`.
 3. The plugin will then proceed to update your Obsidian vault with the current structure and content from Amazing Marvin.
 
-Once synced, your Obsidian vault will contain a new `AmazingMarvin` folder. Inside, you'll find the structured notes corresponding to your categories and projects from Amazing Marvin.
+Once imported, your Obsidian vault will contain the configured managed folder. Inside, you'll find the structured notes corresponding to your categories and projects from Amazing Marvin.
 
 ### Creating a Marvin Task
 
@@ -134,8 +133,8 @@ Now, when you check off a task with an Amazing Marvin Link in an Obsidian note, 
 
 ### Important Considerations
 
-- **Data Loss**: Be cautious when editing Amazing Marvin-generated notes in Obsidian, as these changes will be overwritten by the next sync.
-- **Backup Recommended**: It's advisable to back up your Obsidian vault before running the sync, especially if you've made local modifications to the synchronized notes.
+- **Managed regions**: Changes inside an Amazing Marvin-managed category, project, or Inbox region are refreshed on the next import. Keep lasting notes outside the marked region.
+- **Conflicting moves**: If a destination file already exists or multiple notes claim the same Marvin item, import stops rather than overwriting either note.
 
 By following these guidelines, you can ensure your Amazing Marvin data is accurately reflected in Obsidian while being mindful of the plugin's current limitations.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,39 @@ ancestor tasks are excluded. Inbox import is controlled independently. An
 empty selected-root list intentionally imports no category/project notes, and
 changing the selection never deletes notes from an earlier import.
 
+### Experimental incremental import
+
+The default importer continues to use the limited-token REST API. An opt-in
+incremental mode uses the separate `databaseUri`, `databaseUser`, and
+`databasePassword` values from Marvin's API settings. They are stored with this
+plugin's Obsidian settings, sent only to the configured database, and never
+exposed through the companion MCP. Obsidian may sync plugin settings according
+to the user's Sync configuration. Credential-bearing database URIs and
+non-HTTPS remote URIs are rejected.
+
+On first use, the plugin checkpoints the CouchDB changes feed, hydrates a fresh
+category/children snapshot through a dedicated uncached REST router, and
+catches up from that exact opaque checkpoint. The resulting cache is persisted as
+`marvin-incremental-cache-v1.json` in the plugin directory. Later long-poll
+catch-ups coalesce replayed changes and update only affected managed notes.
+Category moves also target descendants whose paths changed; deleted or
+deselected item notes remain recoverable.
+
+The cache contains Marvin task and category data, so protect the vault and its
+backups as you would the Marvin account.
+
+The checkpoint is saved with a pending-projection marker. If a vault write
+fails or Obsidian exits after the checkpoint advances, the next run performs a
+safe full projection before acknowledging it. Connection failures use bounded
+exponential backoff with no hidden request retries. A manual import falls back
+to REST if the experimental path cannot connect, and settings show the last
+successful catch-up or recoverable error. Use **Reset cache** to force a fresh
+hydration.
+
+See [Amazing Marvin database access](https://github.com/amazingmarvin/MarvinAPI/wiki/Database-Access)
+and [CouchDB `_changes`](https://docs.couchdb.org/en/stable/api/database/changes.html)
+for the upstream credential and checkpoint contracts.
+
 ### Running a Sync
 
 To initiate a sync:

--- a/README.md
+++ b/README.md
@@ -124,9 +124,28 @@ Additional object-returning methods are available for automation:
 - `getToday(date)`
 - `getDue(date)`
 - `getTodayAndDue(date)`
+- `getLabels()`
 - `createTask(task)`
 - `ensureTaskForSource(input)`
 - `refreshTodayTasks(input)`
+
+### Task formatting and labels
+
+The default projection remains the existing Dataview format. In settings,
+tasks can instead use Obsidian Tasks' Dataview fields or emoji date format.
+Tasks-compatible presets always put the readable title first; the current
+Dataview preset has a separate title-first option.
+
+Dataview date links use a configurable Moment format. For example,
+`YYYY-[W]WW` renders `2026-07-23` as `[[2026-W30|2026-07-23]]`, which lets a
+daily date alias resolve to a weekly note. An optional task tag supports an
+Obsidian Tasks global filter.
+
+Marvin labels can be projected as namespaced Obsidian tags such as
+`#marvin/Knowledge-work`. Label IDs are resolved through the limited `/labels`
+API and cached for an hour; unknown IDs are not exposed as opaque tags. If
+labels are enabled and cannot be read or recovered from the stale cache, the
+managed projection is left unchanged rather than silently removing tags.
 
 ### Auto-Mark as Done Feature
 
@@ -225,12 +244,15 @@ The initial tool surface is deliberately small:
 
 - `marvin_today`
 - `marvin_due`
+- `marvin_labels`
 - `marvin_create_task`
 - `marvin_mark_done`
 
 Read results identify whether data is fresh, cached, or stale. Errors retain
 the attempted local/public origins and throttling details. The server uses the
 limited API token only; it does not use Marvin's full-access CouchDB API.
+`marvin_create_task` accepts the stable label IDs returned by
+`marvin_labels`.
 
 The MCP owns Marvin-only operations and does not edit an Obsidian vault.
 Cross-system operations that must atomically persist a source/action

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ their Marvin ID when possible; empty folders from an earlier location are left
 in place. Notes for Marvin items no longer returned by the API are also left in
 place rather than deleted automatically.
 
+Imports can include all categories/projects or selected roots. A selected root
+includes all descendants; its ancestors remain as navigation-only notes so the
+Marvin hierarchy and backlinks stay intact, while sibling branches and
+ancestor tasks are excluded. Inbox import is controlled independently. An
+empty selected-root list intentionally imports no category/project notes, and
+changing the selection never deletes notes from an earlier import.
+
 ### Running a Sync
 
 To initiate a sync:
@@ -124,6 +131,8 @@ Additional object-returning methods are available for automation:
 - `getToday(date)`
 - `getDue(date)`
 - `getTodayAndDue(date)`
+- `getCategories()`
+- `getChildren(parentId)`
 - `getLabels()`
 - `createTask(task)`
 - `ensureTaskForSource(input)`
@@ -244,6 +253,8 @@ The initial tool surface is deliberately small:
 
 - `marvin_today`
 - `marvin_due`
+- `marvin_categories`
+- `marvin_children`
 - `marvin_labels`
 - `marvin_create_task`
 - `marvin_mark_done`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The Amazing Marvin Plugin provides a way to bring your tasks and project structu
 - **Categories and Projects are folder notes**: Categories and projects are created as folder notes, compatible with [Obsidian folder notes](https://github.com/LostPaul/obsidian-folder-notes).
 - **Task Creation**: Users can create Amazing Marvin tasks directly within Obsidian, with support for standard Marvin shorthand notations like `+` for dates or `@` for labels.
 - **Deep Linking**: Each task and category is equipped with a deep link, providing quick navigation back to Amazing Marvin.
+- **Refreshable Daily Notes**: A bounded Today region keeps scheduled and due tasks current without rerunning the full daily-note template or overwriting surrounding prose.
+- **Automation API**: Templater, in-Obsidian agents, and other plugins can use the same typed operations as the UI, including idempotent source/action task creation.
 
 ## Usage Instructions
 
@@ -46,7 +48,11 @@ The task creation dialog is designed to mirror the task input experience in Amaz
 - Autocomplete for Categories and Projects using `#` syntax or a search sub-dialog.
 - Recognizes shorthand notations for properties like start date (`~`), due date (`@`), and labels (`+`).
 - Places a link to the Marvin task as a deep link in Obsidian at the cursor location upon task creation.
-- The created Marvin task contains an Advanced URI-friendly link back to the Obsidian note that instigated the task.
+- The created Marvin task links back to the Obsidian note that instigated the task.
+- The source note records the Marvin task ID and deep link in its
+  `amazing-marvin-actions` frontmatter property.
+- The link can use either Advanced URI (the default, for the Advanced URI
+  community plugin) or Obsidian's standard URI format.
 
 To create a task:
 
@@ -54,6 +60,65 @@ To create a task:
 2. Search for and select the command `Create Marvin Task`.
 3. Input the task details and select the appropriate category from the dropdown, which shows suggestions as you type.
 4. Upon task creation, a markdown checklist item with a link to the Marvin task is inserted at your cursor location in Obsidian.
+
+### Keeping Today's Tasks Current
+
+Run `Amazing Marvin: Refresh today's tasks` from a daily note. On the first
+run, the plugin adopts existing Marvin checklist entries under
+`## Today's tasks` as the morning set and surrounds only the generated task
+content with managed HTML-comment markers. It never rewrites content outside
+those markers.
+
+Later scheduled and due tasks appear under `### Added since morning`. Results
+are deduplicated by Marvin task ID, completion state is rerendered from Marvin,
+and a successful empty response remains visibly distinct from a fetch failure.
+A failed fetch leaves the existing note untouched.
+
+Once a note has a managed region, the plugin can refresh it on startup, when
+Obsidian regains focus, and at the configured interval. Automatic refresh does
+not initialize or adopt an unmarked note; run the command once (or use the API
+below) to establish the boundary.
+
+### Templater and In-Obsidian Automation
+
+The plugin exposes a stable object API at
+`app.plugins.plugins["cloudatlas-o-am"].api`. For example:
+
+```js
+const marvin = app.plugins.plugins["cloudatlas-o-am"].api;
+const sourcePath = tp.file.path(true);
+
+await marvin.ensureTaskForSource({
+  sourcePath,
+  actionKey: "decide-whether-to-pursue",
+  title: "Decide whether to pursue Titan AI",
+  day: tp.date.now("YYYY-MM-DD"),
+});
+
+await marvin.refreshTodayTasks({
+  date: tp.date.now("YYYY-MM-DD"),
+  filePath: tp.file.path(true),
+});
+```
+
+`actionKey` is a caller-owned stable identity for one action in one source
+note. Do not derive it from the mutable task title. Repeating the same
+`sourcePath` and `actionKey` returns the existing Marvin association.
+
+The API writes a pending source association before creating the Marvin task.
+If a connection drops at an ambiguous point, a repeat is stopped rather than
+silently creating a duplicate. After inspecting Marvin, callers can use
+`resolvePendingSourceAction({ sourcePath, actionKey, taskId })` or explicitly
+`clearPendingSourceAction({ sourcePath, actionKey })`.
+
+Additional object-returning methods are available for automation:
+
+- `getToday(date)`
+- `getDue(date)`
+- `getTodayAndDue(date)`
+- `createTask(task)`
+- `ensureTaskForSource(input)`
+- `refreshTodayTasks(input)`
 
 ### Auto-Mark as Done Feature
 
@@ -157,6 +222,12 @@ The initial tool surface is deliberately small:
 Read results identify whether data is fresh, cached, or stale. Errors retain
 the attempted local/public origins and throttling details. The server uses the
 limited API token only; it does not use Marvin's full-access CouchDB API.
+
+The MCP owns Marvin-only operations and does not edit an Obsidian vault.
+Cross-system operations that must atomically persist a source/action
+association and update a managed note region use the plugin API above. Both
+paths share the Marvin client, and the source/action state machine itself
+lives in that shared package rather than in prompt instructions.
 
 See
 [`docs/architecture/marvin-client-and-mcp.md`](docs/architecture/marvin-client-and-mcp.md)

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -6,8 +6,8 @@ allow a later split without making separate repositories a prerequisite.
 
 | Layer | Owns | Does not own |
 | --- | --- | --- |
-| `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links | Obsidian vault/UI behavior; MCP schemas; source-note identity |
-| `src/marvin` | Obsidian `requestUrl` transport adapter | HTTP/API semantics, cache policy, or fallback decisions |
+| `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links; source/action state machine | Obsidian vault/UI behavior; MCP schemas; source-note storage |
+| `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection | HTTP/API semantics, cache policy, or fallback decisions |
 | Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
 | `packages/marvin-mcp` | Stdio lifecycle, four tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
 
@@ -26,19 +26,27 @@ errors are never cached as empty results. Stale-on-error responses are marked
 `freshness: "stale"` and carry the current failure. Task creation and
 completion invalidate today, due, and children entries.
 
-## Extension seam for #51
+## Source/action and Today projection
 
-The next layer should add deterministic integration operations above this
-client:
+`SourceActionService` persists a pending association before calling Marvin.
+Ambiguous transport, 5xx, or invalid-success responses retain that pending
+record, so an unattended retry cannot create another task. Definite 4xx
+rejections clear the pending state. A successful write promotes it to a linked
+record containing the Marvin task ID and deep link.
 
-- ensure one Marvin task for a stable Obsidian source/action key;
-- persist the resulting Marvin ID/deep link back to the source note; and
-- refresh a bounded daily-note region by stable Marvin ID without overwriting
-  surrounding prose.
+The Obsidian adapter stores those records in the source note's
+`amazing-marvin-actions` frontmatter property. Daily-note refresh reads the
+linked task IDs to render a source wikilink when one exists. Tasks created
+directly in Marvin render normally without a synthetic source note.
 
-That source/action identity is not a task title and does not belong in MCP
-prompt text. The Obsidian projection remains responsible for note mutation;
-the shared client remains responsible for Marvin state and explicit failures.
+The managed Today region stores its initial morning IDs in a versioned HTML
+comment. Refresh atomically replaces only that region against the latest note
+contents; new IDs render below the morning list, and content outside the
+markers is preserved.
+
+Source/action identity is not a task title and does not belong in MCP prompt
+text. The Obsidian projection remains responsible for note mutation; the
+shared client remains responsible for Marvin state and explicit failures.
 
 ## Upstream and security boundary
 

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -7,7 +7,7 @@ allow a later split without making separate repositories a prerequisite.
 | Layer | Owns | Does not own |
 | --- | --- | --- |
 | `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links; source/action state machine | Obsidian vault/UI behavior; MCP schemas; source-note storage |
-| `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection | HTTP/API semantics, cache policy, or fallback decisions |
+| `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection; non-destructive category/project projection | HTTP/API semantics, cache policy, or fallback decisions |
 | Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
 | `packages/marvin-mcp` | Stdio lifecycle, four tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
 
@@ -43,6 +43,13 @@ The managed Today region stores its initial morning IDs in a versioned HTML
 comment. Refresh atomically replaces only that region against the latest note
 contents; new IDs render below the morning list, and content outside the
 markers is preserved.
+
+Category, project, and Inbox imports use a separate managed marker. Stable
+Marvin IDs locate notes when their generated path or configured root changes.
+Frontmatter updates are property-scoped, and the importer repairs the older
+malformed list representation before asking Obsidian to parse and rewrite it.
+Removed Marvin items are not inferred to be safe deletions, so their notes
+remain recoverable.
 
 Source/action identity is not a task title and does not belong in MCP prompt
 text. The Obsidian projection remains responsible for note mutation; the

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -1,0 +1,52 @@
+# Marvin client and MCP boundaries
+
+The Amazing Marvin client and first MCP server intentionally live in this
+repository while the integration has two consumers. Their package boundaries
+allow a later split without making separate repositories a prerequisite.
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links | Obsidian vault/UI behavior; MCP schemas; source-note identity |
+| `src/marvin` | Obsidian `requestUrl` transport adapter | HTTP/API semantics, cache policy, or fallback decisions |
+| Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
+| `packages/marvin-mcp` | Stdio lifecycle, four tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
+
+Both runtime adapters construct `MarvinApiClient` instances and one
+`MarvinRouter`. Writes use the public API only. Safe reads may use the desktop
+API when explicitly enabled, then fall back only when the local endpoint is
+unavailable or unsupported.
+
+The Node fetch transport enforces request timeouts with cancellation.
+Obsidian's `requestUrl` API does not expose cancellation, so its timeout value
+is advisory at that adapter boundary. Neither adapter retries automatically;
+live Obsidian verification should include a stalled or unreachable endpoint.
+
+The router caches successful reads in memory. Empty arrays are successful data;
+errors are never cached as empty results. Stale-on-error responses are marked
+`freshness: "stale"` and carry the current failure. Task creation and
+completion invalidate today, due, and children entries.
+
+## Extension seam for #51
+
+The next layer should add deterministic integration operations above this
+client:
+
+- ensure one Marvin task for a stable Obsidian source/action key;
+- persist the resulting Marvin ID/deep link back to the source note; and
+- refresh a bounded daily-note region by stable Marvin ID without overwriting
+  surrounding prose.
+
+That source/action identity is not a task title and does not belong in MCP
+prompt text. The Obsidian projection remains responsible for note mutation;
+the shared client remains responsible for Marvin state and explicit failures.
+
+## Upstream and security boundary
+
+The client is an internal fork of
+[`@jacobboykin/amazing-marvin-client` v1.1.1](https://github.com/jacobboykin/amazing-marvin-client-js/tree/1f04630374c5ec9c3ff08e847dad96e8ad62fae9).
+Its provenance and MIT license are retained in
+`packages/marvin-client/UPSTREAM.md` and
+`packages/marvin-client/LICENSE.upstream`.
+
+Only Amazing Marvin's limited `X-API-Token` endpoints are in scope. Full-access
+CouchDB operations are intentionally absent.

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -37,6 +37,27 @@ Selective import remains a plugin projection concern: selected roots include
 descendants, ancestors are structure-only, and deselection never authorizes
 note deletion.
 
+## Incremental cache trust boundary
+
+The optional CouchDB path is intentionally outside `packages/marvin-client`
+and `packages/marvin-mcp`. It uses separate full-database credentials in the
+Obsidian adapter only; the limited-token client remains the hydration source,
+manual fallback, and only Marvin credential surface available to MCP.
+
+Hydration captures a CouchDB checkpoint before reading the REST snapshot through
+a dedicated uncached router, then applies `_changes` from that opaque sequence
+so neither an older memory-cache entry nor an edit during hydration creates a
+gap. Cache updates are idempotent by document revision, checkpoint every bounded
+page, and persist `projectionPending` until all affected managed notes write
+successfully. On restart, a pending projection forces a safe full projection
+even when the feed has no new results.
+
+Task changes target their old/new parent notes or Inbox. Category changes also
+target old/new parents and descendants whose generated paths may change.
+Physical/trash deletion removes cache entries and parent links but does not
+authorize deleting the item's Obsidian note. A serialized projection queue
+prevents manual and automatic imports from racing path moves.
+
 ## Source/action and Today projection
 
 `SourceActionService` persists a pending association before calling Marvin.

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -9,7 +9,7 @@ allow a later split without making separate repositories a prerequisite.
 | `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links; source/action state machine | Obsidian vault/UI behavior; MCP schemas; source-note storage |
 | `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection; non-destructive category/project projection | HTTP/API semantics, cache policy, or fallback decisions |
 | Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
-| `packages/marvin-mcp` | Stdio lifecycle, five tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
+| `packages/marvin-mcp` | Stdio lifecycle, seven tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
 
 Both runtime adapters construct `MarvinApiClient` instances and one
 `MarvinRouter`. Writes use the public API only. Safe reads may use the desktop
@@ -30,6 +30,12 @@ The stable label list uses the same local-first route and a longer bounded
 cache. The plugin resolves task `labelIds` to namespaced Obsidian tags, while
 the MCP exposes the same IDs to `marvin_create_task`; neither consumer
 reimplements label API behavior.
+
+Category and child reads are also exposed through the MCP and Obsidian object
+API. This lets an agent discover stable parent IDs instead of guessing them.
+Selective import remains a plugin projection concern: selected roots include
+descendants, ancestors are structure-only, and deselection never authorizes
+note deletion.
 
 ## Source/action and Today projection
 

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -9,7 +9,7 @@ allow a later split without making separate repositories a prerequisite.
 | `packages/marvin-client` | Limited-token endpoint models; request/error contract; Node fetch transport; local-first read routing; bounded cache; throttle circuit; stable-ID deduplication; Marvin deep links; source/action state machine | Obsidian vault/UI behavior; MCP schemas; source-note storage |
 | `src/marvin` | Obsidian `requestUrl` transport adapter; source-action frontmatter adapter; bounded Today projection; non-destructive category/project projection | HTTP/API semantics, cache policy, or fallback decisions |
 | Obsidian plugin | Commands, notices, task rendering, vault/editor changes, Obsidian links | A second Marvin API client |
-| `packages/marvin-mcp` | Stdio lifecycle, four tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
+| `packages/marvin-mcp` | Stdio lifecycle, five tool schemas, tool-facing result/error presentation | A second Marvin API client; Obsidian access; generic LLM orchestration |
 
 Both runtime adapters construct `MarvinApiClient` instances and one
 `MarvinRouter`. Writes use the public API only. Safe reads may use the desktop
@@ -25,6 +25,11 @@ The router caches successful reads in memory. Empty arrays are successful data;
 errors are never cached as empty results. Stale-on-error responses are marked
 `freshness: "stale"` and carry the current failure. Task creation and
 completion invalidate today, due, and children entries.
+
+The stable label list uses the same local-first route and a longer bounded
+cache. The plugin resolves task `labelIds` to namespaced Obsidian tags, while
+the MCP exposes the same IDs to `marvin_create_task`; neither consumer
+reimplements label API behavior.
 
 ## Source/action and Today projection
 

--- a/docs/evaluations/0053-amazing-marvin-client.md
+++ b/docs/evaluations/0053-amazing-marvin-client.md
@@ -1,0 +1,240 @@
+# Amazing Marvin client, routing, and cache evaluation
+
+Issue: [#53](https://github.com/open-horizon-labs/obsidian-am/issues/53)
+
+Supports: [#52](https://github.com/open-horizon-labs/obsidian-am/issues/52) and [#51](https://github.com/open-horizon-labs/obsidian-am/issues/51)
+
+Evaluated: 2026-07-23
+
+## Decision
+
+Fork and extend
+[`@jacobboykin/amazing-marvin-client` v1.1.1](https://github.com/jacobboykin/amazing-marvin-client-js/tree/1f04630374c5ec9c3ff08e847dad96e8ad62fae9)
+inside this repository for #52. Preserve its MIT attribution and useful endpoint
+models, but do not take a runtime dependency on the published package.
+
+This should initially be an internal fork, co-located with the plugin and MCP
+as already planned in #52. It can move to a dedicated repository/package later
+if another consumer makes that useful.
+
+The current plugin is more complete in product-specific behavior: it uses
+Obsidian's transport, attempts local-desktop reads before public API reads,
+adds deep links, and presents human-facing throttle failures. The candidate is
+more complete in API breadth, typed models, structured HTTP errors, timeouts,
+and tests. The fork should combine those strengths.
+
+Direct adoption is not viable:
+
+- The package export map exposes only `require`. Native Node ESM import fails
+  with `ERR_PACKAGE_PATH_NOT_EXPORTED`, and the plugin's esbuild import fails
+  because no `browser`, `import`, `module`, or `default` condition exists.
+- Its default three retries mean four public requests for a single 429 or
+  retryable failure. The 65-test suite takes about 70 seconds because error
+  cases exercise those real backoff delays.
+- It has no local-to-public routing or cache.
+- It discards error response bodies and models only one origin per client.
+- The project was created in September 2025, contains seven commits and two
+  releases over two days, has one star and no issue history, and has had no
+  push since 2025-09-14. Its source is useful; its maintenance cadence is not a
+  dependency boundary to rely on.
+
+The upstream code is preferable to a clean-room rewrite because its limited
+token endpoint coverage, types, retry/error tests, and dependency-free runtime
+are substantial reusable work. Forking lets us correct the infrastructure
+policy and packaging in one code line.
+
+### Other JavaScript options screened
+
+| Option | Useful material | Why it is not the shared client |
+| --- | --- | --- |
+| [`@pipedream/amazing_marvin`](https://www.npmjs.com/package/@pipedream/amazing_marvin) | Maintained integration actions and endpoint examples | Pipedream component boundary, not a reusable typed client |
+| [Amazing Marvin browser-extension helpers](https://github.com/amazingmarvin/amazingmarvin-browserextension/blob/master/src/utils/api.js) | Official request behavior and endpoint examples | Coupled to extension storage, background messaging, and UI workflows |
+| [`amazing-marvin-mcp-server`](https://www.npmjs.com/package/amazing-marvin-mcp-server) | MCP tool naming and API-reference material | MCP implementation rather than a shared plugin/MCP client; does not supply our local routing or #51 identity semantics |
+| Current plugin client code | Proven Obsidian transport, local-first intent, links, and notices | Embedded in `src/main.ts`, weak error boundary, no cache/tests, and only a small endpoint subset |
+
+These remain references for fork tests and API behavior. None changes the
+decision to own one in-repository fork rather than stack adapters around
+multiple libraries.
+
+## Evidence
+
+The candidate was checked out at
+[`1f04630`](https://github.com/jacobboykin/amazing-marvin-client-js/commit/1f04630374c5ec9c3ff08e847dad96e8ad62fae9).
+
+- `npm test -- --run`: 65/65 tests passed in 70.24 seconds.
+- `npm run test:coverage`: 94.75% statement/line coverage and 85.18%
+  branch coverage for `src/client.ts`.
+- `npm run typecheck:all`, `npm run lint`, and `npm run build`: passed.
+- A fresh `npm pack @jacobboykin/amazing-marvin-client@1.1.1` was
+  file-for-file identical to a package built from the tagged source.
+- CommonJS `require()` worked.
+- Native Node ESM import failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+- The same TypeScript-style import failed under this plugin's esbuild
+  configuration because the export map has no matching condition.
+- The tests use injected mock `fetch` implementations. They provide strong
+  unit coverage, but the files named "integration" and "workflows" are not live
+  Marvin contract tests.
+- The package has no runtime dependencies and is MIT licensed. Its larger
+  dependency tree is development tooling only.
+
+The official API documentation confirms:
+
+- `todayItems` uses `?date=YYYY-MM-DD` or `X-Date`;
+- `dueItems` uses `?by=YYYY-MM-DD`;
+- `children` is experimental and returns open children;
+- the minimal `addTask` example sends only a title; and
+- `markDone` is experimental and has incomplete Marvin feature parity.
+
+Sources:
+[official Marvin API wiki](https://github.com/amazingmarvin/MarvinAPI/wiki/Marvin-API),
+[official API changelog](https://github.com/amazingmarvin/MarvinAPI/blob/5ca43bfd7ed23aa1956e00f9e5f555fe6240510a/CHANGELOG.md),
+[desktop local API documentation](https://help.amazingmarvin.com/en/articles/5165191-desktop-local-api-server).
+
+## Feature and reliability matrix
+
+| Concern | Current plugin | Candidate v1.1.1 | Required fork behavior |
+| --- | --- | --- | --- |
+| Today items | Works with `date`; untyped transport result | Typed `getTodayItems(date)`, query plus header | Retain typed method; normalize and encode date once |
+| Due items | Sends unsupported `date` query | Correctly sends documented `by` query | Use `by`; add a contract test so #51 gets the requested day |
+| Categories | Public or attempted-local GET | Typed categories/projects | Retain types and stable IDs |
+| Children | Public fallback exists; README records local 404 | Typed method against one base URL | Route local first only when enabled; treat 404 as endpoint-specific fallback |
+| Add task | Public-only; adds Obsidian note link and timezone offset | Typed, configurable base URL, autocomplete header | Keep integration-specific link construction outside HTTP core; public-only until local write support is proven |
+| Mark done | Public-only; user notices; some errors are swallowed | Typed request/error, but assumes response shape | Keep explicit errors and public-only default; contract-test the response |
+| IDs and types | Small task/category interfaces plus deep links | Broad limited-token models | Seed from candidate; narrow/verify fields used by #51/#52; do not imply runtime validation |
+| Empty vs. error | `fetchTasksAndCategories` converts every failure to `[]` | Successful empty array is distinct from thrown `MarvinError` | Preserve this distinction through plugin and MCP result envelopes |
+| Timeout | Delegated to `requestUrl`; no explicit policy | 10 seconds per attempt using `AbortController` | One deadline per operation; transport reports whether cancellation is supported |
+| 429 | No automatic retry; some operations show a notice | Retries 3 times by default, honors `Retry-After` | Default to zero retries; expose retry time and open a short public-origin circuit |
+| Other retries | None | Retries network and 5xx with uncapped, non-jittered exponential delay | Router may opt into one jittered retry for idempotent public GETs only; never retry writes automatically |
+| Error detail | String/console/notice; later failure overwrites local detail | Status, method, endpoint, timestamp; response body discarded | Preserve origin, status, response detail, cause, retry-after, and every attempted origin |
+| Local routing | Intended local-first, but currently contacts local even when disabled | One base URL per instance | Correct setting gate; valid empty local result stops routing; fallback only for unavailable/unsupported local reads |
+| Cache | None | None | Credential-scoped bounded memory cache with explicit freshness metadata |
+| Test quality | No test command or transport tests | 65 mocked tests; high unit coverage; no live contract test | Keep unit suite; add routing/cache, packaging, adapter-contract, and optional live smoke tests |
+| Obsidian runtime | Works through `requestUrl` | Published import cannot be bundled | Dual ESM/CJS exports plus an Obsidian transport adapter and bundle smoke test |
+| MCP/Node runtime | Not available | `require` works; native ESM import fails | Native ESM entry point and Node fetch transport; same client contract as plugin |
+| Dependencies/license | Existing plugin dependencies; MIT | Zero runtime dependencies; MIT | Preserve zero or near-zero runtime footprint and upstream attribution |
+| Maintenance | Product code is ours but API access is embedded in `main.ts` | Brief release history and no ongoing activity | Own releases/tests in this repository; upstream can remain a reference |
+
+Two current-plugin defects should be corrected while #52 migrates callers:
+
+1. `fetchMarvinData` performs the local request before checking
+   `useLocalServer`. When disabled, a successful local result is then ignored
+   and the public API is called too.
+2. `getDueTasks` uses `?date=`, but the documented parameter is `?by=`.
+
+The current `Set` union of due and scheduled results also deduplicates by
+JavaScript object identity, not Marvin `_id`; #52 already requires stable-ID
+deduplication.
+
+## Routing policy
+
+The executable decision prototype is
+[`evaluations/issue-53/local-first-router.test.mjs`](../../evaluations/issue-53/local-first-router.test.mjs).
+Run it with:
+
+```sh
+node --test evaluations/issue-53/local-first-router.test.mjs
+```
+
+The production router should follow these rules:
+
+1. Only safe reads are local-first. Writes remain public-only until a local
+   endpoint is explicitly verified.
+2. If local use is disabled, do not contact localhost.
+3. A valid local response, including `[]`, is success and stops routing.
+4. Fall back for local connection/timeout failures and unsupported/unavailable
+   statuses such as 404, 405, 501, and transient 5xx.
+5. Do not turn local 400/401/403/429 responses into a public request. Those are
+   request, credential, permission, or throttle signals, not evidence that an
+   endpoint is missing.
+6. On public fallback success, return `origin: "public"` plus diagnostic
+   metadata about the local failure.
+7. If both origins fail, throw one structured error containing both attempts.
+   Never replace it with an empty list.
+
+Fallback eligibility belongs to endpoint/origin policy, not a blanket
+`catch { try public }`.
+
+## Cache and throttle policy
+
+Use a credential-scoped, in-memory LRU cache. A cache instance belongs to one
+configured client, so tokens never appear in cache keys. Recreate or clear it
+when credentials or local-origin settings change. Within that instance, key
+entries by operation plus canonical arguments (for example
+`todayItems:2026-07-23` or `children:unassigned`).
+
+| Read | Key arguments | Fresh TTL | Stale-if-error window |
+| --- | --- | ---: | ---: |
+| Today items | normalized date | 30 seconds | 10 minutes |
+| Due items | normalized `by` date | 30 seconds | 10 minutes |
+| Children | parent ID | 60 seconds | 15 minutes |
+| Categories | none | 5 minutes | 60 minutes |
+
+Additional rules:
+
+- Maximum 128 entries and coalesce concurrent reads for the same key.
+- Cache only successful, schema-valid reads. A successful empty array may be
+  cached; an error may not.
+- Return `{ data, freshness, origin, fetchedAt, ageMs, warnings }`, where
+  `freshness` is `fresh`, `cached`, or `stale`.
+- Return stale data only after a transient network, timeout, 429, or 5xx
+  failure. Never return stale data for authentication, permission, validation,
+  or malformed-response failures.
+- A stale result must carry the current failure as a warning. Callers decide
+  whether stale is acceptable; it is never presented as fresh.
+- `addTask` invalidates today, due, and affected children entries because
+  title autocomplete can alter scheduling/parentage.
+- `markDone` invalidates today, due, and children entries. With only 128
+  entries, invalidating all task-list reads is simpler and safer than keeping a
+  reverse membership index.
+- Do not retry 429 in the request loop. Record `Retry-After` as
+  `publicBlockedUntil`, serve explicit stale data when allowed, or return an
+  actionable throttle error without contacting public again during that
+  interval.
+- Automatic retries default to zero. If later evidence justifies it, allow at
+  most one jittered retry for idempotent public GETs on network/5xx failures.
+  Never automatically retry `addTask`.
+
+## Minimal fork delta for #52
+
+1. Seed an internal `packages/marvin-client` from upstream v1.1.1 with license
+   and provenance, exposing dual ESM/CJS entry points.
+2. Replace the hard `typeof fetch` assumption with the shared request/response
+   transport contract needed by both an Obsidian `requestUrl` adapter and a
+   Node fetch adapter. Make timeout/cancellation capability explicit.
+3. Change retry defaults to zero, preserve response bodies and causes in
+   errors, bound any delay, and add origin/attempt metadata at the router.
+4. Add the local-first read router and bounded cache above the typed endpoint
+   client. Keep writes public-only initially.
+5. Correct/encode query parameters, especially `dueItems?by=`, and relax or
+   default request fields where the official minimal request permits them.
+6. Add package smoke tests for native Node ESM and the plugin's esbuild,
+   adapter contract tests, routing/cache tests, and a token-gated live smoke
+   test that is not required in normal CI.
+7. Migrate the plugin and first MCP tools to the same client contract. Keep
+   deep-link rendering, Obsidian note mutation, and #51 source/action identity
+   above the HTTP/router layer.
+
+Estimated follow-up scope is three small implementation slices: about half a
+day for fork provenance/packaging, one day for transport/routing/cache and
+tests, and one to two days to migrate the plugin and add the first MCP vertical
+slice. No separate architecture spike is warranted.
+
+## Verification still required during #52
+
+This evaluation did not use a live Marvin token or running desktop API. The
+official contract, current plugin behavior, and candidate mock suite are enough
+to choose the code boundary, but #52 should use a token-gated smoke test to
+confirm actual response shapes for `addTask` and `markDone` and record which
+read endpoints the current desktop release supports.
+
+The initial TTLs and stale windows are policy defaults, not measured truths.
+Expose cache/throttle diagnostics so real plugin and MCP use can shorten or
+lengthen them without changing result semantics.
+
+## Exit test
+
+This decision should be revisited only if the fork starts accumulating API
+surface unrelated to actual plugin/MCP consumers, or if Amazing Marvin
+publishes an actively maintained official limited-token client with compatible
+routing hooks. Until then, the fork gives #52 one owned client contract without
+reimplementing the candidate's useful work or inheriting its release defects.

--- a/evaluations/issue-53/local-first-router.test.mjs
+++ b/evaluations/issue-53/local-first-router.test.mjs
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const FALLBACK_STATUSES = new Set([0, 404, 405, 500, 501, 502, 503, 504]);
+
+class RouteError extends AggregateError {
+	constructor(operation, attempts) {
+		super(
+			attempts.map(({ error }) => error),
+			`Amazing Marvin ${operation} failed via ${attempts
+				.map(({ origin }) => origin)
+				.join(" then ")}`,
+		);
+		this.name = "RouteError";
+		this.operation = operation;
+		this.attempts = attempts;
+	}
+}
+
+function asAttempt(origin, error) {
+	return {
+		origin,
+		error:
+			error instanceof Error
+				? error
+				: Object.assign(new Error(String(error.message ?? error)), error),
+	};
+}
+
+function mayTryPublic(error) {
+	return FALLBACK_STATUSES.has(error.status ?? 0);
+}
+
+/**
+ * A focused decision prototype, not production code.
+ *
+ * The result metadata proves that an empty success remains distinguishable from
+ * failure and that callers can observe which origin supplied the data.
+ */
+async function readLocalFirst({
+	operation,
+	localEnabled,
+	local,
+	publicApi,
+}) {
+	const attempts = [];
+
+	if (localEnabled) {
+		try {
+			return {
+				data: await local(operation),
+				freshness: "fresh",
+				origin: "local",
+				fallbackFrom: null,
+			};
+		} catch (error) {
+			const attempt = asAttempt("local", error);
+			attempts.push(attempt);
+			if (!mayTryPublic(attempt.error)) {
+				throw new RouteError(operation, attempts);
+			}
+		}
+	}
+
+	try {
+		return {
+			data: await publicApi(operation),
+			freshness: "fresh",
+			origin: "public",
+			fallbackFrom: attempts[0] ?? null,
+		};
+	} catch (error) {
+		attempts.push(asAttempt("public", error));
+		throw new RouteError(operation, attempts);
+	}
+}
+
+function failure(status, message, extra = {}) {
+	return Object.assign(new Error(message), { status, ...extra });
+}
+
+test("does not contact the local API when it is disabled", async () => {
+	let localCalls = 0;
+	const result = await readLocalFirst({
+		operation: "todayItems:2026-07-23",
+		localEnabled: false,
+		local: async () => {
+			localCalls += 1;
+			return ["unexpected"];
+		},
+		publicApi: async () => [],
+	});
+
+	assert.equal(localCalls, 0);
+	assert.deepEqual(result, {
+		data: [],
+		freshness: "fresh",
+		origin: "public",
+		fallbackFrom: null,
+	});
+});
+
+test("accepts a successful empty local result without calling public", async () => {
+	let publicCalls = 0;
+	const result = await readLocalFirst({
+		operation: "todayItems:2026-07-23",
+		localEnabled: true,
+		local: async () => [],
+		publicApi: async () => {
+			publicCalls += 1;
+			return ["unexpected"];
+		},
+	});
+
+	assert.equal(publicCalls, 0);
+	assert.equal(result.origin, "local");
+	assert.deepEqual(result.data, []);
+});
+
+test("falls back when the local API lacks an endpoint", async () => {
+	const result = await readLocalFirst({
+		operation: "children:unassigned",
+		localEnabled: true,
+		local: async () => {
+			throw failure(404, "Local /children is unsupported");
+		},
+		publicApi: async () => [{ _id: "task-1" }],
+	});
+
+	assert.equal(result.origin, "public");
+	assert.equal(result.fallbackFrom.origin, "local");
+	assert.equal(result.fallbackFrom.error.status, 404);
+	assert.deepEqual(result.data, [{ _id: "task-1" }]);
+});
+
+test("falls back when the local server is unavailable", async () => {
+	const result = await readLocalFirst({
+		operation: "categories",
+		localEnabled: true,
+		local: async () => {
+			throw failure(0, "ECONNREFUSED");
+		},
+		publicApi: async () => [{ _id: "category-1" }],
+	});
+
+	assert.equal(result.origin, "public");
+	assert.equal(result.fallbackFrom.error.message, "ECONNREFUSED");
+});
+
+test("does not turn a local throttle into a second-origin request", async () => {
+	let publicCalls = 0;
+
+	await assert.rejects(
+		readLocalFirst({
+			operation: "todayItems:2026-07-23",
+			localEnabled: true,
+			local: async () => {
+				throw failure(429, "Rate limited", { retryAfterMs: 30_000 });
+			},
+			publicApi: async () => {
+				publicCalls += 1;
+				return [];
+			},
+		}),
+		(error) => {
+			assert.equal(error.attempts.length, 1);
+			assert.equal(error.attempts[0].error.retryAfterMs, 30_000);
+			return true;
+		},
+	);
+
+	assert.equal(publicCalls, 0);
+});
+
+test("preserves both failures when local fallback and public fail", async () => {
+	await assert.rejects(
+		readLocalFirst({
+			operation: "children:unassigned",
+			localEnabled: true,
+			local: async () => {
+				throw failure(404, "Local endpoint unsupported");
+			},
+			publicApi: async () => {
+				throw failure(503, "Public API unavailable");
+			},
+		}),
+		(error) => {
+			assert.equal(error.name, "RouteError");
+			assert.deepEqual(
+				error.attempts.map(({ origin, error: attemptError }) => [
+					origin,
+					attemptError.status,
+					attemptError.message,
+				]),
+				[
+					["local", 404, "Local endpoint unsupported"],
+					["public", 503, "Public API unavailable"],
+				],
+			);
+			return true;
+		},
+	);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,18 @@
 {
-  "name": "cloud-atlas",
+  "name": "cloud-atlas-am",
   "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cloud-atlas",
+      "name": "cloud-atlas-am",
       "version": "0.9.9",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
+        "@open-horizon/marvin-client": "file:packages/marvin-client",
         "obsidian-daily-notes-interface": "^0.9.4"
       },
       "devDependencies": {
@@ -19,7 +23,8 @@
         "esbuild": "^0.19.7",
         "obsidian": "^1.4.11",
         "tslib": "^2.6.2",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.2",
+        "vitest": "^1.6.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -499,6 +504,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -559,6 +576,88 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -594,6 +693,410 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@open-horizon/marvin-client": {
+      "resolved": "packages/marvin-client",
+      "link": true
+    },
+    "node_modules/@open-horizon/marvin-mcp": {
+      "resolved": "packages/marvin-mcp",
+      "link": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
       "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -603,9 +1106,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -833,12 +1337,128 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -854,6 +1474,19 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -872,6 +1505,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -915,11 +1587,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -954,6 +1673,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -962,6 +1729,25 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/chalk": {
@@ -979,6 +1765,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/color-convert": {
@@ -1008,12 +1807,75 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
-      "peer": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1024,12 +1886,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1040,12 +1902,44 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1070,6 +1964,65 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1109,6 +2062,12 @@
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1286,6 +2245,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1296,12 +2265,126 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -1345,6 +2428,22 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -1377,6 +2476,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -1418,12 +2538,114 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1519,6 +2741,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1533,6 +2767,85 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -1585,9 +2898,25 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1629,12 +2958,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -1662,6 +3024,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1694,6 +3062,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1717,6 +3102,16 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1728,6 +3123,53 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1751,6 +3193,44 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -1766,6 +3246,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -1775,16 +3275,94 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/obsidian": {
       "version": "1.5.7",
@@ -1816,14 +3394,40 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -1889,6 +3493,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1913,10 +3526,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -1927,6 +3548,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1940,6 +3585,63 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1950,6 +3652,47 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1958,6 +3701,22 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -1979,6 +3738,50 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2016,6 +3819,67 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2039,6 +3903,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -2054,12 +3924,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2071,10 +3990,100 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/slash": {
@@ -2085,6 +4094,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -2099,6 +4141,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2110,6 +4165,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/style-mod": {
@@ -2138,6 +4206,33 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2148,6 +4243,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2181,6 +4285,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -2192,6 +4306,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2207,11 +4352,27 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -2221,6 +4382,594 @@
       "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/w3c-keyname": {
@@ -2233,8 +4982,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2245,12 +4992,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -2269,6 +5031,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "packages/marvin-client": {
+      "name": "@open-horizon/marvin-client",
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "packages/marvin-mcp": {
+      "name": "@open-horizon/marvin-mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@open-horizon/marvin-client": "file:../marvin-client",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "amazing-marvin-mcp": "dist/server.js"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,17 +2,27 @@
   "name": "cloud-atlas-am",
   "version": "0.9.9",
   "description": "Interoperability between Obsidian and Amazing Marvin",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "main": "dist/main.js",
   "scripts": {
-    "dev": "node esbuild.config.mjs",
-    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-    "dev-build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs dev-build",
+    "build": "npm run build:client && npm run build:plugin && npm run build:mcp",
+    "build:client": "npm run build --workspace @open-horizon/marvin-client",
+    "build:mcp": "npm run build --workspace @open-horizon/marvin-mcp",
+    "build:plugin": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "dev": "npm run build:client && node esbuild.config.mjs",
+    "dev-build": "npm run build:client && tsc -noEmit -skipLibCheck && node esbuild.config.mjs dev-build",
+    "test": "npm run build:client && vitest run",
+    "typecheck": "npm run build:client && tsc -noEmit -skipLibCheck && npm run typecheck --workspaces --if-present",
     "version": "node version-bump.mjs && git add manifest.json versions.json"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@open-horizon/marvin-client": "file:packages/marvin-client",
     "obsidian-daily-notes-interface": "^0.9.4"
   },
   "devDependencies": {
@@ -23,6 +33,7 @@
     "esbuild": "^0.19.7",
     "obsidian": "^1.4.11",
     "tslib": "^2.6.2",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^1.6.1"
   }
 }

--- a/packages/marvin-client/LICENSE.upstream
+++ b/packages/marvin-client/LICENSE.upstream
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jacob Boykin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/marvin-client/UPSTREAM.md
+++ b/packages/marvin-client/UPSTREAM.md
@@ -1,0 +1,14 @@
+# Upstream provenance
+
+This package is an internal fork derived from
+[`@jacobboykin/amazing-marvin-client` v1.1.1](https://github.com/jacobboykin/amazing-marvin-client-js/tree/1f04630374c5ec9c3ff08e847dad96e8ad62fae9),
+used under its MIT license.
+
+The fork retains the limited-token endpoint models and client patterns that
+are relevant to this repository. It intentionally changes the transport,
+packaging, retry, routing, cache, and error contracts so the same behavior is
+available to the Obsidian plugin and the in-repository MCP server.
+
+See
+[`docs/evaluations/0053-amazing-marvin-client.md`](../../docs/evaluations/0053-amazing-marvin-client.md)
+for the evidence and decision.

--- a/packages/marvin-client/package.json
+++ b/packages/marvin-client/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@open-horizon/marvin-client",
+  "version": "0.1.0",
+  "description": "Shared Amazing Marvin limited-token client for Obsidian and MCP adapters",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "LICENSE.upstream",
+    "UPSTREAM.md"
+  ],
+  "scripts": {
+    "build": "npm run clean && esbuild src/index.ts --bundle --platform=node --target=node18 --format=esm --outfile=dist/index.js && esbuild src/index.ts --bundle --platform=node --target=node18 --format=cjs --outfile=dist/index.cjs && tsc --project tsconfig.json --emitDeclarationOnly",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "typecheck": "tsc --project tsconfig.test.json --noEmit"
+  },
+  "sideEffects": false,
+  "license": "MIT"
+}

--- a/packages/marvin-client/src/cache.ts
+++ b/packages/marvin-client/src/cache.ts
@@ -1,0 +1,82 @@
+import type {
+	MarvinErrorSummary,
+	MarvinOrigin,
+} from "./types.js";
+
+export interface MarvinCachePolicy {
+	freshTtlMs: number;
+	staleIfErrorMs: number;
+}
+
+export interface MarvinCacheEntry<T> {
+	data: T;
+	origin: Exclude<MarvinOrigin, "mixed">;
+	fetchedAt: number;
+	expiresAt: number;
+	staleUntil: number;
+	warnings: MarvinErrorSummary[];
+}
+
+export class MarvinReadCache {
+	private readonly entries = new Map<string, MarvinCacheEntry<unknown>>();
+
+	constructor(private readonly maximumEntries = 128) {
+		if (maximumEntries <= 0) {
+			throw new Error("Cache maximum entries must be greater than zero");
+		}
+	}
+
+	get<T>(key: string, now: number): MarvinCacheEntry<T> | undefined {
+		const entry = this.entries.get(key) as MarvinCacheEntry<T> | undefined;
+		if (!entry) {
+			return undefined;
+		}
+		if (entry.staleUntil <= now) {
+			this.entries.delete(key);
+			return undefined;
+		}
+
+		this.entries.delete(key);
+		this.entries.set(key, entry);
+		return entry;
+	}
+
+	set<T>(
+		key: string,
+		value: {
+			data: T;
+			origin: Exclude<MarvinOrigin, "mixed">;
+			fetchedAt: number;
+			warnings: MarvinErrorSummary[];
+		},
+		policy: MarvinCachePolicy,
+	): void {
+		const entry: MarvinCacheEntry<T> = {
+			...value,
+			expiresAt: value.fetchedAt + policy.freshTtlMs,
+			staleUntil: value.fetchedAt + policy.freshTtlMs + policy.staleIfErrorMs,
+		};
+		this.entries.delete(key);
+		this.entries.set(key, entry);
+
+		while (this.entries.size > this.maximumEntries) {
+			const oldest = this.entries.keys().next().value as string | undefined;
+			if (oldest === undefined) {
+				break;
+			}
+			this.entries.delete(oldest);
+		}
+	}
+
+	invalidatePrefixes(prefixes: string[]): void {
+		for (const key of this.entries.keys()) {
+			if (prefixes.some((prefix) => key.startsWith(prefix))) {
+				this.entries.delete(key);
+			}
+		}
+	}
+
+	clear(): void {
+		this.entries.clear();
+	}
+}

--- a/packages/marvin-client/src/client.test.ts
+++ b/packages/marvin-client/src/client.test.ts
@@ -70,6 +70,20 @@ describe("MarvinApiClient", () => {
 		}]);
 	});
 
+	it("normalizes categories without a type discriminator", async () => {
+		const transport = new QueueTransport(
+			jsonResponse(200, [
+				{ _id: "category-1", title: "Work" },
+				{ _id: "project-1", title: "Book", type: "project" },
+			]),
+		);
+
+		await expect(client(transport).getCategories()).resolves.toEqual([
+			{ _id: "category-1", title: "Work", type: "category" },
+			{ _id: "project-1", title: "Book", type: "project" },
+		]);
+	});
+
 	it("does not retry a throttled request", async () => {
 		const transport = new QueueTransport({
 			status: 429,

--- a/packages/marvin-client/src/client.test.ts
+++ b/packages/marvin-client/src/client.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { MarvinApiClient } from "./client";
+import { jsonResponse, QueueTransport } from "./test-helpers";
+
+function client(transport: QueueTransport): MarvinApiClient {
+	return new MarvinApiClient({
+		apiToken: "test-token",
+		baseUrl: "https://example.test/api",
+		origin: "public",
+		transport,
+	});
+}
+
+describe("MarvinApiClient", () => {
+	it("uses the documented and encoded by parameter for due items", async () => {
+		const transport = new QueueTransport(jsonResponse(200, []));
+
+		await client(transport).getDueItems("2026-07-23 & later");
+
+		expect(transport.requests).toHaveLength(1);
+		expect(transport.requests[0]?.url).toBe(
+			"https://example.test/api/dueItems?by=2026-07-23+%26+later",
+		);
+	});
+
+	it("defaults task done to false without requiring callers to provide it", async () => {
+		const transport = new QueueTransport(
+			jsonResponse(200, { _id: "task-1", title: "Decide", done: false }),
+		);
+
+		await client(transport).addTask({ title: "Decide" });
+
+		expect(JSON.parse(transport.requests[0]?.body ?? "{}")).toEqual({
+			done: false,
+			title: "Decide",
+		});
+	});
+
+	it("keeps a successful empty list distinct from a failure", async () => {
+		const transport = new QueueTransport(
+			jsonResponse(200, []),
+			{
+				status: 503,
+				statusText: "Unavailable",
+				headers: {},
+				text: "maintenance",
+			},
+		);
+		const api = client(transport);
+
+		await expect(api.getTodayItems("2026-07-23")).resolves.toEqual([]);
+		await expect(api.getTodayItems("2026-07-24")).rejects.toMatchObject({
+			kind: "http",
+			status: 503,
+			responseBody: "maintenance",
+		});
+	});
+
+	it("does not retry a throttled request", async () => {
+		const transport = new QueueTransport({
+			status: 429,
+			statusText: "Too Many Requests",
+			headers: { "retry-after": "30" },
+			text: "slow down",
+		});
+
+		await expect(client(transport).getCategories()).rejects.toMatchObject({
+			kind: "throttle",
+			status: 429,
+			retryAfterMs: 30_000,
+			responseBody: "slow down",
+		});
+		expect(transport.requests).toHaveLength(1);
+	});
+
+	it("rejects malformed successful read responses before they can be cached", async () => {
+		const transport = new QueueTransport(jsonResponse(200, { not: "an array" }));
+
+		await expect(client(transport).getTodayItems()).rejects.toMatchObject({
+			kind: "validation",
+		});
+	});
+});

--- a/packages/marvin-client/src/client.test.ts
+++ b/packages/marvin-client/src/client.test.ts
@@ -56,6 +56,20 @@ describe("MarvinApiClient", () => {
 		});
 	});
 
+	it("reads labels through the limited API without retries", async () => {
+		const transport = new QueueTransport(
+			jsonResponse(200, [{ _id: "label-1", title: "Knowledge work" }]),
+		);
+
+		await expect(client(transport).getLabels()).resolves.toEqual([
+			{ _id: "label-1", title: "Knowledge work" },
+		]);
+		expect(transport.requests).toMatchObject([{
+			method: "GET",
+			url: "https://example.test/api/labels",
+		}]);
+	});
+
 	it("does not retry a throttled request", async () => {
 		const transport = new QueueTransport({
 			status: 429,

--- a/packages/marvin-client/src/client.ts
+++ b/packages/marvin-client/src/client.ts
@@ -1,0 +1,247 @@
+import { asMarvinError, MarvinError } from "./errors.js";
+import type {
+	AddTaskRequest,
+	Category,
+	MarkDoneResult,
+	MarvinOrigin,
+	MarvinTransport,
+	MarvinTransportRequest,
+	Project,
+	Task,
+	TaskOrProject,
+} from "./types.js";
+
+const DEFAULT_PUBLIC_BASE_URL = "https://serv.amazingmarvin.com/api";
+
+export interface MarvinApiClientOptions {
+	apiToken: string;
+	transport: MarvinTransport;
+	origin: Exclude<MarvinOrigin, "mixed">;
+	baseUrl?: string;
+	timeoutMs?: number;
+}
+
+function parseRetryAfter(value: string | undefined, now = Date.now()): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+
+	const seconds = Number(value);
+	if (!Number.isNaN(seconds)) {
+		return Math.max(0, Math.floor(seconds * 1_000));
+	}
+
+	const date = Date.parse(value);
+	return Number.isNaN(date) ? undefined : Math.max(0, date - now);
+}
+
+function requireArray<T>(
+	value: unknown,
+	context: {
+		operation: string;
+		origin: Exclude<MarvinOrigin, "mixed">;
+		endpoint: string;
+		method: string;
+	},
+): T[] {
+	if (!Array.isArray(value)) {
+		throw new MarvinError({
+			kind: "validation",
+			message: `Amazing Marvin ${context.operation} returned a non-array response`,
+			...context,
+		});
+	}
+	return value as T[];
+}
+
+function requireTask(
+	value: unknown,
+	context: {
+		operation: string;
+		origin: Exclude<MarvinOrigin, "mixed">;
+		endpoint: string;
+		method: string;
+	},
+): Task {
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| typeof (value as Partial<Task>)._id !== "string"
+		|| typeof (value as Partial<Task>).title !== "string"
+	) {
+		throw new MarvinError({
+			kind: "validation",
+			message: `Amazing Marvin ${context.operation} returned an invalid task`,
+			...context,
+		});
+	}
+	return value as Task;
+}
+
+export class MarvinApiClient {
+	readonly origin: Exclude<MarvinOrigin, "mixed">;
+	private readonly apiToken: string;
+	private readonly baseUrl: string;
+	private readonly timeoutMs: number;
+	private readonly transport: MarvinTransport;
+
+	constructor(options: MarvinApiClientOptions) {
+		if (!options.apiToken.trim()) {
+			throw new Error("Amazing Marvin API token is required");
+		}
+		this.apiToken = options.apiToken;
+		this.transport = options.transport;
+		this.origin = options.origin;
+		this.baseUrl = (options.baseUrl ?? DEFAULT_PUBLIC_BASE_URL).replace(/\/+$/, "");
+		this.timeoutMs = options.timeoutMs ?? 10_000;
+		if (this.timeoutMs <= 0) {
+			throw new Error("Amazing Marvin timeout must be greater than zero");
+		}
+	}
+
+	async getTodayItems(date?: string): Promise<TaskOrProject[]> {
+		const endpoint = this.withQuery("/todayItems", date ? { date } : {});
+		const value = await this.requestJson("today items", endpoint, "GET");
+		return requireArray<TaskOrProject>(value, this.context("today items", endpoint, "GET"));
+	}
+
+	async getDueItems(by?: string): Promise<TaskOrProject[]> {
+		const endpoint = this.withQuery("/dueItems", by ? { by } : {});
+		const value = await this.requestJson("due items", endpoint, "GET");
+		return requireArray<TaskOrProject>(value, this.context("due items", endpoint, "GET"));
+	}
+
+	async getCategories(): Promise<(Category | Project)[]> {
+		const endpoint = "/categories";
+		const value = await this.requestJson("categories", endpoint, "GET");
+		return requireArray<Category | Project>(
+			value,
+			this.context("categories", endpoint, "GET"),
+		);
+	}
+
+	async getChildren(parentId: string): Promise<(Task | Project)[]> {
+		const endpoint = this.withQuery("/children", { parentId });
+		const value = await this.requestJson("children", endpoint, "GET");
+		return requireArray<Task | Project>(value, this.context("children", endpoint, "GET"));
+	}
+
+	async addTask(task: AddTaskRequest): Promise<Task> {
+		const endpoint = "/addTask";
+		const value = await this.requestJson("add task", endpoint, "POST", {
+			done: false,
+			...task,
+		});
+		return requireTask(value, this.context("add task", endpoint, "POST"));
+	}
+
+	async markDone(itemId: string, timeZoneOffset?: number): Promise<MarkDoneResult> {
+		const endpoint = "/markDone";
+		const value = await this.requestJson(
+			"mark done",
+			endpoint,
+			"POST",
+			{
+				itemId,
+				...(timeZoneOffset === undefined ? {} : { timeZoneOffset }),
+			},
+			true,
+		);
+
+		if (value === null) {
+			return null;
+		}
+		if (typeof value !== "object" || Array.isArray(value)) {
+			throw new MarvinError({
+				kind: "validation",
+				message: "Amazing Marvin mark done returned an invalid response",
+				...this.context("mark done", endpoint, "POST"),
+			});
+		}
+		return value as Record<string, unknown>;
+	}
+
+	private context(
+		operation: string,
+		endpoint: string,
+		method: MarvinTransportRequest["method"],
+	) {
+		return {
+			operation,
+			origin: this.origin,
+			endpoint,
+			method,
+		};
+	}
+
+	private withQuery(endpoint: string, query: Record<string, string>): string {
+		const params = new URLSearchParams(query);
+		const serialized = params.toString();
+		return serialized ? `${endpoint}?${serialized}` : endpoint;
+	}
+
+	private async requestJson(
+		operation: string,
+		endpoint: string,
+		method: MarvinTransportRequest["method"],
+		body?: unknown,
+		allowEmpty = false,
+	): Promise<unknown> {
+		const request: MarvinTransportRequest = {
+			url: `${this.baseUrl}${endpoint}`,
+			method,
+			headers: {
+				"Content-Type": "application/json",
+				"X-API-Token": this.apiToken,
+			},
+			...(body === undefined ? {} : { body: JSON.stringify(body) }),
+			timeoutMs: this.timeoutMs,
+		};
+
+		let response;
+		try {
+			response = await this.transport.request(request);
+		} catch (error) {
+			throw asMarvinError(error, {
+				kind: "transport",
+				...this.context(operation, endpoint, method),
+			});
+		}
+
+		if (response.status < 200 || response.status >= 300) {
+			const retryAfterMs = parseRetryAfter(response.headers["retry-after"]);
+			throw new MarvinError({
+				kind: response.status === 429 ? "throttle" : "http",
+				message: `Amazing Marvin ${operation} failed with HTTP ${response.status}`,
+				...this.context(operation, endpoint, method),
+				status: response.status,
+				...(response.statusText === undefined ? {} : { statusText: response.statusText }),
+				responseBody: response.text,
+				...(retryAfterMs === undefined ? {} : { retryAfterMs }),
+			});
+		}
+
+		if (!response.text.trim()) {
+			if (allowEmpty) {
+				return null;
+			}
+			throw new MarvinError({
+				kind: "parse",
+				message: `Amazing Marvin ${operation} returned an empty response`,
+				...this.context(operation, endpoint, method),
+			});
+		}
+
+		try {
+			return JSON.parse(response.text) as unknown;
+		} catch (error) {
+			throw new MarvinError({
+				kind: "parse",
+				message: `Amazing Marvin ${operation} returned invalid JSON`,
+				...this.context(operation, endpoint, method),
+				responseBody: response.text,
+				cause: error,
+			});
+		}
+	}
+}

--- a/packages/marvin-client/src/client.ts
+++ b/packages/marvin-client/src/client.ts
@@ -2,6 +2,7 @@ import { asMarvinError, MarvinError } from "./errors.js";
 import type {
 	AddTaskRequest,
 	Category,
+	Label,
 	MarkDoneResult,
 	MarvinOrigin,
 	MarvinTransport,
@@ -117,6 +118,15 @@ export class MarvinApiClient {
 		return requireArray<Category | Project>(
 			value,
 			this.context("categories", endpoint, "GET"),
+		);
+	}
+
+	async getLabels(): Promise<Label[]> {
+		const endpoint = "/labels";
+		const value = await this.requestJson("labels", endpoint, "GET");
+		return requireArray<Label>(
+			value,
+			this.context("labels", endpoint, "GET"),
 		);
 	}
 

--- a/packages/marvin-client/src/client.ts
+++ b/packages/marvin-client/src/client.ts
@@ -115,10 +115,15 @@ export class MarvinApiClient {
 	async getCategories(): Promise<(Category | Project)[]> {
 		const endpoint = "/categories";
 		const value = await this.requestJson("categories", endpoint, "GET");
-		return requireArray<Category | Project>(
+		const categories = requireArray<Category | Project>(
 			value,
 			this.context("categories", endpoint, "GET"),
 		);
+		return categories.map((item) => (
+			item.type === "project"
+				? item
+				: { ...item, type: "category" }
+		));
 	}
 
 	async getLabels(): Promise<Label[]> {

--- a/packages/marvin-client/src/errors.ts
+++ b/packages/marvin-client/src/errors.ts
@@ -1,0 +1,119 @@
+import type {
+	MarvinErrorSummary,
+	MarvinOrigin,
+} from "./types.js";
+
+type ErrorKind = MarvinErrorSummary["kind"];
+type ConcreteOrigin = Exclude<MarvinOrigin, "mixed">;
+
+export interface MarvinErrorOptions {
+	kind: ErrorKind;
+	message: string;
+	operation: string;
+	origin: ConcreteOrigin;
+	endpoint?: string;
+	method?: string;
+	status?: number;
+	statusText?: string;
+	responseBody?: string;
+	retryAfterMs?: number;
+	cause?: unknown;
+}
+
+export class MarvinError extends Error {
+	readonly kind: ErrorKind;
+	readonly operation: string;
+	readonly origin: ConcreteOrigin;
+	readonly endpoint: string | undefined;
+	readonly method: string | undefined;
+	readonly status: number | undefined;
+	readonly statusText: string | undefined;
+	readonly responseBody: string | undefined;
+	readonly retryAfterMs: number | undefined;
+	override readonly cause: unknown;
+
+	constructor(options: MarvinErrorOptions) {
+		super(options.message);
+		this.name = "MarvinError";
+		this.kind = options.kind;
+		this.operation = options.operation;
+		this.origin = options.origin;
+		this.endpoint = options.endpoint;
+		this.method = options.method;
+		this.status = options.status;
+		this.statusText = options.statusText;
+		this.responseBody = options.responseBody;
+		this.retryAfterMs = options.retryAfterMs;
+		this.cause = options.cause;
+	}
+
+	isTransient(): boolean {
+		return this.kind === "transport"
+			|| this.kind === "throttle"
+			|| (this.status !== undefined && this.status >= 500);
+	}
+
+	toSummary(): MarvinErrorSummary {
+		return {
+			kind: this.kind,
+			message: this.message,
+			operation: this.operation,
+			origin: this.origin,
+			...(this.endpoint === undefined ? {} : { endpoint: this.endpoint }),
+			...(this.method === undefined ? {} : { method: this.method }),
+			...(this.status === undefined ? {} : { status: this.status }),
+			...(this.statusText === undefined ? {} : { statusText: this.statusText }),
+			...(this.responseBody === undefined ? {} : { responseBody: this.responseBody }),
+			...(this.retryAfterMs === undefined ? {} : { retryAfterMs: this.retryAfterMs }),
+		};
+	}
+}
+
+export class MarvinRouteError extends MarvinError {
+	readonly attempts: MarvinError[];
+
+	constructor(operation: string, attempts: MarvinError[]) {
+		const last = attempts[attempts.length - 1];
+		super({
+			kind: "route",
+			message: `Amazing Marvin ${operation} failed via ${attempts
+				.map((attempt) => attempt.origin)
+				.join(" then ")}`,
+			operation,
+			origin: last?.origin ?? "public",
+			...(last?.endpoint === undefined ? {} : { endpoint: last.endpoint }),
+			...(last?.method === undefined ? {} : { method: last.method }),
+			...(last?.status === undefined ? {} : { status: last.status }),
+			...(last?.statusText === undefined ? {} : { statusText: last.statusText }),
+			...(last?.responseBody === undefined ? {} : { responseBody: last.responseBody }),
+			...(last?.retryAfterMs === undefined ? {} : { retryAfterMs: last.retryAfterMs }),
+			cause: last,
+		});
+		this.name = "MarvinRouteError";
+		this.attempts = attempts;
+	}
+
+	override isTransient(): boolean {
+		return this.attempts.at(-1)?.isTransient() ?? false;
+	}
+}
+
+export function asMarvinError(
+	error: unknown,
+	context: Pick<MarvinErrorOptions, "operation" | "origin"> & Partial<MarvinErrorOptions>,
+): MarvinError {
+	if (error instanceof MarvinError) {
+		return error;
+	}
+
+	const cause = error instanceof Error ? error : undefined;
+	return new MarvinError({
+		kind: "transport",
+		message: cause?.message ?? String(error),
+		operation: context.operation,
+		origin: context.origin,
+		...(context.endpoint === undefined ? {} : { endpoint: context.endpoint }),
+		...(context.method === undefined ? {} : { method: context.method }),
+		cause: error,
+	});
+}

--- a/packages/marvin-client/src/index.ts
+++ b/packages/marvin-client/src/index.ts
@@ -2,5 +2,6 @@ export * from "./cache.js";
 export * from "./client.js";
 export * from "./errors.js";
 export * from "./router.js";
+export * from "./sourceAction.js";
 export * from "./transport.js";
 export * from "./types.js";

--- a/packages/marvin-client/src/index.ts
+++ b/packages/marvin-client/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./cache.js";
+export * from "./client.js";
+export * from "./errors.js";
+export * from "./router.js";
+export * from "./transport.js";
+export * from "./types.js";

--- a/packages/marvin-client/src/package.test.ts
+++ b/packages/marvin-client/src/package.test.ts
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("@open-horizon/marvin-client package", () => {
+	it("loads through native ESM and CommonJS entry points", () => {
+		const cwd = process.cwd();
+		const esm = execFileSync(
+			process.execPath,
+			[
+				"--input-type=module",
+				"--eval",
+				"import { MarvinRouter } from '@open-horizon/marvin-client'; process.stdout.write(typeof MarvinRouter)",
+			],
+			{ cwd, encoding: "utf8" },
+		);
+		const commonJs = execFileSync(
+			process.execPath,
+			[
+				"--eval",
+				"const { MarvinRouter } = require('@open-horizon/marvin-client'); process.stdout.write(typeof MarvinRouter)",
+			],
+			{ cwd, encoding: "utf8" },
+		);
+
+		expect(esm).toBe("function");
+		expect(commonJs).toBe("function");
+	});
+});

--- a/packages/marvin-client/src/router.test.ts
+++ b/packages/marvin-client/src/router.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+import { MarvinReadCache } from "./cache";
+import { MarvinApiClient } from "./client";
+import { MarvinRouteError } from "./errors";
+import { MarvinRouter, marvinDeepLink } from "./router";
+import { jsonResponse, QueueTransport } from "./test-helpers";
+import type { MarvinTransportResponse } from "./types";
+
+function api(
+	origin: "local" | "public",
+	transport: QueueTransport,
+): MarvinApiClient {
+	return new MarvinApiClient({
+		apiToken: "test-token",
+		baseUrl: origin === "local"
+			? "http://localhost:12082/api"
+			: "https://example.test/api",
+		origin,
+		transport,
+	});
+}
+
+describe("MarvinRouter", () => {
+	it("never contacts local when no configured local client exists", async () => {
+		const local = new QueueTransport(jsonResponse(200, ["unexpected"]));
+		const publicApi = new QueueTransport(jsonResponse(200, []));
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getTodayItems("2026-07-23")).resolves.toMatchObject({
+			data: [],
+			freshness: "fresh",
+			origin: "public",
+		});
+		expect(local.requests).toHaveLength(0);
+		expect(publicApi.requests).toHaveLength(1);
+	});
+
+	it("accepts a successful empty local result without public fallback", async () => {
+		const local = new QueueTransport(jsonResponse(200, []));
+		const publicApi = new QueueTransport(jsonResponse(200, ["unexpected"]));
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getTodayItems("2026-07-23")).resolves.toMatchObject({
+			data: [],
+			origin: "local",
+		});
+		expect(local.requests).toHaveLength(1);
+		expect(publicApi.requests).toHaveLength(0);
+	});
+
+	it("falls back for an unsupported local endpoint and exposes why", async () => {
+		const local = new QueueTransport({
+			status: 404,
+			statusText: "Not Found",
+			headers: {},
+			text: "unsupported",
+		});
+		const publicApi = new QueueTransport(
+			jsonResponse(200, [{ _id: "task-1", title: "Task", done: false }]),
+		);
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		const result = await router.getChildren("unassigned");
+
+		expect(result.origin).toBe("public");
+		expect(result.warnings).toMatchObject([
+			{ origin: "local", status: 404, responseBody: "unsupported" },
+		]);
+	});
+
+	it("preserves both attempted-origin failures", async () => {
+		const local = new QueueTransport(new Error("ECONNREFUSED"));
+		const publicApi = new QueueTransport({
+			status: 503,
+			statusText: "Unavailable",
+			headers: {},
+			text: "maintenance",
+		});
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getCategories()).rejects.toSatisfy((error) => {
+			expect(error).toBeInstanceOf(MarvinRouteError);
+			if (!(error instanceof MarvinRouteError)) {
+				return false;
+			}
+			expect(error.attempts).toMatchObject([
+				{ origin: "local", kind: "transport", message: "ECONNREFUSED" },
+				{ origin: "public", kind: "http", status: 503 },
+			]);
+			return true;
+		});
+	});
+
+	it("does not turn a local throttle into a public request", async () => {
+		const local = new QueueTransport({
+			status: 429,
+			statusText: "Too Many Requests",
+			headers: { "retry-after": "30" },
+			text: "slow down",
+		});
+		const publicApi = new QueueTransport(jsonResponse(200, []));
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getTodayItems()).rejects.toMatchObject({
+			attempts: [{ origin: "local", status: 429 }],
+		});
+		expect(publicApi.requests).toHaveLength(0);
+	});
+
+	it("does not hide a local authentication failure behind public fallback", async () => {
+		const local = new QueueTransport({
+			status: 401,
+			statusText: "Unauthorized",
+			headers: {},
+			text: "bad token",
+		});
+		const publicApi = new QueueTransport(jsonResponse(200, []));
+		const router = new MarvinRouter({
+			localClient: api("local", local),
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getCategories()).rejects.toMatchObject({
+			attempts: [{ origin: "local", status: 401, responseBody: "bad token" }],
+		});
+		expect(publicApi.requests).toHaveLength(0);
+	});
+
+	it("reuses a fresh cached read", async () => {
+		const publicApi = new QueueTransport(jsonResponse(200, []));
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		expect((await router.getTodayItems("2026-07-23")).freshness).toBe("fresh");
+		expect((await router.getTodayItems("2026-07-23")).freshness).toBe("cached");
+		expect(publicApi.requests).toHaveLength(1);
+	});
+
+	it("coalesces concurrent reads for the same key", async () => {
+		let release: ((value: MarvinTransportResponse) => void) | undefined;
+		let calls = 0;
+		const response = new Promise<MarvinTransportResponse>((resolve) => {
+			release = resolve;
+		});
+		const transport = {
+			request: async () => {
+				calls += 1;
+				return response;
+			},
+		};
+		const router = new MarvinRouter({
+			publicClient: new MarvinApiClient({
+				apiToken: "test-token",
+				baseUrl: "https://example.test/api",
+				origin: "public",
+				transport,
+			}),
+		});
+
+		const first = router.getTodayItems("2026-07-23");
+		const second = router.getTodayItems("2026-07-23");
+		release?.(jsonResponse(200, []));
+
+		await expect(Promise.all([first, second])).resolves.toMatchObject([
+			{ data: [], freshness: "fresh" },
+			{ data: [], freshness: "fresh" },
+		]);
+		expect(calls).toBe(1);
+	});
+
+	it("returns explicitly stale data on throttle and opens a public circuit", async () => {
+		let now = 1_000;
+		const publicApi = new QueueTransport(
+			jsonResponse(200, [{ _id: "task-1", title: "Cached", done: false }]),
+			{
+				status: 429,
+				statusText: "Too Many Requests",
+				headers: { "retry-after": "30" },
+				text: "slow down",
+			},
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+			now: () => now,
+		});
+
+		await router.getTodayItems("2026-07-23");
+		now += 31_000;
+		const firstStale = await router.getTodayItems("2026-07-23");
+		const circuitStale = await router.getTodayItems("2026-07-23");
+
+		expect(firstStale).toMatchObject({
+			freshness: "stale",
+			data: [{ _id: "task-1" }],
+			warnings: [{ kind: "throttle", status: 429 }],
+		});
+		expect(circuitStale.freshness).toBe("stale");
+		expect(publicApi.requests).toHaveLength(2);
+	});
+
+	it("does not cache failures as empty successes", async () => {
+		const publicApi = new QueueTransport(
+			{
+				status: 503,
+				statusText: "Unavailable",
+				headers: {},
+				text: "maintenance",
+			},
+			jsonResponse(200, []),
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		await expect(router.getDueItems("2026-07-23")).rejects.toBeInstanceOf(
+			MarvinRouteError,
+		);
+		await expect(router.getDueItems("2026-07-23")).resolves.toMatchObject({
+			data: [],
+			freshness: "fresh",
+		});
+		expect(publicApi.requests).toHaveLength(2);
+	});
+
+	it("invalidates task-list reads after a write", async () => {
+		const publicApi = new QueueTransport(
+			jsonResponse(200, []),
+			jsonResponse(200, { _id: "task-1", title: "New", done: false }),
+			jsonResponse(200, [{ _id: "task-1", title: "New", done: false }]),
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		await router.getTodayItems("2026-07-23");
+		await router.addTask({ title: "New" });
+		const refreshed = await router.getTodayItems("2026-07-23");
+
+		expect(refreshed.data).toHaveLength(1);
+		expect(publicApi.requests).toHaveLength(3);
+	});
+
+	it("deduplicates scheduled and due results by Marvin ID", async () => {
+		const publicApi = new QueueTransport(
+			jsonResponse(200, [
+				{ _id: "same", title: "Scheduled", done: false },
+				{ _id: "today-only", title: "Today", done: false },
+			]),
+			jsonResponse(200, [
+				{ _id: "same", title: "Due", done: false },
+				{ _id: "due-only", title: "Due", done: false },
+			]),
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		const result = await router.getTodayAndDue("2026-07-23");
+
+		expect(result.data.map((item) => item._id)).toEqual([
+			"same",
+			"today-only",
+			"due-only",
+		]);
+		expect(publicApi.requests.map((request) => request.url)).toEqual([
+			"https://example.test/api/todayItems?date=2026-07-23",
+			"https://example.test/api/dueItems?by=2026-07-23",
+		]);
+	});
+
+	it("bounds the read cache and uses container deep links", () => {
+		const cache = new MarvinReadCache(2);
+		const policy = { freshTtlMs: 1_000, staleIfErrorMs: 1_000 };
+		cache.set("today:1", {
+			data: [],
+			origin: "public",
+			fetchedAt: 0,
+			warnings: [],
+		}, policy);
+		cache.set("today:2", {
+			data: [],
+			origin: "public",
+			fetchedAt: 0,
+			warnings: [],
+		}, policy);
+		cache.set("today:3", {
+			data: [],
+			origin: "public",
+			fetchedAt: 0,
+			warnings: [],
+		}, policy);
+
+		expect(cache.get("today:1", 1)).toBeUndefined();
+		expect(cache.get("today:2", 1)).toBeDefined();
+		expect(marvinDeepLink({ _id: "category-1", type: "category" })).toBe(
+			"https://app.amazingmarvin.com/#p=category-1",
+		);
+	});
+});

--- a/packages/marvin-client/src/router.test.ts
+++ b/packages/marvin-client/src/router.test.ts
@@ -151,6 +151,21 @@ describe("MarvinRouter", () => {
 		expect(publicApi.requests).toHaveLength(1);
 	});
 
+	it("routes and caches the stable label list", async () => {
+		const publicApi = new QueueTransport(
+			jsonResponse(200, [{ _id: "label-1", title: "Knowledge work" }]),
+		);
+		const router = new MarvinRouter({
+			publicClient: api("public", publicApi),
+		});
+
+		expect((await router.getLabels()).data).toEqual([
+			{ _id: "label-1", title: "Knowledge work" },
+		]);
+		expect((await router.getLabels()).freshness).toBe("cached");
+		expect(publicApi.requests).toHaveLength(1);
+	});
+
 	it("coalesces concurrent reads for the same key", async () => {
 		let release: ((value: MarvinTransportResponse) => void) | undefined;
 		let calls = 0;

--- a/packages/marvin-client/src/router.ts
+++ b/packages/marvin-client/src/router.ts
@@ -11,6 +11,7 @@ import {
 import type {
 	AddTaskRequest,
 	Category,
+	Label,
 	MarkDoneResult,
 	MarvinErrorSummary,
 	MarvinItem,
@@ -29,9 +30,10 @@ const DEFAULT_CACHE_POLICIES = {
 	due: { freshTtlMs: 30_000, staleIfErrorMs: 10 * 60_000 },
 	children: { freshTtlMs: 60_000, staleIfErrorMs: 15 * 60_000 },
 	categories: { freshTtlMs: 5 * 60_000, staleIfErrorMs: 60 * 60_000 },
+	labels: { freshTtlMs: 60 * 60_000, staleIfErrorMs: 24 * 60 * 60_000 },
 } satisfies Record<ReadKind, MarvinCachePolicy>;
 
-type ReadKind = "today" | "due" | "children" | "categories";
+type ReadKind = "today" | "due" | "children" | "categories" | "labels";
 
 export interface MarvinRouterOptions {
 	publicClient: MarvinApiClient;
@@ -110,6 +112,15 @@ export class MarvinRouter {
 			this.policies.categories,
 			"categories",
 			(client) => client.getCategories(),
+		);
+	}
+
+	getLabels(): Promise<MarvinReadResult<Label[]>> {
+		return this.readThrough(
+			"labels",
+			this.policies.labels,
+			"labels",
+			(client) => client.getLabels(),
 		);
 	}
 

--- a/packages/marvin-client/src/router.ts
+++ b/packages/marvin-client/src/router.ts
@@ -1,0 +1,327 @@
+import { MarvinApiClient } from "./client.js";
+import {
+	MarvinReadCache,
+	type MarvinCachePolicy,
+} from "./cache.js";
+import {
+	MarvinError,
+	MarvinRouteError,
+	asMarvinError,
+} from "./errors.js";
+import type {
+	AddTaskRequest,
+	Category,
+	MarkDoneResult,
+	MarvinErrorSummary,
+	MarvinItem,
+	MarvinOrigin,
+	MarvinReadResult,
+	Project,
+	Task,
+	TaskOrProject,
+} from "./types.js";
+
+const LOCAL_FALLBACK_STATUSES = new Set([404, 405, 500, 501, 502, 503, 504]);
+const DEFAULT_THROTTLE_BLOCK_MS = 60_000;
+
+const DEFAULT_CACHE_POLICIES = {
+	today: { freshTtlMs: 30_000, staleIfErrorMs: 10 * 60_000 },
+	due: { freshTtlMs: 30_000, staleIfErrorMs: 10 * 60_000 },
+	children: { freshTtlMs: 60_000, staleIfErrorMs: 15 * 60_000 },
+	categories: { freshTtlMs: 5 * 60_000, staleIfErrorMs: 60 * 60_000 },
+} satisfies Record<ReadKind, MarvinCachePolicy>;
+
+type ReadKind = "today" | "due" | "children" | "categories";
+
+export interface MarvinRouterOptions {
+	publicClient: MarvinApiClient;
+	localClient?: MarvinApiClient;
+	cache?: MarvinReadCache;
+	cachePolicies?: Partial<Record<ReadKind, MarvinCachePolicy>>;
+	now?: () => number;
+}
+
+interface RoutedValue<T> {
+	data: T;
+	origin: Exclude<MarvinOrigin, "mixed">;
+	warnings: MarvinErrorSummary[];
+}
+
+export function dedupeById<T extends BaseId>(items: Iterable<T>): T[] {
+	const byId = new Map<string, T>();
+	for (const item of items) {
+		if (!byId.has(item._id)) {
+			byId.set(item._id, item);
+		}
+	}
+	return Array.from(byId.values());
+}
+
+interface BaseId {
+	_id: string;
+}
+
+export function marvinDeepLink(item: Pick<MarvinItem, "_id" | "type">): string {
+	const isContainer = item.type === "project" || item.type === "category";
+	return `https://app.amazingmarvin.com/#${isContainer ? "p" : "t"}=${item._id}`;
+}
+
+export class MarvinRouter {
+	private readonly publicClient: MarvinApiClient;
+	private readonly localClient: MarvinApiClient | undefined;
+	private readonly cache: MarvinReadCache;
+	private readonly policies: Record<ReadKind, MarvinCachePolicy>;
+	private readonly now: () => number;
+	private readonly inFlight = new Map<string, Promise<MarvinReadResult<unknown>>>();
+	private publicBlockedUntil = 0;
+
+	constructor(options: MarvinRouterOptions) {
+		this.publicClient = options.publicClient;
+		this.localClient = options.localClient;
+		this.cache = options.cache ?? new MarvinReadCache();
+		this.policies = {
+			...DEFAULT_CACHE_POLICIES,
+			...options.cachePolicies,
+		};
+		this.now = options.now ?? Date.now;
+	}
+
+	getTodayItems(date?: string): Promise<MarvinReadResult<TaskOrProject[]>> {
+		return this.readThrough(
+			`today:${date ?? "server-today"}`,
+			this.policies.today,
+			"today items",
+			(client) => client.getTodayItems(date),
+		);
+	}
+
+	getDueItems(by?: string): Promise<MarvinReadResult<TaskOrProject[]>> {
+		return this.readThrough(
+			`due:${by ?? "server-today"}`,
+			this.policies.due,
+			"due items",
+			(client) => client.getDueItems(by),
+		);
+	}
+
+	getCategories(): Promise<MarvinReadResult<(Category | Project)[]>> {
+		return this.readThrough(
+			"categories",
+			this.policies.categories,
+			"categories",
+			(client) => client.getCategories(),
+		);
+	}
+
+	getChildren(parentId: string): Promise<MarvinReadResult<(Task | Project)[]>> {
+		return this.readThrough(
+			`children:${parentId}`,
+			this.policies.children,
+			"children",
+			(client) => client.getChildren(parentId),
+		);
+	}
+
+	async getTodayAndDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>> {
+		const [today, due] = await Promise.all([
+			this.getTodayItems(date),
+			this.getDueItems(date),
+		]);
+		const fetchedAt = Math.min(today.fetchedAt, due.fetchedAt);
+
+		return {
+			data: dedupeById([...today.data, ...due.data]),
+			freshness: this.leastFresh(today.freshness, due.freshness),
+			origin: today.origin === due.origin ? today.origin : "mixed",
+			fetchedAt,
+			ageMs: Math.max(0, this.now() - fetchedAt),
+			warnings: [...today.warnings, ...due.warnings],
+		};
+	}
+
+	async addTask(task: AddTaskRequest): Promise<Task> {
+		try {
+			return await this.runPublic("add task", (client) => client.addTask(task));
+		} finally {
+			this.invalidateTaskLists();
+		}
+	}
+
+	async markDone(itemId: string, timeZoneOffset?: number): Promise<MarkDoneResult> {
+		try {
+			return await this.runPublic(
+				"mark done",
+				(client) => client.markDone(itemId, timeZoneOffset),
+			);
+		} finally {
+			this.invalidateTaskLists();
+		}
+	}
+
+	clearCache(): void {
+		this.cache.clear();
+	}
+
+	private invalidateTaskLists(): void {
+		this.cache.invalidatePrefixes(["today:", "due:", "children:"]);
+	}
+
+	private async readThrough<T>(
+		key: string,
+		policy: MarvinCachePolicy,
+		operation: string,
+		read: (client: MarvinApiClient) => Promise<T>,
+	): Promise<MarvinReadResult<T>> {
+		const startedAt = this.now();
+		const cached = this.cache.get<T>(key, startedAt);
+		if (cached && cached.expiresAt > startedAt) {
+			return {
+				data: cached.data,
+				freshness: "cached",
+				origin: cached.origin,
+				fetchedAt: cached.fetchedAt,
+				ageMs: Math.max(0, startedAt - cached.fetchedAt),
+				warnings: cached.warnings,
+			};
+		}
+
+		const existing = this.inFlight.get(key) as Promise<MarvinReadResult<T>> | undefined;
+		if (existing) {
+			return existing;
+		}
+
+		const pending = this.fetchAndCache(
+			key,
+			policy,
+			operation,
+			read,
+			cached,
+		).finally(() => {
+			this.inFlight.delete(key);
+		});
+		this.inFlight.set(key, pending as Promise<MarvinReadResult<unknown>>);
+		return pending;
+	}
+
+	private async fetchAndCache<T>(
+		key: string,
+		policy: MarvinCachePolicy,
+		operation: string,
+		read: (client: MarvinApiClient) => Promise<T>,
+		stale: ReturnType<MarvinReadCache["get"]> | undefined,
+	): Promise<MarvinReadResult<T>> {
+		try {
+			const routed = await this.routeRead(operation, read);
+			const fetchedAt = this.now();
+			this.cache.set(key, { ...routed, fetchedAt }, policy);
+			return {
+				...routed,
+				freshness: "fresh",
+				fetchedAt,
+				ageMs: 0,
+			};
+		} catch (error) {
+			const routeError = error instanceof MarvinRouteError
+				? error
+				: new MarvinRouteError(operation, [
+					asMarvinError(error, { operation, origin: "public" }),
+				]);
+			const now = this.now();
+			if (stale && stale.staleUntil > now && routeError.isTransient()) {
+				return {
+					data: stale.data as T,
+					freshness: "stale",
+					origin: stale.origin,
+					fetchedAt: stale.fetchedAt,
+					ageMs: Math.max(0, now - stale.fetchedAt),
+					warnings: [
+						...stale.warnings,
+						...routeError.attempts.map((attempt) => attempt.toSummary()),
+					],
+				};
+			}
+			throw routeError;
+		}
+	}
+
+	private async routeRead<T>(
+		operation: string,
+		read: (client: MarvinApiClient) => Promise<T>,
+	): Promise<RoutedValue<T>> {
+		const attempts: MarvinError[] = [];
+
+		if (this.localClient) {
+			try {
+				return {
+					data: await read(this.localClient),
+					origin: "local",
+					warnings: [],
+				};
+			} catch (error) {
+				const localError = asMarvinError(error, {
+					operation,
+					origin: "local",
+				});
+				attempts.push(localError);
+				if (!this.mayFallBackFromLocal(localError)) {
+					throw new MarvinRouteError(operation, attempts);
+				}
+			}
+		}
+
+		try {
+			return {
+				data: await this.runPublic(operation, read),
+				origin: "public",
+				warnings: attempts.map((attempt) => attempt.toSummary()),
+			};
+		} catch (error) {
+			attempts.push(asMarvinError(error, { operation, origin: "public" }));
+			throw new MarvinRouteError(operation, attempts);
+		}
+	}
+
+	private mayFallBackFromLocal(error: MarvinError): boolean {
+		return error.kind === "transport"
+			|| (error.status !== undefined && LOCAL_FALLBACK_STATUSES.has(error.status));
+	}
+
+	private async runPublic<T>(
+		operation: string,
+		call: (client: MarvinApiClient) => Promise<T>,
+	): Promise<T> {
+		const now = this.now();
+		if (this.publicBlockedUntil > now) {
+			throw new MarvinError({
+				kind: "throttle",
+				message: `Amazing Marvin public API is throttled for ${this.publicBlockedUntil - now}ms`,
+				operation,
+				origin: "public",
+				status: 429,
+				retryAfterMs: this.publicBlockedUntil - now,
+			});
+		}
+
+		try {
+			return await call(this.publicClient);
+		} catch (error) {
+			const marvinError = asMarvinError(error, {
+				operation,
+				origin: "public",
+			});
+			if (marvinError.status === 429) {
+				this.publicBlockedUntil = now
+					+ (marvinError.retryAfterMs ?? DEFAULT_THROTTLE_BLOCK_MS);
+			}
+			throw marvinError;
+		}
+	}
+
+	private leastFresh(
+		left: MarvinReadResult<unknown>["freshness"],
+		right: MarvinReadResult<unknown>["freshness"],
+	): MarvinReadResult<unknown>["freshness"] {
+		const score = { fresh: 0, cached: 1, stale: 2 } as const;
+		return score[left] >= score[right] ? left : right;
+	}
+}

--- a/packages/marvin-client/src/sourceAction.test.ts
+++ b/packages/marvin-client/src/sourceAction.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	SourceActionError,
+	SourceActionService,
+	type SourceActionKey,
+	type SourceActionRecord,
+	type SourceActionStore,
+} from "./sourceAction.js";
+import { MarvinError } from "./errors.js";
+import type { AddTaskRequest, Task } from "./types.js";
+
+class MemorySourceActionStore implements SourceActionStore {
+	readonly records = new Map<string, SourceActionRecord>();
+	failLinkedWrite = false;
+
+	async get(key: SourceActionKey): Promise<SourceActionRecord | undefined> {
+		return this.records.get(this.key(key));
+	}
+
+	async set(record: SourceActionRecord): Promise<void> {
+		if (record.state === "linked" && this.failLinkedWrite) {
+			throw new Error("disk full");
+		}
+		this.records.set(this.key(record), record);
+	}
+
+	async delete(key: SourceActionKey): Promise<void> {
+		this.records.delete(this.key(key));
+	}
+
+	private key(key: SourceActionKey): string {
+		return `${key.sourceKey}\u0000${key.actionKey}`;
+	}
+}
+
+const createdTask: Task = {
+	_id: "task-1",
+	title: "Decide whether to pursue Titan AI",
+	done: false,
+	day: "2026-07-23",
+};
+
+function createService(
+	store = new MemorySourceActionStore(),
+	addTask: (task: AddTaskRequest) => Promise<Task> = vi.fn(async () => createdTask),
+) {
+	return {
+		store,
+		addTask,
+		service: new SourceActionService({
+			router: { addTask },
+			store,
+			now: () => 1_000,
+			requestId: () => "request-1",
+		}),
+	};
+}
+
+describe("SourceActionService", () => {
+	it("creates once and reuses the persisted stable association", async () => {
+		const { service, addTask } = createService();
+		const request = {
+			sourceKey: "Opportunities/Titan AI.md",
+			actionKey: "decide-whether-to-pursue",
+			task: {
+				title: createdTask.title,
+				day: "2026-07-23",
+			},
+		};
+
+		const first = await service.ensure(request);
+		const second = await service.ensure(request);
+
+		expect(first).toMatchObject({
+			created: true,
+			taskId: "task-1",
+			deepLink: "https://app.amazingmarvin.com/#t=task-1",
+		});
+		expect(second).toMatchObject({
+			created: false,
+			taskId: "task-1",
+		});
+		expect(addTask).toHaveBeenCalledTimes(1);
+	});
+
+	it("coalesces concurrent calls for the same source and action", async () => {
+		let release: ((task: Task) => void) | undefined;
+		const addTask = vi.fn(() => new Promise<Task>((resolve) => {
+			release = resolve;
+		}));
+		const { service } = createService(new MemorySourceActionStore(), addTask);
+		const request = {
+			sourceKey: "note.md",
+			actionKey: "follow-up",
+			task: { title: "Follow up" },
+		};
+
+		const first = service.ensure(request);
+		const second = service.ensure(request);
+		await vi.waitFor(() => {
+			expect(release).toBeTypeOf("function");
+		});
+		release?.(createdTask);
+
+		expect(await first).toEqual(await second);
+		expect(addTask).toHaveBeenCalledTimes(1);
+	});
+
+	it("retains a pending record after an ambiguous creation failure", async () => {
+		const { service, store, addTask } = createService(
+			new MemorySourceActionStore(),
+			vi.fn(async () => {
+				throw new Error("connection reset after write");
+			}),
+		);
+		const request = {
+			sourceKey: "note.md",
+			actionKey: "follow-up",
+			task: { title: "Follow up" },
+		};
+
+		await expect(service.ensure(request)).rejects.toMatchObject({
+			code: "creation-uncertain",
+		});
+		await expect(service.ensure(request)).rejects.toMatchObject({
+			code: "pending",
+		});
+		expect(store.records.values().next().value).toMatchObject({
+			state: "pending",
+			requestId: "request-1",
+		});
+		expect(addTask).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears pending state after a definite API rejection so a later retry is possible", async () => {
+		const store = new MemorySourceActionStore();
+		const rejected = new MarvinError({
+			kind: "throttle",
+			message: "throttled",
+			operation: "add task",
+			origin: "public",
+			status: 429,
+		});
+		const addTask = vi.fn(async () => {
+			if (addTask.mock.calls.length === 1) {
+				throw rejected;
+			}
+			return createdTask;
+		});
+		const { service } = createService(store, addTask);
+		const request = {
+			sourceKey: "note.md",
+			actionKey: "follow-up",
+			task: { title: "Follow up" },
+		};
+
+		await expect(service.ensure(request)).rejects.toBe(rejected);
+		expect(await store.get(request)).toBeUndefined();
+		await expect(service.ensure(request)).resolves.toMatchObject({
+			created: true,
+			taskId: "task-1",
+		});
+		expect(addTask).toHaveBeenCalledTimes(2);
+	});
+
+	it("retains the created task ID when association persistence fails", async () => {
+		const store = new MemorySourceActionStore();
+		store.failLinkedWrite = true;
+		const { service } = createService(store);
+
+		const failure = await service.ensure({
+			sourceKey: "note.md",
+			actionKey: "follow-up",
+			task: { title: "Follow up" },
+		}).catch((error: unknown) => error);
+
+		expect(failure).toBeInstanceOf(SourceActionError);
+		expect(failure).toMatchObject({
+			code: "association-write-failed",
+			task: { _id: "task-1" },
+		});
+		expect(store.records.values().next().value).toMatchObject({
+			state: "pending",
+		});
+	});
+
+	it("can resolve or explicitly clear a pending record", async () => {
+		const { service, store } = createService(
+			new MemorySourceActionStore(),
+			vi.fn(async () => {
+				throw new Error("timeout");
+			}),
+		);
+		const key = { sourceKey: "note.md", actionKey: "follow-up" };
+
+		await service.ensure({ ...key, task: { title: "Follow up" } }).catch(() => undefined);
+		const resolved = await service.resolvePending({
+			...key,
+			taskId: "recovered-task",
+		});
+		expect(resolved).toMatchObject({
+			created: false,
+			taskId: "recovered-task",
+		});
+
+		await expect(service.clearPending(key)).rejects.toThrow(
+			"Refusing to clear linked Marvin task",
+		);
+		await store.set({
+			version: 1,
+			state: "pending",
+			...key,
+			title: "Follow up",
+			requestId: "request-2",
+			requestedAt: 2_000,
+		});
+		await service.clearPending(key);
+		expect(await store.get(key)).toBeUndefined();
+	});
+});

--- a/packages/marvin-client/src/sourceAction.ts
+++ b/packages/marvin-client/src/sourceAction.ts
@@ -1,0 +1,314 @@
+import type { MarvinRouter } from "./router.js";
+import { marvinDeepLink } from "./router.js";
+import { MarvinError } from "./errors.js";
+import type { AddTaskRequest, Task } from "./types.js";
+
+export interface SourceActionKey {
+	sourceKey: string;
+	actionKey: string;
+}
+
+export interface PendingSourceActionRecord extends SourceActionKey {
+	version: 1;
+	state: "pending";
+	title: string;
+	requestId: string;
+	requestedAt: number;
+}
+
+export interface LinkedSourceActionRecord extends SourceActionKey {
+	version: 1;
+	state: "linked";
+	title: string;
+	requestId: string;
+	requestedAt: number;
+	taskId: string;
+	deepLink: string;
+	linkedAt: number;
+}
+
+export type SourceActionRecord =
+	| PendingSourceActionRecord
+	| LinkedSourceActionRecord;
+
+export interface SourceActionStore {
+	get(key: SourceActionKey): Promise<SourceActionRecord | undefined>;
+	set(record: SourceActionRecord): Promise<void>;
+	delete(key: SourceActionKey): Promise<void>;
+}
+
+export interface EnsureSourceActionRequest extends SourceActionKey {
+	task: AddTaskRequest;
+}
+
+export interface EnsureSourceActionResult {
+	created: boolean;
+	taskId: string;
+	deepLink: string;
+	title: string;
+	record: LinkedSourceActionRecord;
+	task?: Task;
+}
+
+export interface ResolvePendingSourceActionRequest extends SourceActionKey {
+	taskId: string;
+	title?: string;
+}
+
+export type SourceActionErrorCode =
+	| "pending"
+	| "creation-uncertain"
+	| "association-write-failed";
+
+export class SourceActionError extends Error {
+	readonly code: SourceActionErrorCode;
+	readonly record: SourceActionRecord;
+	readonly task: Task | undefined;
+	override readonly cause: unknown;
+
+	constructor(options: {
+		code: SourceActionErrorCode;
+		message: string;
+		record: SourceActionRecord;
+		task?: Task;
+		cause?: unknown;
+	}) {
+		super(options.message);
+		this.name = "SourceActionError";
+		this.code = options.code;
+		this.record = options.record;
+		this.task = options.task;
+		this.cause = options.cause;
+	}
+}
+
+export interface SourceActionServiceOptions {
+	router: Pick<MarvinRouter, "addTask">;
+	store: SourceActionStore;
+	now?: () => number;
+	requestId?: () => string;
+}
+
+/**
+ * Coordinates one Marvin task with one stable external source/action key.
+ *
+ * The pending record is persisted before the network write. If the request or
+ * association write has an ambiguous outcome, subsequent calls stop at that
+ * record instead of creating a duplicate. A caller can resolve or explicitly
+ * clear the pending record after inspecting Marvin.
+ */
+export class SourceActionService {
+	private readonly router: Pick<MarvinRouter, "addTask">;
+	private readonly store: SourceActionStore;
+	private readonly now: () => number;
+	private readonly requestId: () => string;
+	private readonly inFlight = new Map<string, Promise<EnsureSourceActionResult>>();
+
+	constructor(options: SourceActionServiceOptions) {
+		this.router = options.router;
+		this.store = options.store;
+		this.now = options.now ?? Date.now;
+		this.requestId = options.requestId ?? defaultRequestId;
+	}
+
+	ensure(request: EnsureSourceActionRequest): Promise<EnsureSourceActionResult> {
+		const key = normalizeKey(request);
+		if (!request.task.title?.trim()) {
+			throw new Error("A source action task title is required");
+		}
+
+		const serializedKey = JSON.stringify([key.sourceKey, key.actionKey]);
+		const existing = this.inFlight.get(serializedKey);
+		if (existing) {
+			return existing;
+		}
+
+		const pending = this.ensureOnce({
+			...request,
+			...key,
+			task: {
+				...request.task,
+				title: request.task.title.trim(),
+			},
+		}).finally(() => {
+			this.inFlight.delete(serializedKey);
+		});
+		this.inFlight.set(serializedKey, pending);
+		return pending;
+	}
+
+	async resolvePending(
+		request: ResolvePendingSourceActionRequest,
+	): Promise<EnsureSourceActionResult> {
+		const key = normalizeKey(request);
+		const taskId = request.taskId.trim();
+		if (!taskId) {
+			throw new Error("A Marvin task ID is required to resolve a source action");
+		}
+		const existing = await this.store.get(key);
+		if (existing?.state === "linked") {
+			if (existing.taskId !== taskId) {
+				throw new Error(
+					`Source action is already linked to Marvin task ${existing.taskId}`,
+				);
+			}
+			return resultFromRecord(existing, false);
+		}
+		if (!existing) {
+			throw new Error("No pending source action exists to resolve");
+		}
+
+		const linked = this.linkedRecord(
+			existing,
+			taskId,
+			request.title?.trim() || existing.title,
+		);
+		await this.store.set(linked);
+		return resultFromRecord(linked, false);
+	}
+
+	async clearPending(keyInput: SourceActionKey): Promise<void> {
+		const key = normalizeKey(keyInput);
+		const existing = await this.store.get(key);
+		if (existing?.state === "linked") {
+			throw new Error(
+				`Refusing to clear linked Marvin task ${existing.taskId}; only pending source actions can be cleared`,
+			);
+		}
+		if (existing) {
+			await this.store.delete(key);
+		}
+	}
+
+	private async ensureOnce(
+		request: EnsureSourceActionRequest,
+	): Promise<EnsureSourceActionResult> {
+		const key = normalizeKey(request);
+		const existing = await this.store.get(key);
+		if (existing?.state === "linked") {
+			return resultFromRecord(existing, false);
+		}
+		if (existing) {
+			throw new SourceActionError({
+				code: "pending",
+				message:
+					`Source action ${existing.actionKey} has an unresolved Marvin creation attempt. `
+					+ "Inspect Marvin, then resolve or clear the pending association before retrying.",
+				record: existing,
+			});
+		}
+
+		const pending: PendingSourceActionRecord = {
+			version: 1,
+			state: "pending",
+			...key,
+			title: request.task.title,
+			requestId: this.requestId(),
+			requestedAt: this.now(),
+		};
+		await this.store.set(pending);
+
+		let task: Task;
+		try {
+			task = await this.router.addTask(request.task);
+		} catch (cause) {
+			if (isDefiniteRejection(cause)) {
+				try {
+					await this.store.delete(key);
+				} catch (deleteCause) {
+					throw new SourceActionError({
+						code: "creation-uncertain",
+						message:
+							"Marvin rejected task creation, but the pending association could not be cleared. Clear it before retrying.",
+						record: pending,
+						cause: deleteCause,
+					});
+				}
+				throw cause;
+			}
+			throw new SourceActionError({
+				code: "creation-uncertain",
+				message:
+					"Marvin task creation did not complete cleanly. The pending association was retained to prevent a duplicate.",
+				record: pending,
+				cause,
+			});
+		}
+
+		const linked = this.linkedRecord(pending, task._id, task.title);
+		try {
+			await this.store.set(linked);
+		} catch (cause) {
+			throw new SourceActionError({
+				code: "association-write-failed",
+				message:
+					`Marvin task ${task._id} was created, but its source association could not be persisted. `
+					+ "Resolve the pending association with this task ID before retrying.",
+				record: pending,
+				task,
+				cause,
+			});
+		}
+
+		return {
+			...resultFromRecord(linked, true),
+			task,
+		};
+	}
+
+	private linkedRecord(
+		pending: PendingSourceActionRecord,
+		taskId: string,
+		title: string,
+	): LinkedSourceActionRecord {
+		if (!taskId) {
+			throw new Error("A Marvin task ID is required to resolve a source action");
+		}
+		return {
+			...pending,
+			state: "linked",
+			title,
+			taskId,
+			deepLink: marvinDeepLink({ _id: taskId, type: "task" }),
+			linkedAt: this.now(),
+		};
+	}
+}
+
+function normalizeKey(key: SourceActionKey): SourceActionKey {
+	const sourceKey = key.sourceKey.trim();
+	const actionKey = key.actionKey.trim();
+	if (!sourceKey) {
+		throw new Error("A stable source key is required");
+	}
+	if (!actionKey) {
+		throw new Error("A stable action key is required");
+	}
+	return { sourceKey, actionKey };
+}
+
+function resultFromRecord(
+	record: LinkedSourceActionRecord,
+	created: boolean,
+): EnsureSourceActionResult {
+	return {
+		created,
+		taskId: record.taskId,
+		deepLink: record.deepLink,
+		title: record.title,
+		record,
+	};
+}
+
+function defaultRequestId(): string {
+	return globalThis.crypto?.randomUUID?.()
+		?? `source-action-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function isDefiniteRejection(error: unknown): boolean {
+	return error instanceof MarvinError
+		&& error.status !== undefined
+		&& error.status >= 400
+		&& error.status < 500
+		&& error.status !== 408;
+}

--- a/packages/marvin-client/src/test-helpers.ts
+++ b/packages/marvin-client/src/test-helpers.ts
@@ -1,0 +1,45 @@
+import type {
+	MarvinTransport,
+	MarvinTransportRequest,
+	MarvinTransportResponse,
+} from "./types";
+
+type QueuedResult = MarvinTransportResponse | Error;
+
+export function jsonResponse(
+	status: number,
+	value: unknown,
+	headers: Record<string, string> = {},
+): MarvinTransportResponse {
+	return {
+		status,
+		statusText: status >= 200 && status < 300 ? "OK" : "Error",
+		headers,
+		text: JSON.stringify(value),
+	};
+}
+
+export class QueueTransport implements MarvinTransport {
+	readonly requests: MarvinTransportRequest[] = [];
+	private readonly queue: QueuedResult[];
+
+	constructor(...results: QueuedResult[]) {
+		this.queue = [...results];
+	}
+
+	push(...results: QueuedResult[]): void {
+		this.queue.push(...results);
+	}
+
+	async request(request: MarvinTransportRequest): Promise<MarvinTransportResponse> {
+		this.requests.push(request);
+		const next = this.queue.shift();
+		if (!next) {
+			throw new Error(`No fake response queued for ${request.method} ${request.url}`);
+		}
+		if (next instanceof Error) {
+			throw next;
+		}
+		return next;
+	}
+}

--- a/packages/marvin-client/src/transport.ts
+++ b/packages/marvin-client/src/transport.ts
@@ -1,0 +1,47 @@
+import type {
+	MarvinTransport,
+	MarvinTransportRequest,
+	MarvinTransportResponse,
+} from "./types.js";
+
+export type FetchLike = (
+	input: string | URL | Request,
+	init?: RequestInit,
+) => Promise<Response>;
+
+function responseHeaders(headers: Headers): Record<string, string> {
+	return Object.fromEntries(
+		Array.from(headers.entries()).map(([key, value]) => [key.toLowerCase(), value]),
+	);
+}
+
+export class FetchTransport implements MarvinTransport {
+	constructor(private readonly fetch: FetchLike = globalThis.fetch) {
+		if (!fetch) {
+			throw new Error("A fetch implementation is required");
+		}
+	}
+
+	async request(request: MarvinTransportRequest): Promise<MarvinTransportResponse> {
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), request.timeoutMs);
+
+		try {
+			const response = await this.fetch(request.url, {
+				method: request.method,
+				headers: request.headers,
+				...(request.body === undefined ? {} : { body: request.body }),
+				signal: controller.signal,
+			});
+
+			return {
+				status: response.status,
+				statusText: response.statusText,
+				headers: responseHeaders(response.headers),
+				text: await response.text(),
+			};
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+}

--- a/packages/marvin-client/src/types.ts
+++ b/packages/marvin-client/src/types.ts
@@ -59,6 +59,7 @@ export interface Category extends BaseMarvinItem {
 	title: string;
 	type?: "category";
 	parentId?: string;
+	labelIds?: string[];
 	startDate?: string;
 	dueDate?: string;
 	endDate?: string;
@@ -68,6 +69,16 @@ export interface Category extends BaseMarvinItem {
 	rank?: number;
 	recurring?: boolean;
 	isRecurring?: boolean;
+}
+
+export interface Label extends BaseMarvinItem {
+	title: string;
+	groupId?: string;
+	color?: string;
+	icon?: string;
+	showAs?: "text" | "icon" | "both";
+	isAction?: boolean;
+	isHidden?: boolean;
 }
 
 export type TaskOrProject = Task | Project;

--- a/packages/marvin-client/src/types.ts
+++ b/packages/marvin-client/src/types.ts
@@ -1,0 +1,146 @@
+export type MarvinOrigin = "local" | "public" | "mixed";
+export type MarvinFreshness = "fresh" | "cached" | "stale";
+
+export interface BaseMarvinItem {
+	_id: string;
+	_rev?: string;
+	createdAt?: number;
+	updatedAt?: number;
+}
+
+export interface Subtask {
+	_id: string;
+	title: string;
+	done: boolean;
+	rank?: number;
+	timeEstimate?: number;
+}
+
+export interface Task extends BaseMarvinItem {
+	title: string;
+	done: boolean;
+	type?: "task";
+	parentId?: string;
+	day?: string;
+	firstScheduled?: string;
+	startDate?: string;
+	dueDate?: string;
+	endDate?: string;
+	doneAt?: number;
+	completedAt?: number;
+	note?: string;
+	labelIds?: string[];
+	timeEstimate?: number;
+	priority?: string;
+	recurring?: boolean;
+	isRecurring?: boolean;
+	subtasks?: Record<string, Subtask> | Subtask[];
+}
+
+export interface Project extends BaseMarvinItem {
+	title: string;
+	type: "project";
+	parentId?: string;
+	day?: string;
+	firstScheduled?: string;
+	startDate?: string;
+	dueDate?: string;
+	endDate?: string;
+	done?: boolean;
+	doneDate?: string;
+	note?: string;
+	labelIds?: string[];
+	timeEstimate?: number;
+	priority?: "low" | "mid" | "high";
+	recurring?: boolean;
+}
+
+export interface Category extends BaseMarvinItem {
+	title: string;
+	type?: "category";
+	parentId?: string;
+	startDate?: string;
+	dueDate?: string;
+	endDate?: string;
+	done?: boolean;
+	note?: string;
+	priority?: string;
+	rank?: number;
+	recurring?: boolean;
+	isRecurring?: boolean;
+}
+
+export type TaskOrProject = Task | Project;
+export type MarvinItem = Task | Project | Category;
+
+export interface AddTaskRequest {
+	title: string;
+	done?: boolean;
+	day?: string;
+	parentId?: string;
+	labelIds?: string[];
+	firstScheduled?: string;
+	rank?: number;
+	dailySection?: string;
+	bonusSection?: string;
+	customSection?: string;
+	timeBlockSection?: string;
+	note?: string;
+	dueDate?: string;
+	timeEstimate?: number;
+	isReward?: boolean;
+	isStarred?: boolean | number;
+	isFrogged?: boolean | number;
+	plannedWeek?: string;
+	plannedMonth?: string;
+	rewardPoints?: number;
+	rewardId?: string;
+	backburner?: boolean;
+	reviewDate?: string;
+	itemSnoozeTime?: number;
+	permaSnoozeTime?: string;
+	timeZoneOffset?: number;
+}
+
+export type MarkDoneResult = Record<string, unknown> | null;
+
+export interface MarvinErrorSummary {
+	kind: "http" | "throttle" | "transport" | "parse" | "validation" | "route";
+	message: string;
+	operation: string;
+	origin: Exclude<MarvinOrigin, "mixed">;
+	endpoint?: string;
+	method?: string;
+	status?: number;
+	statusText?: string;
+	responseBody?: string;
+	retryAfterMs?: number;
+}
+
+export interface MarvinReadResult<T> {
+	data: T;
+	freshness: MarvinFreshness;
+	origin: MarvinOrigin;
+	fetchedAt: number;
+	ageMs: number;
+	warnings: MarvinErrorSummary[];
+}
+
+export interface MarvinTransportRequest {
+	url: string;
+	method: "GET" | "POST";
+	headers: Record<string, string>;
+	body?: string;
+	timeoutMs: number;
+}
+
+export interface MarvinTransportResponse {
+	status: number;
+	statusText?: string;
+	headers: Record<string, string>;
+	text: string;
+}
+
+export interface MarvinTransport {
+	request(request: MarvinTransportRequest): Promise<MarvinTransportResponse>;
+}

--- a/packages/marvin-client/src/types.ts
+++ b/packages/marvin-client/src/types.ts
@@ -57,7 +57,7 @@ export interface Project extends BaseMarvinItem {
 
 export interface Category extends BaseMarvinItem {
 	title: string;
-	type?: "category";
+	type: "category";
 	parentId?: string;
 	labelIds?: string[];
 	startDate?: string;

--- a/packages/marvin-client/tsconfig.json
+++ b/packages/marvin-client/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "exactOptionalPropertyTypes": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/test-helpers.ts"
+  ]
+}

--- a/packages/marvin-client/tsconfig.test.json
+++ b/packages/marvin-client/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "types": [
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/marvin-mcp/package.json
+++ b/packages/marvin-mcp/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@open-horizon/marvin-mcp",
+  "version": "0.1.0",
+  "description": "In-repository MCP adapter for the shared Amazing Marvin client",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "amazing-marvin-mcp": "./dist/server.js"
+  },
+  "main": "./dist/server.js",
+  "types": "./dist/server.d.ts",
+  "scripts": {
+    "build": "npm run clean && esbuild src/server.ts --bundle --platform=node --target=node18 --format=esm --packages=external --banner:js='#!/usr/bin/env node' --outfile=dist/server.js && tsc --project tsconfig.json --emitDeclarationOnly",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "typecheck": "tsc --project tsconfig.test.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@open-horizon/marvin-client": "file:../marvin-client",
+    "zod": "^4.4.3"
+  },
+  "license": "MIT"
+}

--- a/packages/marvin-mcp/src/server.ts
+++ b/packages/marvin-mcp/src/server.ts
@@ -1,0 +1,64 @@
+import { pathToFileURL } from "node:url";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+	FetchTransport,
+	MarvinApiClient,
+	MarvinRouter,
+} from "@open-horizon/marvin-client";
+import { createMarvinMcpServer } from "./tools.js";
+
+export interface MarvinMcpEnvironment {
+	[key: string]: string | undefined;
+	AMAZING_MARVIN_API_TOKEN?: string;
+	AMAZING_MARVIN_PUBLIC_API_URL?: string;
+	AMAZING_MARVIN_USE_LOCAL?: string;
+	AMAZING_MARVIN_LOCAL_API_URL?: string;
+}
+
+export function createRouterFromEnvironment(
+	environment: MarvinMcpEnvironment = process.env,
+): MarvinRouter {
+	const apiToken = environment.AMAZING_MARVIN_API_TOKEN?.trim();
+	if (!apiToken) {
+		throw new Error("AMAZING_MARVIN_API_TOKEN is required");
+	}
+
+	const transport = new FetchTransport();
+	const publicClient = new MarvinApiClient({
+		apiToken,
+		baseUrl: environment.AMAZING_MARVIN_PUBLIC_API_URL
+			?? "https://serv.amazingmarvin.com/api",
+		origin: "public",
+		transport,
+	});
+	const localClient = environment.AMAZING_MARVIN_USE_LOCAL === "true"
+		? new MarvinApiClient({
+			apiToken,
+			baseUrl: environment.AMAZING_MARVIN_LOCAL_API_URL
+				?? "http://localhost:12082/api",
+			origin: "local",
+			transport,
+		})
+		: undefined;
+
+	return new MarvinRouter({
+		publicClient,
+		...(localClient === undefined ? {} : { localClient }),
+	});
+}
+
+export async function runMcpServer(
+	environment: MarvinMcpEnvironment = process.env,
+): Promise<void> {
+	const server = createMarvinMcpServer(createRouterFromEnvironment(environment));
+	await server.connect(new StdioServerTransport());
+	console.error("Amazing Marvin MCP server running on stdio");
+}
+
+const entry = process.argv[1];
+if (entry && import.meta.url === pathToFileURL(entry).href) {
+	runMcpServer().catch((error) => {
+		console.error("Amazing Marvin MCP server failed:", error);
+		process.exitCode = 1;
+	});
+}

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -26,6 +26,19 @@ function operations(overrides: Partial<MarvinOperations> = {}): MarvinOperations
 	return {
 		getTodayItems: async () => todayResult,
 		getDueItems: async () => ({ ...todayResult, data: [] }),
+		getCategories: async () => ({
+			...todayResult,
+			data: [{
+				_id: "project-1",
+				title: "Knowledge work",
+				type: "project",
+				parentId: "root",
+			}],
+		}),
+		getChildren: async () => ({
+			...todayResult,
+			data: [{ _id: "child-1", title: "Draft", done: false }],
+		}),
 		getLabels: async () => ({
 			...todayResult,
 			data: [{ _id: "label-1", title: "Knowledge work" }],
@@ -69,8 +82,18 @@ describe("Amazing Marvin MCP", () => {
 			name: "marvin_labels",
 			arguments: {},
 		});
+		const categories = await client.callTool({
+			name: "marvin_categories",
+			arguments: {},
+		});
+		const children = await client.callTool({
+			name: "marvin_children",
+			arguments: { parentId: "project-1" },
+		});
 
 		expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
+			"marvin_categories",
+			"marvin_children",
 			"marvin_create_task",
 			"marvin_due",
 			"marvin_labels",
@@ -92,6 +115,16 @@ describe("Amazing Marvin MCP", () => {
 				id: "label-1",
 				title: "Knowledge work",
 			}],
+		});
+		expect(categories.structuredContent).toMatchObject({
+			items: [{
+				id: "project-1",
+				parentId: "root",
+				deepLink: "https://app.amazingmarvin.com/#p=project-1",
+			}],
+		});
+		expect(children.structuredContent).toMatchObject({
+			items: [{ id: "child-1", title: "Draft" }],
 		});
 	});
 

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -172,6 +172,24 @@ describe("Amazing Marvin MCP", () => {
 		});
 	});
 
+	it("returns malformed dates in the structured error envelope", async () => {
+		const client = await connect(operations());
+
+		const result = await client.callTool({
+			name: "marvin_today",
+			arguments: { date: "not-a-date" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toEqual({
+			error: {
+				kind: "input",
+				field: "date",
+				message: "Use YYYY-MM-DD",
+			},
+		});
+	});
+
 	it("routes create and completion tools through the shared operations", async () => {
 		const calls: unknown[] = [];
 		const client = await connect(operations({

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -1,0 +1,179 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+	MarvinError,
+	MarvinRouteError,
+	type MarvinReadResult,
+	type Task,
+	type TaskOrProject,
+} from "@open-horizon/marvin-client";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createMarvinMcpServer,
+	type MarvinOperations,
+} from "./tools.js";
+
+const todayResult: MarvinReadResult<TaskOrProject[]> = {
+	data: [{ _id: "task-1", title: "Decide", done: false }],
+	freshness: "fresh",
+	origin: "public",
+	fetchedAt: 1_721_753_600_000,
+	ageMs: 0,
+	warnings: [],
+};
+
+function operations(overrides: Partial<MarvinOperations> = {}): MarvinOperations {
+	return {
+		getTodayItems: async () => todayResult,
+		getDueItems: async () => ({ ...todayResult, data: [] }),
+		addTask: async (input): Promise<Task> => ({
+			_id: "created-1",
+			title: input.title,
+			done: false,
+		}),
+		markDone: async () => ({ success: true }),
+		...overrides,
+	};
+}
+
+describe("Amazing Marvin MCP", () => {
+	const close: Array<() => Promise<void>> = [];
+
+	afterEach(async () => {
+		await Promise.all(close.splice(0).map((callback) => callback()));
+	});
+
+	async function connect(ops: MarvinOperations) {
+		const server = createMarvinMcpServer(ops);
+		const client = new Client({ name: "test-client", version: "0.1.0" });
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+		close.push(() => client.close(), () => server.close());
+		return client;
+	}
+
+	it("exposes the bounded tool set and stable task IDs", async () => {
+		const client = await connect(operations());
+
+		const tools = await client.listTools();
+		const result = await client.callTool({
+			name: "marvin_today",
+			arguments: { date: "2026-07-23" },
+		});
+
+		expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
+			"marvin_create_task",
+			"marvin_due",
+			"marvin_mark_done",
+			"marvin_today",
+		]);
+		expect(result.isError).not.toBe(true);
+		expect(result.structuredContent).toMatchObject({
+			freshness: "fresh",
+			origin: "public",
+			items: [{
+				id: "task-1",
+				title: "Decide",
+				deepLink: "https://app.amazingmarvin.com/#t=task-1",
+			}],
+		});
+	});
+
+	it("returns actionable attempted-origin errors through MCP", async () => {
+		const routeError = new MarvinRouteError("today items", [
+			new MarvinError({
+				kind: "transport",
+				message: "ECONNREFUSED",
+				operation: "today items",
+				origin: "local",
+			}),
+			new MarvinError({
+				kind: "throttle",
+				message: "Rate limited",
+				operation: "today items",
+				origin: "public",
+				status: 429,
+				retryAfterMs: 30_000,
+			}),
+		]);
+		const client = await connect(operations({
+			getTodayItems: async () => {
+				throw routeError;
+			},
+		}));
+
+		const result = await client.callTool({
+			name: "marvin_today",
+			arguments: {},
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toMatchObject({
+			error: {
+				attempts: [
+					{ origin: "local", kind: "transport", message: "ECONNREFUSED" },
+					{
+						origin: "public",
+						kind: "throttle",
+						status: 429,
+						retryAfterMs: 30_000,
+					},
+				],
+			},
+		});
+	});
+
+	it("routes create and completion tools through the shared operations", async () => {
+		const calls: unknown[] = [];
+		const client = await connect(operations({
+			addTask: async (input) => {
+				calls.push(["addTask", input]);
+				return { _id: "created-1", title: input.title, done: false };
+			},
+			markDone: async (itemId, timeZoneOffset) => {
+				calls.push(["markDone", itemId, timeZoneOffset]);
+				return { success: true };
+			},
+		}));
+
+		const created = await client.callTool({
+			name: "marvin_create_task",
+			arguments: {
+				title: "Prepare application",
+				day: "2026-07-23",
+				parentId: "project-1",
+			},
+		});
+		const completed = await client.callTool({
+			name: "marvin_mark_done",
+			arguments: {
+				itemId: "created-1",
+				timeZoneOffset: -240,
+			},
+		});
+
+		expect(created.structuredContent).toMatchObject({
+			task: {
+				id: "created-1",
+				title: "Prepare application",
+				deepLink: "https://app.amazingmarvin.com/#t=created-1",
+			},
+		});
+		expect(completed.structuredContent).toMatchObject({
+			itemId: "created-1",
+			result: { success: true },
+		});
+		expect(calls).toMatchObject([
+			[
+				"addTask",
+				{
+					title: "Prepare application",
+					day: "2026-07-23",
+					parentId: "project-1",
+				},
+			],
+			["markDone", "created-1", -240],
+		]);
+	});
+});

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -26,6 +26,10 @@ function operations(overrides: Partial<MarvinOperations> = {}): MarvinOperations
 	return {
 		getTodayItems: async () => todayResult,
 		getDueItems: async () => ({ ...todayResult, data: [] }),
+		getLabels: async () => ({
+			...todayResult,
+			data: [{ _id: "label-1", title: "Knowledge work" }],
+		}),
 		addTask: async (input): Promise<Task> => ({
 			_id: "created-1",
 			title: input.title,
@@ -61,10 +65,15 @@ describe("Amazing Marvin MCP", () => {
 			name: "marvin_today",
 			arguments: { date: "2026-07-23" },
 		});
+		const labels = await client.callTool({
+			name: "marvin_labels",
+			arguments: {},
+		});
 
 		expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
 			"marvin_create_task",
 			"marvin_due",
+			"marvin_labels",
 			"marvin_mark_done",
 			"marvin_today",
 		]);
@@ -76,6 +85,12 @@ describe("Amazing Marvin MCP", () => {
 				id: "task-1",
 				title: "Decide",
 				deepLink: "https://app.amazingmarvin.com/#t=task-1",
+			}],
+		});
+		expect(labels.structuredContent).toMatchObject({
+			labels: [{
+				id: "label-1",
+				title: "Knowledge work",
 			}],
 		});
 	});
@@ -143,6 +158,7 @@ describe("Amazing Marvin MCP", () => {
 				title: "Prepare application",
 				day: "2026-07-23",
 				parentId: "project-1",
+				labelIds: ["label-1"],
 			},
 		});
 		const completed = await client.callTool({
@@ -171,6 +187,7 @@ describe("Amazing Marvin MCP", () => {
 					title: "Prepare application",
 					day: "2026-07-23",
 					parentId: "project-1",
+					labelIds: ["label-1"],
 				},
 			],
 			["markDone", "created-1", -240],

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -3,6 +3,7 @@ import * as z from "zod/v4";
 import {
 	MarvinError,
 	MarvinRouteError,
+	type Label,
 	type MarvinRouter,
 	type TaskOrProject,
 	marvinDeepLink,
@@ -10,7 +11,7 @@ import {
 
 export type MarvinOperations = Pick<
 	MarvinRouter,
-	"getTodayItems" | "getDueItems" | "addTask" | "markDone"
+	"getTodayItems" | "getDueItems" | "getLabels" | "addTask" | "markDone"
 >;
 
 const dateSchema = z.string()
@@ -29,6 +30,18 @@ function itemForTool(item: TaskOrProject) {
 		...(item.dueDate === undefined ? {} : { dueDate: item.dueDate }),
 		...(item.startDate === undefined ? {} : { startDate: item.startDate }),
 		...(item.note === undefined ? {} : { note: item.note }),
+	};
+}
+
+function labelForTool(label: Label) {
+	return {
+		id: label._id,
+		title: label.title,
+		...(label.groupId === undefined ? {} : { groupId: label.groupId }),
+		...(label.color === undefined ? {} : { color: label.color }),
+		...(label.icon === undefined ? {} : { icon: label.icon }),
+		...(label.isAction === undefined ? {} : { isAction: label.isAction }),
+		...(label.isHidden === undefined ? {} : { isHidden: label.isHidden }),
 	};
 }
 
@@ -116,12 +129,34 @@ export function createMarvinMcpServer(
 		}
 	});
 
+	server.registerTool("marvin_labels", {
+		title: "Amazing Marvin Labels",
+		description: "Read stable label IDs and titles for task creation and filtering.",
+		inputSchema: {},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async () => {
+		try {
+			const { data, ...metadata } = await operations.getLabels();
+			return success({
+				...metadata,
+				labels: data.map(labelForTool),
+			});
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
 	server.registerTool("marvin_create_task", {
 		title: "Create Amazing Marvin Task",
 		description: "Create one task in Amazing Marvin with the limited API token.",
 		inputSchema: {
 			title: z.string().trim().min(1).describe("Task title; Marvin shortcuts are supported"),
 			parentId: z.string().trim().min(1).optional(),
+			labelIds: z.array(z.string().trim().min(1)).optional()
+				.describe("Stable IDs returned by marvin_labels"),
 			day: dateSchema,
 			dueDate: dateSchema,
 			note: z.string().optional(),
@@ -140,6 +175,7 @@ export function createMarvinMcpServer(
 				title: input.title,
 				timeZoneOffset: new Date().getTimezoneOffset() * -1,
 				...(input.parentId === undefined ? {} : { parentId: input.parentId }),
+				...(input.labelIds === undefined ? {} : { labelIds: input.labelIds }),
 				...(input.day === undefined ? {} : { day: input.day }),
 				...(input.dueDate === undefined ? {} : { dueDate: input.dueDate }),
 				...(input.note === undefined ? {} : { note: input.note }),

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -21,9 +21,41 @@ export type MarvinOperations = Pick<
 	| "markDone"
 >;
 
-const dateSchema = z.string()
-	.regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD")
-	.optional();
+// Validate dates in the handler rather than the SDK schema path. MCP schema
+// failures are emitted as text-only protocol errors before a tool handler can
+// return the structured error envelope LLM callers rely on.
+const dateSchema = z.string().optional();
+
+class MarvinMcpInputError extends Error {
+	constructor(
+		readonly field: string,
+		message: string,
+	) {
+		super(message);
+		this.name = "MarvinMcpInputError";
+	}
+
+	toSummary() {
+		return {
+			kind: "input",
+			field: this.field,
+			message: this.message,
+		};
+	}
+}
+
+function requireOptionalDate(
+	value: string | undefined,
+	field: string,
+): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		throw new MarvinMcpInputError(field, "Use YYYY-MM-DD");
+	}
+	return value;
+}
 
 function itemForTool(item: MarvinItem) {
 	return {
@@ -72,7 +104,9 @@ function readSuccess(result: MarvinReadResult<MarvinItem[]>) {
 }
 
 function failure(error: unknown) {
-	const details = error instanceof MarvinRouteError
+	const details = error instanceof MarvinMcpInputError
+		? error.toSummary()
+		: error instanceof MarvinRouteError
 		? {
 			message: error.message,
 			attempts: error.attempts.map((attempt) => attempt.toSummary()),
@@ -113,7 +147,9 @@ export function createMarvinMcpServer(
 		},
 	}, async ({ date }) => {
 		try {
-			return readSuccess(await operations.getTodayItems(date));
+			return readSuccess(await operations.getTodayItems(
+				requireOptionalDate(date, "date"),
+			));
 		} catch (error) {
 			return failure(error);
 		}
@@ -131,7 +167,9 @@ export function createMarvinMcpServer(
 		},
 	}, async ({ date }) => {
 		try {
-			return readSuccess(await operations.getDueItems(date));
+			return readSuccess(await operations.getDueItems(
+				requireOptionalDate(date, "date"),
+			));
 		} catch (error) {
 			return failure(error);
 		}
@@ -214,13 +252,15 @@ export function createMarvinMcpServer(
 		},
 	}, async (input) => {
 		try {
+			const day = requireOptionalDate(input.day, "day");
+			const dueDate = requireOptionalDate(input.dueDate, "dueDate");
 			const task = await operations.addTask({
 				title: input.title,
 				timeZoneOffset: new Date().getTimezoneOffset() * -1,
 				...(input.parentId === undefined ? {} : { parentId: input.parentId }),
 				...(input.labelIds === undefined ? {} : { labelIds: input.labelIds }),
-				...(input.day === undefined ? {} : { day: input.day }),
-				...(input.dueDate === undefined ? {} : { dueDate: input.dueDate }),
+				...(day === undefined ? {} : { day }),
+				...(dueDate === undefined ? {} : { dueDate }),
 				...(input.note === undefined ? {} : { note: input.note }),
 				...(input.timeEstimate === undefined ? {} : { timeEstimate: input.timeEstimate }),
 			});

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -24,7 +24,9 @@ export type MarvinOperations = Pick<
 // Validate dates in the handler rather than the SDK schema path. MCP schema
 // failures are emitted as text-only protocol errors before a tool handler can
 // return the structured error envelope LLM callers rely on.
-const dateSchema = z.string().optional();
+const dateSchema = z.string()
+	.describe("Date in YYYY-MM-DD format")
+	.optional();
 
 class MarvinMcpInputError extends Error {
 	constructor(
@@ -139,7 +141,9 @@ export function createMarvinMcpServer(
 		title: "Amazing Marvin Today",
 		description: "Read tasks and projects scheduled for a date in Amazing Marvin.",
 		inputSchema: {
-			date: dateSchema.describe("Optional date; defaults to Marvin's server date"),
+			date: dateSchema.describe(
+				"Optional YYYY-MM-DD date; defaults to Marvin's server date",
+			),
 		},
 		annotations: {
 			readOnlyHint: true,
@@ -159,7 +163,9 @@ export function createMarvinMcpServer(
 		title: "Amazing Marvin Due",
 		description: "Read open tasks and projects due on or before a date.",
 		inputSchema: {
-			date: dateSchema.describe("Optional inclusive due date; defaults to Marvin's server date"),
+			date: dateSchema.describe(
+				"Optional inclusive YYYY-MM-DD date; defaults to Marvin's server date",
+			),
 		},
 		annotations: {
 			readOnlyHint: true,

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -1,0 +1,184 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+import {
+	MarvinError,
+	MarvinRouteError,
+	type MarvinRouter,
+	type TaskOrProject,
+	marvinDeepLink,
+} from "@open-horizon/marvin-client";
+
+export type MarvinOperations = Pick<
+	MarvinRouter,
+	"getTodayItems" | "getDueItems" | "addTask" | "markDone"
+>;
+
+const dateSchema = z.string()
+	.regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD")
+	.optional();
+
+function itemForTool(item: TaskOrProject) {
+	return {
+		id: item._id,
+		title: item.title,
+		type: item.type ?? "task",
+		done: item.done ?? false,
+		deepLink: marvinDeepLink(item),
+		...(item.parentId === undefined ? {} : { parentId: item.parentId }),
+		...(item.day === undefined ? {} : { day: item.day }),
+		...(item.dueDate === undefined ? {} : { dueDate: item.dueDate }),
+		...(item.startDate === undefined ? {} : { startDate: item.startDate }),
+		...(item.note === undefined ? {} : { note: item.note }),
+	};
+}
+
+function success(structuredContent: Record<string, unknown>) {
+	return {
+		content: [{
+			type: "text" as const,
+			text: JSON.stringify(structuredContent, null, 2),
+		}],
+		structuredContent,
+	};
+}
+
+function readSuccess(result: Awaited<ReturnType<MarvinOperations["getTodayItems"]>>) {
+	const { data, ...metadata } = result;
+	return success({
+		...metadata,
+		items: data.map(itemForTool),
+	});
+}
+
+function failure(error: unknown) {
+	const details = error instanceof MarvinRouteError
+		? {
+			message: error.message,
+			attempts: error.attempts.map((attempt) => attempt.toSummary()),
+		}
+		: error instanceof MarvinError
+			? error.toSummary()
+			: {
+				message: error instanceof Error ? error.message : String(error),
+			};
+
+	return {
+		isError: true,
+		content: [{
+			type: "text" as const,
+			text: JSON.stringify({ error: details }, null, 2),
+		}],
+		structuredContent: { error: details },
+	};
+}
+
+export function createMarvinMcpServer(
+	operations: MarvinOperations,
+): McpServer {
+	const server = new McpServer({
+		name: "amazing-marvin",
+		version: "0.1.0",
+	});
+
+	server.registerTool("marvin_today", {
+		title: "Amazing Marvin Today",
+		description: "Read tasks and projects scheduled for a date in Amazing Marvin.",
+		inputSchema: {
+			date: dateSchema.describe("Optional date; defaults to Marvin's server date"),
+		},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async ({ date }) => {
+		try {
+			return readSuccess(await operations.getTodayItems(date));
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_due", {
+		title: "Amazing Marvin Due",
+		description: "Read open tasks and projects due on or before a date.",
+		inputSchema: {
+			date: dateSchema.describe("Optional inclusive due date; defaults to Marvin's server date"),
+		},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async ({ date }) => {
+		try {
+			return readSuccess(await operations.getDueItems(date));
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_create_task", {
+		title: "Create Amazing Marvin Task",
+		description: "Create one task in Amazing Marvin with the limited API token.",
+		inputSchema: {
+			title: z.string().trim().min(1).describe("Task title; Marvin shortcuts are supported"),
+			parentId: z.string().trim().min(1).optional(),
+			day: dateSchema,
+			dueDate: dateSchema,
+			note: z.string().optional(),
+			timeEstimate: z.number().int().nonnegative().optional()
+				.describe("Estimated duration in milliseconds"),
+		},
+		annotations: {
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		},
+	}, async (input) => {
+		try {
+			const task = await operations.addTask({
+				title: input.title,
+				timeZoneOffset: new Date().getTimezoneOffset() * -1,
+				...(input.parentId === undefined ? {} : { parentId: input.parentId }),
+				...(input.day === undefined ? {} : { day: input.day }),
+				...(input.dueDate === undefined ? {} : { dueDate: input.dueDate }),
+				...(input.note === undefined ? {} : { note: input.note }),
+				...(input.timeEstimate === undefined ? {} : { timeEstimate: input.timeEstimate }),
+			});
+			return success({ task: itemForTool(task) });
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_mark_done", {
+		title: "Complete Amazing Marvin Task",
+		description: "Mark one Amazing Marvin task or project complete by stable ID.",
+		inputSchema: {
+			itemId: z.string().trim().min(1).describe("Stable Amazing Marvin item ID"),
+			timeZoneOffset: z.number().int().optional()
+				.describe("Minutes from UTC; defaults to the MCP process timezone"),
+		},
+		annotations: {
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		},
+	}, async ({ itemId, timeZoneOffset }) => {
+		try {
+			const result = await operations.markDone(
+				itemId,
+				timeZoneOffset ?? new Date().getTimezoneOffset() * -1,
+			);
+			return success({
+				itemId,
+				result,
+			});
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	return server;
+}

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -4,21 +4,28 @@ import {
 	MarvinError,
 	MarvinRouteError,
 	type Label,
+	type MarvinItem,
+	type MarvinReadResult,
 	type MarvinRouter,
-	type TaskOrProject,
 	marvinDeepLink,
 } from "@open-horizon/marvin-client";
 
 export type MarvinOperations = Pick<
 	MarvinRouter,
-	"getTodayItems" | "getDueItems" | "getLabels" | "addTask" | "markDone"
+	| "getTodayItems"
+	| "getDueItems"
+	| "getCategories"
+	| "getChildren"
+	| "getLabels"
+	| "addTask"
+	| "markDone"
 >;
 
 const dateSchema = z.string()
 	.regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD")
 	.optional();
 
-function itemForTool(item: TaskOrProject) {
+function itemForTool(item: MarvinItem) {
 	return {
 		id: item._id,
 		title: item.title,
@@ -26,10 +33,11 @@ function itemForTool(item: TaskOrProject) {
 		done: item.done ?? false,
 		deepLink: marvinDeepLink(item),
 		...(item.parentId === undefined ? {} : { parentId: item.parentId }),
-		...(item.day === undefined ? {} : { day: item.day }),
+		...(!("day" in item) || item.day === undefined ? {} : { day: item.day }),
 		...(item.dueDate === undefined ? {} : { dueDate: item.dueDate }),
 		...(item.startDate === undefined ? {} : { startDate: item.startDate }),
 		...(item.note === undefined ? {} : { note: item.note }),
+		...(item.labelIds === undefined ? {} : { labelIds: item.labelIds }),
 	};
 }
 
@@ -55,7 +63,7 @@ function success(structuredContent: Record<string, unknown>) {
 	};
 }
 
-function readSuccess(result: Awaited<ReturnType<MarvinOperations["getTodayItems"]>>) {
+function readSuccess(result: MarvinReadResult<MarvinItem[]>) {
 	const { data, ...metadata } = result;
 	return success({
 		...metadata,
@@ -124,6 +132,41 @@ export function createMarvinMcpServer(
 	}, async ({ date }) => {
 		try {
 			return readSuccess(await operations.getDueItems(date));
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_categories", {
+		title: "Amazing Marvin Categories and Projects",
+		description: "Read stable category/project IDs and their parent hierarchy.",
+		inputSchema: {},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async () => {
+		try {
+			return readSuccess(await operations.getCategories());
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_children", {
+		title: "Amazing Marvin Children",
+		description: "Read direct tasks and projects below one stable parent ID.",
+		inputSchema: {
+			parentId: z.string().trim().min(1)
+				.describe("Category/project ID, or unassigned for Inbox"),
+		},
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: true,
+		},
+	}, async ({ parentId }) => {
+		try {
+			return readSuccess(await operations.getChildren(parentId));
 		} catch (error) {
 			return failure(error);
 		}

--- a/packages/marvin-mcp/tsconfig.json
+++ b/packages/marvin-mcp/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "exactOptionalPropertyTypes": true,
+    "lib": [
+      "DOM",
+      "ES2022"
+    ],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/marvin-mcp/tsconfig.test.json
+++ b/packages/marvin-mcp/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "types": [
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/src/addTaskModal.ts
+++ b/src/addTaskModal.ts
@@ -69,13 +69,18 @@ export class AddTaskModal extends Modal {
   onSubmit: (result: { catId: string, task: string }) => void;
   categories: Category[];
 
-  constructor(app: App, categories: Category[], onSubmit: (result: { catId: string; task: string; }) => void) {
+  constructor(
+    app: App,
+    categories: Category[],
+    onSubmit: (result: { catId: string; task: string; }) => void,
+    defaultCategoryId = inboxCategory._id,
+  ) {
     super(app);
     this.onSubmit = onSubmit;
     this.categories = categories.sort((a, b) => {
       return this.getFullPathToCategoryTitle(a, categories).localeCompare(this.getFullPathToCategoryTitle(b, categories));
     });
-    this.result = { catId: inboxCategory._id, task: '' };
+    this.result = { catId: defaultCategoryId, task: '' };
   }
 
   onOpen() {
@@ -88,8 +93,11 @@ export class AddTaskModal extends Modal {
       .setName("Category")
       .addText(text => {
         categoryInput = text.inputEl;
-        text.setValue(inboxCategory.title);
-        this.result.catId = inboxCategory._id;
+        const selectedCategory = this.categories.find(
+          category => category._id === this.result.catId,
+        ) ?? inboxCategory;
+        text.setValue(selectedCategory.title);
+        this.result.catId = selectedCategory._id;
         text.onChange(value => {
           const suggester = new CategorySuggesterModal(this.app, this.categories, (item: Category) => {
             categoryInput.value = item.title;

--- a/src/amTaskWatcher.ts
+++ b/src/amTaskWatcher.ts
@@ -23,7 +23,9 @@ export function amTaskWatcher(_app: App, plugin: AmazingMarvinPlugin) {
           let line = update.state.doc.lineAt(fromA).text;
           const match = line.match(COMPLETED_AM_TASK);
           if (match && match[1]) {
-            plugin.markDone(match[1]);
+            void plugin.markDone(match[1]).catch((error) => {
+              console.error("Could not mark Amazing Marvin task as done:", error);
+            });
           }
         });
       }

--- a/src/amTaskWatcher.ts
+++ b/src/amTaskWatcher.ts
@@ -5,8 +5,7 @@ import {
   ViewPlugin,
   ViewUpdate,
 } from '@codemirror/view';
-
-const COMPLETED_AM_TASK = /^\s*[-*+]\s\[[xX]\]\s\[⚓\]\(https:\/\/app\.amazingmarvin\.com\/#t=([^)\s]+)/;
+import { isNewlyCompletedMarvinTask } from "./marvin/taskLine";
 
 export function amTaskWatcher(_app: App, plugin: AmazingMarvinPlugin) {
   return ViewPlugin.fromClass(
@@ -18,12 +17,12 @@ export function amTaskWatcher(_app: App, plugin: AmazingMarvinPlugin) {
         if (!update.docChanged) {
           return;
         }
-        update.changes.iterChanges((fromA, _toA, _fromB, _toB, change) => {
-          //only match if the change is on an AM task and it's a completed task
-          let line = update.state.doc.lineAt(fromA).text;
-          const match = line.match(COMPLETED_AM_TASK);
-          if (match && match[1]) {
-            void plugin.markDone(match[1]).catch((error) => {
+        update.changes.iterChanges((fromA, _toA, fromB) => {
+          const before = update.startState.doc.lineAt(fromA).text;
+          const after = update.state.doc.lineAt(fromB).text;
+          const taskId = isNewlyCompletedMarvinTask(before, after);
+          if (taskId) {
+            void plugin.markDone(taskId).catch((error) => {
               console.error("Could not mark Amazing Marvin task as done:", error);
             });
           }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,63 @@
+import type {
+	AddTaskRequest,
+	EnsureSourceActionResult,
+	MarvinReadResult,
+	ResolvePendingSourceActionRequest,
+	TaskOrProject,
+} from "@open-horizon/marvin-client";
+
+export interface EnsureTaskForSourceInput {
+	sourcePath: string;
+	actionKey: string;
+	title: string;
+	parentId?: string;
+	day?: string;
+	dueDate?: string;
+	labelIds?: string[];
+	note?: string;
+}
+
+export interface RefreshTodayTasksInput {
+	date: string;
+	filePath?: string;
+}
+
+export interface RefreshTodayTasksResult {
+	date: string;
+	filePath: string;
+	changed: boolean;
+	createdRegion: boolean;
+	morningIds: string[];
+	lateIds: string[];
+	freshness: MarvinReadResult<unknown>["freshness"];
+	origin: MarvinReadResult<unknown>["origin"];
+	warnings: MarvinReadResult<unknown>["warnings"];
+}
+
+/**
+ * Stable automation surface for Templater and other in-Obsidian callers.
+ *
+ * Access it as:
+ * `app.plugins.plugins["cloudatlas-o-am"].api`
+ */
+export interface AmazingMarvinApi {
+	getToday(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	getDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	getTodayAndDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	createTask(task: AddTaskRequest): Promise<TaskOrProject>;
+	ensureTaskForSource(
+		input: EnsureTaskForSourceInput,
+	): Promise<EnsureSourceActionResult>;
+	resolvePendingSourceAction(
+		input: Omit<ResolvePendingSourceActionRequest, "sourceKey"> & {
+			sourcePath: string;
+		},
+	): Promise<EnsureSourceActionResult>;
+	clearPendingSourceAction(input: {
+		sourcePath: string;
+		actionKey: string;
+	}): Promise<void>;
+	refreshTodayTasks(
+		input: RefreshTodayTasksInput,
+	): Promise<RefreshTodayTasksResult>;
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import type {
 	AddTaskRequest,
 	EnsureSourceActionResult,
+	Label,
 	MarvinReadResult,
 	ResolvePendingSourceActionRequest,
 	TaskOrProject,
@@ -44,6 +45,7 @@ export interface AmazingMarvinApi {
 	getToday(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
 	getDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
 	getTodayAndDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	getLabels(): Promise<MarvinReadResult<Label[]>>;
 	createTask(task: AddTaskRequest): Promise<TaskOrProject>;
 	ensureTaskForSource(
 		input: EnsureTaskForSourceInput,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,9 +1,12 @@
 import type {
 	AddTaskRequest,
+	Category,
 	EnsureSourceActionResult,
 	Label,
 	MarvinReadResult,
+	Project,
 	ResolvePendingSourceActionRequest,
+	Task,
 	TaskOrProject,
 } from "@open-horizon/marvin-client";
 
@@ -45,6 +48,8 @@ export interface AmazingMarvinApi {
 	getToday(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
 	getDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
 	getTodayAndDue(date: string): Promise<MarvinReadResult<TaskOrProject[]>>;
+	getCategories(): Promise<MarvinReadResult<(Category | Project)[]>>;
+	getChildren(parentId: string): Promise<MarvinReadResult<(Task | Project)[]>>;
 	getLabels(): Promise<MarvinReadResult<Label[]>>;
 	createTask(task: AddTaskRequest): Promise<TaskOrProject>;
 	ensureTaskForSource(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,35 +1,14 @@
-export interface Category {
-	_id: string;
-	title: string;
-	type: string;
-	updatedAt: number;
-	parentId: string;
-	startDate: string;
-	endDate: string;
-	note: string;
-	isRecurring: boolean;
-	priority: string;
-	deepLink: string;
-	dueDate: string;
-	done: boolean;
-}
+import type {
+	Category as MarvinCategory,
+	Project as MarvinProject,
+	Task as MarvinTask,
+} from "@open-horizon/marvin-client";
 
-export interface Task {
-	done: boolean;
-	subtasks: Task[];
-	_id: string;
-	title: string;
-	updatedAt: number;
-	parentId: string;
-	day: string
-	firstScheduled: string;
-	startDate: string;
-	dueDate: string;
-	endDate: string;
-	note: string;
-	doneAt: number;
-	isRecurring: boolean;
-	priority: string;
-	type: string;
+export type Category = (
+	| (Omit<MarvinCategory, "type"> & { type?: "category" | "faux" })
+	| MarvinProject
+) & { deepLink: string };
+
+export type Task = MarvinTask & {
 	deepLink: string;
-}
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,11 @@ import {
 } from "./marvin/todayProjection";
 import { runTodayProjection } from "./marvin/todayWorkflow";
 import {
+	categoryProjectionItems,
+	planCategorySync,
+	type CategorySyncPlan,
+} from "./marvin/syncSelection";
+import {
 	formatTaskMetadata,
 	formatMarvinLabelTags,
 	orderTaskBody,
@@ -121,6 +126,8 @@ export default class AmazingMarvinPlugin extends Plugin {
 		getToday: (date) => this.getMarvinRouter().getTodayItems(date),
 		getDue: (date) => this.getMarvinRouter().getDueItems(date),
 		getTodayAndDue: (date) => this.getMarvinRouter().getTodayAndDue(date),
+		getCategories: () => this.getMarvinRouter().getCategories(),
+		getChildren: (parentId) => this.getMarvinRouter().getChildren(parentId),
 		getLabels: () => this.getMarvinRouter().getLabels(),
 		createTask: async (task) => {
 			const created = await this.getMarvinRouter().addTask(task);
@@ -592,9 +599,16 @@ export default class AmazingMarvinPlugin extends Plugin {
 		await this.refreshLabelsForProjection();
 		const categories = await this.getCategories();
 		this.categories = categories;
+		const plan = planCategorySync(
+			categories,
+			this.settings.syncSelectionMode,
+			this.settings.syncRoots.map((root) => root.id),
+		);
 		const existingFiles = await this.findManagedImportFiles();
-		await this.processCategories(existingFiles);
-		await this.processInbox(existingFiles);
+		await this.processCategories(existingFiles, plan);
+		if (this.settings.syncInbox) {
+			await this.processInbox(existingFiles);
+		}
 	}
 
 	async getCategories(): Promise<Category[]> {
@@ -700,11 +714,19 @@ export default class AmazingMarvinPlugin extends Plugin {
 		));
 	}
 
-	async processCategories(existingFiles: Map<string, TFile>) {
-		for (const category of this.categories) {
+	async processCategories(
+		existingFiles: Map<string, TFile>,
+		plan: CategorySyncPlan,
+	) {
+		for (const category of this.categories.filter(
+			(item) => plan.includedIds.has(item._id),
+		)) {
 			const path = this.getPathForCategory(category);
 			await this.moveManagedFile(existingFiles.get(category._id), path);
-			const content = await this.createContentForCategory(category);
+			const content = await this.createContentForCategory(
+				category,
+				plan,
+			);
 			await this.createOrUpdateManaged(
 				path,
 				category._id,
@@ -715,7 +737,12 @@ export default class AmazingMarvinPlugin extends Plugin {
 		}
 	}
 
-	formatItems(items: (Task | Category)[], level = 0, isSubtask = false) {
+	formatItems(
+		items: (Task | Category)[],
+		level = 0,
+		isSubtask = false,
+		allowedContainerIds?: ReadonlySet<string>,
+	) {
 		let taskContent = '';
 		let categoryContent = '';
 
@@ -724,6 +751,9 @@ export default class AmazingMarvinPlugin extends Plugin {
 			const isCategoryOrProject = item.type === 'category' || item.type === 'project';
 
 			if (isCategoryOrProject) {
+				if (allowedContainerIds && !allowedContainerIds.has(item._id)) {
+					continue;
+				}
 				// Handle category or project formatting
 				const path = this.getPathForCategory(item);
 				categoryContent += `${indentation}- [[${this.wikiTarget(path)}|${this.wikiAlias(item.title)}]] [⚓](${item.deepLink})\n`;
@@ -742,7 +772,12 @@ export default class AmazingMarvinPlugin extends Plugin {
 						type: "task" as const,
 						deepLink: "",
 					})) as Task[];
-					taskContent += this.formatItems(subtasks, level + 1, true); // Pass true for isSubtask
+					taskContent += this.formatItems(
+						subtasks,
+						level + 1,
+						true,
+						allowedContainerIds,
+					);
 				}
 			}
 		}
@@ -797,7 +832,10 @@ export default class AmazingMarvinPlugin extends Plugin {
 		};
 	}
 
-	async createContentForCategory(category: Category): Promise<string> {
+	async createContentForCategory(
+		category: Category,
+		plan: CategorySyncPlan,
+	): Promise<string> {
 		const labelTags = this.settings.showMarvinLabelsAsTags
 			? formatMarvinLabelTags(
 				category.labelIds,
@@ -818,8 +856,21 @@ export default class AmazingMarvinPlugin extends Plugin {
 			}
 		}
 		// Fetch and format tasks
-		const children = await this.getChildren(category._id);
-		content += this.formatItems(children);
+		const fetchedChildren = plan.contentIds.has(category._id)
+			? await this.getChildren(category._id)
+			: undefined;
+		const children = categoryProjectionItems(
+			category._id,
+			plan,
+			this.categories,
+			fetchedChildren,
+		);
+		content += this.formatItems(
+			children,
+			0,
+			false,
+			plan.includedIds,
+		);
 
 		return content;
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,17 @@ import {
 	type TodayProjectionItem,
 } from "./marvin/todayProjection";
 import { runTodayProjection } from "./marvin/todayWorkflow";
+import { CouchChangesClient } from "./marvin/couchChanges";
+import {
+	IncrementalMarvinCache,
+	IncrementalRetryBackoff,
+	type CachedMarvinItem,
+	type IncrementalUpdate,
+} from "./marvin/incrementalCache";
+import {
+	ObsidianIncrementalCacheStore,
+	createObsidianCouchTransport,
+} from "./marvin/obsidianIncremental";
 import {
 	categoryProjectionItems,
 	planCategorySync,
@@ -118,6 +129,15 @@ export default class AmazingMarvinPlugin extends Plugin {
 	private sourceActionService?: SourceActionService;
 	private sourceActionRouter?: MarvinRouter;
 	private marvinLabelsById = new Map<string, Label>();
+	private incrementalCache?: IncrementalMarvinCache;
+	private incrementalCacheKey = "";
+	private incrementalBackoff = new IncrementalRetryBackoff();
+	private incrementalRun?: Promise<void>;
+	private incrementalGeneration = 0;
+	private lastAutomaticIncrementalAt = 0;
+	private lastIncrementalError = "";
+	private lastIncrementalSyncAt = 0;
+	private categoryProjectionTail: Promise<void> = Promise.resolve();
 	private readonly todayRefreshes = new Map<string, Promise<RefreshTodayTasksResult>>();
 	private lastAutomaticRefreshAt = 0;
 	private lastAutomaticRefreshError = "";
@@ -132,6 +152,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		createTask: async (task) => {
 			const created = await this.getMarvinRouter().addTask(task);
 			this.queueManagedTodayRefresh("creating a task");
+			this.queueIncrementalCatchUp("creating a task");
 			return created;
 		},
 		ensureTaskForSource: (input) => this.ensureTaskForSource(input),
@@ -143,6 +164,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 				...(input.title === undefined ? {} : { title: input.title }),
 			});
 			this.queueManagedTodayRefresh("resolving a contextual task");
+			this.queueIncrementalCatchUp("resolving a contextual task");
 			return result;
 		},
 		clearPendingSourceAction: (input) => (
@@ -278,12 +300,15 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 		this.registerDomEvent(window, "focus", () => {
 			void this.runAutomaticTodayRefresh("window focus");
+			void this.runAutomaticIncrementalSync("window focus");
 		});
 		this.registerInterval(window.setInterval(() => {
 			void this.runAutomaticTodayRefresh("interval");
+			void this.runAutomaticIncrementalSync("interval");
 		}, 60_000));
 		this.app.workspace.onLayoutReady(() => {
 			void this.runAutomaticTodayRefresh("startup");
+			void this.runAutomaticIncrementalSync("startup");
 		});
 	}
 	async addMarvinTask(catId: string, taskTitle: string, notePath: string = '', vaultName: string = ''): Promise<Task> {
@@ -323,6 +348,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 			}
 			new Notice("Task added in Amazing Marvin.");
 			this.queueManagedTodayRefresh("creating a task");
+			this.queueIncrementalCatchUp("creating a task");
 			return this.decorateWithDeepLink(task) as Task;
 		} catch (error) {
 			console.error('Error creating task:', error);
@@ -349,7 +375,9 @@ export default class AmazingMarvinPlugin extends Plugin {
 		);
 	}
 
-	onunload() { }
+	onunload() {
+		this.incrementalGeneration += 1;
+	}
 
 	async loadSettings() {
 		const stored = await this.loadData() as Partial<AmazingMarvinPluginSettings> | null;
@@ -360,11 +388,49 @@ export default class AmazingMarvinPlugin extends Plugin {
 	}
 
 	async saveSettings() {
-		this.marvinRouter = undefined;
-		this.marvinRouterKey = "";
-		this.sourceActionService = undefined;
-		this.sourceActionRouter = undefined;
+		const nextIncrementalKey = this.incrementalConfigurationKey();
+		if (
+			this.incrementalCache
+			&& this.incrementalCacheKey !== nextIncrementalKey
+		) {
+			this.incrementalGeneration += 1;
+			this.incrementalCache = undefined;
+			this.incrementalCacheKey = "";
+			this.incrementalBackoff = new IncrementalRetryBackoff();
+			this.lastIncrementalError = "";
+		}
 		await this.saveData(this.settings);
+	}
+
+	getIncrementalSyncStatus(): {
+		lastSuccessfulSyncAt?: number;
+		error?: string;
+	} {
+		const cached = this.incrementalCache?.getStatus();
+		const lastSuccessfulSyncAt = Math.max(
+			this.lastIncrementalSyncAt,
+			cached?.lastSuccessfulSyncAt ?? 0,
+		);
+		return {
+			...(lastSuccessfulSyncAt > 0 ? { lastSuccessfulSyncAt } : {}),
+			...(this.lastIncrementalError
+				? { error: this.lastIncrementalError }
+				: {}),
+		};
+	}
+
+	async clearIncrementalCache(): Promise<void> {
+		this.incrementalGeneration += 1;
+		if (this.incrementalCache) {
+			await this.incrementalCache.clear();
+		} else {
+			await this.createIncrementalCacheStore().clear();
+		}
+		this.incrementalCache = undefined;
+		this.incrementalCacheKey = "";
+		this.incrementalBackoff = new IncrementalRetryBackoff();
+		this.lastIncrementalError = "";
+		this.lastIncrementalSyncAt = 0;
 	}
 
 	async markDone(taskId: string) {
@@ -382,6 +448,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 			note.appendText(' marked as done in Amazing Marvin.');
 			new Notice(note, 5000);
 			this.queueManagedTodayRefresh("completing a task");
+			this.queueIncrementalCatchUp("completing a task");
 			return result;
 		} catch (error) {
 			console.error('Error marking task as done:', error);
@@ -420,6 +487,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 			task: request,
 		});
 		this.queueManagedTodayRefresh("creating a contextual task");
+		this.queueIncrementalCatchUp("creating a contextual task");
 		return result;
 	}
 
@@ -594,30 +662,160 @@ export default class AmazingMarvinPlugin extends Plugin {
 		});
 	}
 
+	private queueIncrementalCatchUp(context: string): void {
+		if (!this.settings.incrementalSyncEnabled) {
+			return;
+		}
+		void this.runAutomaticIncrementalSync(`write: ${context}`);
+	}
+
 
 	async sync() {
+		if (this.settings.incrementalSyncEnabled) {
+			try {
+				const cache = this.getIncrementalCache();
+				const update = await cache.sync("normal");
+				await this.projectIncrementalUpdate(
+					{ ...update, fullRefresh: true },
+					cache,
+				);
+				await cache.acknowledgeProjection();
+				this.recordIncrementalSuccess(update.lastSuccessfulSyncAt);
+				return;
+			} catch (error) {
+				this.recordIncrementalFailure(error);
+				console.warn(
+					"Incremental Amazing Marvin import failed; using REST fallback:",
+					error,
+				);
+				new Notice(
+					`Incremental Amazing Marvin import failed; using the REST fallback. ${this.errorMessage(error)}`,
+					10_000,
+				);
+			}
+		}
+		await this.syncFromRest();
+	}
+
+	private async syncFromRest(): Promise<void> {
 		await this.refreshLabelsForProjection();
-		const categories = await this.getCategories();
+		const categories = await this.readRestCategories();
+		await this.projectCategoryImport(
+			categories,
+			(parentId) => this.readRestChildren(parentId),
+		);
+	}
+
+	private async projectIncrementalUpdate(
+		update: IncrementalUpdate,
+		cache = this.getIncrementalCache(),
+	): Promise<void> {
+		const cachedCategories = cache.getCategories();
+		if (!cachedCategories) {
+			throw new Error("Incremental Amazing Marvin cache is not hydrated");
+		}
+		const categories = cachedCategories.map(
+			(item) => this.decorateWithDeepLink(item, "category") as Category,
+		);
+		await this.refreshLabelsForProjection();
+		await this.projectCategoryImport(
+			categories,
+			async (parentId) => {
+				const children = cache.getChildren(parentId);
+				if (!children) {
+					throw new Error(
+						`Incremental Amazing Marvin cache has no children for ${parentId}`,
+					);
+				}
+				return children.map(
+					(item) => this.decorateWithDeepLink(item) as Task | Category,
+				);
+			},
+			update.fullRefresh
+				? undefined
+				: new Set(update.affectedContainerIds),
+			update.fullRefresh || update.inboxChanged,
+		);
+	}
+
+	private async projectCategoryImport(
+		categories: Category[],
+		readChildren: (parentId: string) => Promise<(Task | Category)[]>,
+		targetIds?: ReadonlySet<string>,
+		updateInbox = true,
+	): Promise<void> {
+		const pending = this.categoryProjectionTail
+			.catch(() => undefined)
+			.then(() => this.projectCategoryImportOnce(
+				categories,
+				readChildren,
+				targetIds,
+				updateInbox,
+			));
+		this.categoryProjectionTail = pending;
+		return pending;
+	}
+
+	private async projectCategoryImportOnce(
+		categories: Category[],
+		readChildren: (parentId: string) => Promise<(Task | Category)[]>,
+		targetIds?: ReadonlySet<string>,
+		updateInbox = true,
+	): Promise<void> {
 		this.categories = categories;
 		const plan = planCategorySync(
 			categories,
 			this.settings.syncSelectionMode,
 			this.settings.syncRoots.map((root) => root.id),
 		);
+		if (targetIds && targetIds.size === 0 && !updateInbox) {
+			return;
+		}
 		const existingFiles = await this.findManagedImportFiles();
-		await this.processCategories(existingFiles, plan);
-		if (this.settings.syncInbox) {
-			await this.processInbox(existingFiles);
+		await this.processCategories(
+			existingFiles,
+			plan,
+			readChildren,
+			targetIds,
+		);
+		if (this.settings.syncInbox && updateInbox) {
+			await this.processInbox(existingFiles, readChildren);
 		}
 	}
 
 	async getCategories(): Promise<Category[]> {
+		const cached = this.settings.incrementalSyncEnabled
+			? this.incrementalCache?.getCategories()
+			: undefined;
+		if (cached) {
+			return cached.map(
+				(item) => this.decorateWithDeepLink(item, "category") as Category,
+			);
+		}
+		return this.readRestCategories();
+	}
+
+	private async readRestCategories(): Promise<Category[]> {
 		const result = await this.getMarvinRouter().getCategories();
 		this.reportReadState(result, "categories");
 		return result.data.map(item => this.decorateWithDeepLink(item, "category") as Category);
 	}
 
 	async getChildren(parentId: string): Promise<(Task | Category)[]> {
+		const cached = this.settings.incrementalSyncEnabled
+			? this.incrementalCache?.getChildren(parentId)
+			: undefined;
+		if (cached) {
+			return cached.map(
+				(item) => this.decorateWithDeepLink(item) as Task | Category,
+			);
+		}
+		return this.readRestChildren(parentId);
+	}
+
+	private async readRestChildren(
+		parentId: string,
+	): Promise<(Task | Category)[]> {
 		const result = await this.getMarvinRouter().getChildren(parentId);
 		this.reportReadState(result, `children of ${parentId}`);
 		return result.data.map(item => this.decorateWithDeepLink(item));
@@ -647,8 +845,11 @@ export default class AmazingMarvinPlugin extends Plugin {
 		} as Task | Category;
 	}
 
-	async processInbox(existingFiles: Map<string, TFile>) {
-		const inboxItems = await this.getChildren("unassigned");
+	async processInbox(
+		existingFiles: Map<string, TFile>,
+		readChildren: (parentId: string) => Promise<(Task | Category)[]>,
+	) {
+		const inboxItems = await readChildren("unassigned");
 		const content = this.formatItems(inboxItems);
 		const inboxFilePath = normalizePath(`${this.getSyncBaseDir()}/Inbox.md`);
 		await this.moveManagedFile(existingFiles.get("unassigned"), inboxFilePath);
@@ -717,15 +918,21 @@ export default class AmazingMarvinPlugin extends Plugin {
 	async processCategories(
 		existingFiles: Map<string, TFile>,
 		plan: CategorySyncPlan,
+		readChildren: (parentId: string) => Promise<(Task | Category)[]>,
+		targetIds?: ReadonlySet<string>,
 	) {
 		for (const category of this.categories.filter(
-			(item) => plan.includedIds.has(item._id),
+			(item) => (
+				plan.includedIds.has(item._id)
+				&& (!targetIds || targetIds.has(item._id))
+			),
 		)) {
 			const path = this.getPathForCategory(category);
 			await this.moveManagedFile(existingFiles.get(category._id), path);
 			const content = await this.createContentForCategory(
 				category,
 				plan,
+				readChildren,
 			);
 			await this.createOrUpdateManaged(
 				path,
@@ -835,6 +1042,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 	async createContentForCategory(
 		category: Category,
 		plan: CategorySyncPlan,
+		readChildren: (parentId: string) => Promise<(Task | Category)[]>,
 	): Promise<string> {
 		const labelTags = this.settings.showMarvinLabelsAsTags
 			? formatMarvinLabelTags(
@@ -857,7 +1065,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		}
 		// Fetch and format tasks
 		const fetchedChildren = plan.contentIds.has(category._id)
-			? await this.getChildren(category._id)
+			? await readChildren(category._id)
 			: undefined;
 		const children = categoryProjectionItems(
 			category._id,
@@ -989,6 +1197,140 @@ export default class AmazingMarvinPlugin extends Plugin {
 		);
 	}
 
+	private async runAutomaticIncrementalSync(
+		reason: string,
+	): Promise<void> {
+		if (
+			!this.settings.incrementalSyncEnabled
+			|| !this.settings.databaseUri
+			|| !this.settings.databaseUser
+			|| !this.settings.databasePassword
+			|| !this.incrementalBackoff.canRun()
+		) {
+			return;
+		}
+		if (this.incrementalRun) {
+			return this.incrementalRun;
+		}
+		const now = Date.now();
+		const minimumDelay = reason.startsWith("write:")
+			? 0
+			: reason === "interval"
+			? Math.max(1, this.settings.incrementalSyncIntervalMinutes) * 60_000
+			: 15_000;
+		if (now - this.lastAutomaticIncrementalAt < minimumDelay) {
+			return;
+		}
+		this.lastAutomaticIncrementalAt = now;
+		const generation = this.incrementalGeneration;
+		const pending = (async () => {
+			try {
+				const cache = this.getIncrementalCache();
+				const update = await cache.sync("longpoll");
+				if (
+					generation !== this.incrementalGeneration
+					|| !this.settings.incrementalSyncEnabled
+				) {
+					return;
+				}
+				if (update.changed || update.fullRefresh) {
+					await this.projectIncrementalUpdate(update, cache);
+					await cache.acknowledgeProjection();
+				}
+				this.recordIncrementalSuccess(update.lastSuccessfulSyncAt);
+			} catch (error) {
+				const previous = this.lastIncrementalError;
+				const delay = this.recordIncrementalFailure(error);
+				console.warn(
+					`Amazing Marvin incremental sync failed after ${reason}; retrying after ${delay}ms:`,
+					error,
+				);
+				if (this.lastIncrementalError !== previous) {
+					new Notice(
+						`Amazing Marvin incremental sync paused after a recoverable error. Existing notes were left unchanged. ${this.lastIncrementalError}`,
+						10_000,
+					);
+				}
+			}
+		})().finally(() => {
+			this.incrementalRun = undefined;
+		});
+		this.incrementalRun = pending;
+		return pending;
+	}
+
+	private recordIncrementalSuccess(at: number): void {
+		this.incrementalBackoff.recordSuccess();
+		this.lastIncrementalSyncAt = at;
+		this.lastIncrementalError = "";
+	}
+
+	private recordIncrementalFailure(error: unknown): number {
+		this.lastIncrementalError = this.errorMessage(error);
+		return this.incrementalBackoff.recordFailure();
+	}
+
+	private getIncrementalCache(): IncrementalMarvinCache {
+		const key = this.incrementalConfigurationKey();
+		if (this.incrementalCache && this.incrementalCacheKey === key) {
+			return this.incrementalCache;
+		}
+		// Hydration must not reuse a REST response fetched before the CouchDB
+		// checkpoint. This router is intentionally private to the one-time snapshot.
+		const hydrationRouter = this.createMarvinRouter();
+		const client = new CouchChangesClient({
+			databaseUri: this.settings.databaseUri,
+			databaseUser: this.settings.databaseUser,
+			databasePassword: this.settings.databasePassword,
+		}, createObsidianCouchTransport(requestUrl));
+		const sourceKey = [
+			this.settings.databaseUri.trim(),
+			this.settings.databaseUser.trim(),
+		].join("\u0000");
+		this.incrementalCache = new IncrementalMarvinCache({
+			sourceKey,
+			changes: client,
+			store: this.createIncrementalCacheStore(),
+			snapshot: {
+				getCategories: async () => {
+					// A failed partial hydration can be retried on this cache instance.
+					// Clear those post-checkpoint reads before taking the new snapshot.
+					hydrationRouter.clearCache();
+					const result = await hydrationRouter.getCategories();
+					this.reportReadState(result, "categories for cache hydration");
+					return result.data;
+				},
+				getChildren: async (parentId) => {
+					const result = await hydrationRouter.getChildren(parentId);
+					this.reportReadState(
+						result,
+						`children of ${parentId} for cache hydration`,
+					);
+					return result.data as CachedMarvinItem[];
+				},
+			},
+		});
+		this.incrementalCacheKey = key;
+		return this.incrementalCache;
+	}
+
+	private createIncrementalCacheStore(): ObsidianIncrementalCacheStore {
+		return new ObsidianIncrementalCacheStore(
+			this.app.vault.adapter,
+			this.manifest.dir
+				?? `.obsidian/plugins/${this.manifest.id}`,
+		);
+	}
+
+	private incrementalConfigurationKey(): string {
+		return [
+			this.settings.incrementalSyncEnabled,
+			this.settings.databaseUri,
+			this.settings.databaseUser,
+			this.settings.databasePassword,
+		].join("\u0000");
+	}
+
 	private getMarvinRouter(): MarvinRouter {
 		const key = [
 			this.settings.apiKey,
@@ -1000,6 +1342,12 @@ export default class AmazingMarvinPlugin extends Plugin {
 			return this.marvinRouter;
 		}
 
+		this.marvinRouter = this.createMarvinRouter();
+		this.marvinRouterKey = key;
+		return this.marvinRouter;
+	}
+
+	private createMarvinRouter(): MarvinRouter {
 		const transport = createObsidianTransport(requestUrl);
 		const publicClient = new MarvinApiClient({
 			apiToken: this.settings.apiKey,
@@ -1016,12 +1364,10 @@ export default class AmazingMarvinPlugin extends Plugin {
 			})
 			: undefined;
 
-		this.marvinRouter = new MarvinRouter({
+		return new MarvinRouter({
 			publicClient,
 			...(localClient === undefined ? {} : { localClient }),
 		});
-		this.marvinRouterKey = key;
-		return this.marvinRouter;
 	}
 
 	private getSourceActionStore(): ObsidianSourceActionStore {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import {
 	Notice,
 	Plugin,
 	TFile,
+	TFolder,
 	moment,
 	normalizePath,
 	requestUrl,
@@ -50,6 +51,17 @@ import {
 	buildSourceActionTaskNote,
 } from "./marvin/obsidianLinks";
 import {
+	managedImportItemId,
+	marvinFrontmatter,
+	refreshCategoryRegion,
+	repairLegacyMarvinFrontmatter,
+	updateMarvinFrontmatter,
+} from "./marvin/categoryProjection";
+import {
+	categoryNotePath,
+	normalizeManagedFolder,
+} from "./marvin/categoryPaths";
+import {
 	ObsidianSourceActionStore,
 } from "./marvin/obsidianSourceActions";
 import { createObsidianTransport } from "./marvin/obsidianTransport";
@@ -81,11 +93,6 @@ const animateNotice = (notice: Notice) => {
 	notice.setMessage(message);
 	setTimeout(() => animateNotice(notice), 500);
 };
-
-const CONSTANTS = {
-	baseDir: "AmazingMarvin",
-};
-
 
 export default class AmazingMarvinPlugin extends Plugin {
 
@@ -555,15 +562,10 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 	async sync() {
 		const categories = await this.getCategories();
-		const baseDirPath = normalizePath(CONSTANTS.baseDir);
-		const baseDir = this.app.vault.getAbstractFileByPath(baseDirPath);
-		if (baseDir) {
-			await this.app.vault.delete(baseDir, true);
-		}
-
 		this.categories = categories;
-		await this.processCategories();
-		await this.processInbox();
+		const existingFiles = await this.findManagedImportFiles();
+		await this.processCategories(existingFiles);
+		await this.processInbox(existingFiles);
 	}
 
 	async getCategories(): Promise<Category[]> {
@@ -602,71 +604,85 @@ export default class AmazingMarvinPlugin extends Plugin {
 		} as Task | Category;
 	}
 
-	async processInbox() {
+	async processInbox(existingFiles: Map<string, TFile>) {
 		const inboxItems = await this.getChildren("unassigned");
 		const content = this.formatItems(inboxItems);
-
-		// Define the path for the Inbox file
-		const inboxFilePath = normalizePath("AmazingMarvin/Inbox.md");
-
-		await this.createOrUpdate(inboxFilePath, content);
+		const inboxFilePath = normalizePath(`${this.getSyncBaseDir()}/Inbox.md`);
+		await this.moveManagedFile(existingFiles.get("unassigned"), inboxFilePath);
+		await this.createOrUpdateManaged(
+			inboxFilePath,
+			"unassigned",
+			content,
+			"inbox",
+			{
+				_id: "unassigned",
+				type: "inbox",
+				title: "Inbox",
+			},
+		);
 	}
 
-	async createOrUpdate(path: string, content: string) {
+	async createOrUpdateManaged(
+		path: string,
+		itemId: string,
+		rendered: string,
+		legacyKind: "category" | "inbox",
+		item?: object,
+	) {
 		const normalizedPath = normalizePath(path);
-		let dirPath = normalizedPath.replace(/^(.+)\/[^\/]*?$/, '$1');
-
-		// Ensure the directory exists
-		if (!await this.app.vault.adapter.exists(dirPath)) {
-			await this.app.vault.createFolder(dirPath);
+		await this.ensureParentFolder(normalizedPath);
+		let file = this.app.vault.getAbstractFileByPath(normalizedPath);
+		if (file && !(file instanceof TFile)) {
+			throw new Error(`Cannot write Amazing Marvin note over folder: ${normalizedPath}`);
+		}
+		if (!file) {
+			const frontmatter = item
+				? `---\n${stringifyYaml(marvinFrontmatter({ ...item })).trimEnd()}\n---\n`
+				: "";
+			const projected = refreshCategoryRegion(frontmatter, {
+				itemId,
+				rendered,
+				legacyKind,
+			});
+			await this.app.vault.create(normalizedPath, projected.content);
+			return;
 		}
 
-		// Overwrite existing file
-		if (await this.app.vault.adapter.exists(normalizedPath)) {
-			const existingContent = await this.app.vault.adapter.remove(normalizedPath);
+		await this.app.vault.process(file, repairLegacyMarvinFrontmatter);
+		if (item) {
+			await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+				updateMarvinFrontmatter(frontmatter, { ...item });
+			});
 		}
-
-		await this.app.vault.create(normalizedPath, content);
+		await this.app.vault.process(file, (content) => (
+			refreshCategoryRegion(content, {
+				itemId,
+				rendered,
+				legacyKind,
+			}).content
+		));
 	}
 
 	getPathForCategory(category: Category) {
-		let pathSegments: string[] = [];
-
-		// Function to recursively build the path segments array
-		const buildPathSegments = (cat: Category) => {
-			const safeTitle = cat.title.replace(/[^a-zA-Z0-9 -]/g, "");
-			pathSegments.unshift(safeTitle); // Add at the beginning
-
-			if (cat.parentId && cat.parentId !== "root") {
-				const parentCat = this.categories.find(c => c._id === cat.parentId);
-				if (parentCat) {
-					buildPathSegments(parentCat);
-				}
-			}
-		};
-
-		buildPathSegments(category);
-
-		// Determine the filename and if the category should be a folder based on its children
-		const hasChildCategoriesOrProjects = this.categories.some(cat =>
-			cat.parentId === category._id && (cat.type === 'project' || cat.type === 'category')
-		);
-
-		// If the category has children that are categories or projects, make it a folder
-		const isFolder = hasChildCategoriesOrProjects;
-
-		// Construct the path
-		let path = `${CONSTANTS.baseDir}/${pathSegments.join('/')}`;
-		path = isFolder ? `${path}/${category.title}.md` : `${path}.md`;
-
-		return normalizePath(path);
+		return normalizePath(categoryNotePath(
+			category,
+			this.categories,
+			this.getSyncBaseDir(),
+		));
 	}
 
-	async processCategories() {
+	async processCategories(existingFiles: Map<string, TFile>) {
 		for (const category of this.categories) {
 			const path = this.getPathForCategory(category);
-			const content = this.createContentForCategory(category);
-			await this.createOrUpdate(path, await content);
+			await this.moveManagedFile(existingFiles.get(category._id), path);
+			const content = await this.createContentForCategory(category);
+			await this.createOrUpdateManaged(
+				path,
+				category._id,
+				content,
+				"category",
+				category,
+			);
 		}
 	}
 
@@ -681,7 +697,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 			if (isCategoryOrProject) {
 				// Handle category or project formatting
 				const path = this.getPathForCategory(item);
-				categoryContent += `${indentation}- [[${path}|${item.title}]] [⚓](${item.deepLink})\n`;
+				categoryContent += `${indentation}- [[${this.wikiTarget(path)}|${this.wikiAlias(item.title)}]] [⚓](${item.deepLink})\n`;
 			} else {
 				if (!isSubtask) { // Only add deep links to top-level tasks
 					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] [⚓](${item.deepLink}) ${this.formatTaskDetails(item as Task, indentation)}`;
@@ -689,7 +705,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] `;
 				}
 
-				taskContent += `${item.title}\n`;
+				taskContent += `${this.inlineMarkdown(item.title)}\n`;
 
 				// Recursively format sub-tasks if any
 				if ('subtasks' in item && item.subtasks && Object.keys(item.subtasks).length > 0) {
@@ -734,31 +750,110 @@ export default class AmazingMarvinPlugin extends Plugin {
 	}
 
 	async createContentForCategory(category: Category): Promise<string> {
-		let yamlFrontmatter = "---\n";
-		// Iterate over category properties and add non-null values to YAML frontmatter
-		for (const [key, value] of Object.entries(category)) {
-			if (value !== null && value !== undefined) {
-				yamlFrontmatter += `${key}: ${stringifyYaml(value)}\n`;
-			}
-		}
-
-		// Close YAML frontmatter block
-		yamlFrontmatter += "---\n";
-
-		let content = `# [⚓](${category.deepLink}) ${category.title}\n\n`;
+		let content = `# [⚓](${category.deepLink}) ${this.inlineMarkdown(category.title)}\n\n`;
 
 		// Link to parent category, if it exists
 		if (category.parentId && category.parentId !== "root") {
 			const parentCategory = this.categories.find(cat => cat._id === category.parentId);
 			if (parentCategory) {
-				content += `Back to [[${parentCategory.title}]]\n\n`;
+				content += `Back to [[${this.wikiTarget(this.getPathForCategory(parentCategory))}|${this.wikiAlias(parentCategory.title)}]]\n\n`;
 			}
 		}
 		// Fetch and format tasks
 		const children = await this.getChildren(category._id);
 		content += this.formatItems(children);
 
-		return yamlFrontmatter + content;
+		return content;
+	}
+
+	private getSyncBaseDir(): string {
+		return normalizePath(normalizeManagedFolder(this.settings.syncFolder));
+	}
+
+	private async ensureParentFolder(path: string): Promise<void> {
+		const separator = path.lastIndexOf("/");
+		if (separator === -1) {
+			return;
+		}
+		const segments = path.slice(0, separator).split("/");
+		let current = "";
+		for (const segment of segments) {
+			current = current ? `${current}/${segment}` : segment;
+			const existing = this.app.vault.getAbstractFileByPath(current);
+			if (existing && !(existing instanceof TFolder)) {
+				throw new Error(
+					`Cannot create Amazing Marvin folder ${current}; a vault file already exists there`,
+				);
+			}
+			if (!existing) {
+				await this.app.vault.createFolder(current);
+			}
+		}
+	}
+
+	private async moveManagedFile(
+		existing: TFile | undefined,
+		destination: string,
+	): Promise<void> {
+		if (!existing || existing.path === destination) {
+			return;
+		}
+		await this.ensureParentFolder(destination);
+		const collision = this.app.vault.getAbstractFileByPath(destination);
+		if (collision && collision !== existing) {
+			throw new Error(
+				`Cannot move ${existing.path} to ${destination}; another vault item already exists there`,
+			);
+		}
+		await this.app.fileManager.renameFile(existing, destination);
+	}
+
+	private inlineMarkdown(value: string): string {
+		return value
+			.replace(/[\r\n]+/g, " ")
+			.replace(/<!--/g, "&lt;!--")
+			.replace(/-->/g, "--&gt;")
+			.trim();
+	}
+
+	private wikiAlias(value: string): string {
+		return this.inlineMarkdown(value)
+			.replace(/\|/g, "\\|")
+			.replace(/\]/g, "\\]");
+	}
+
+	private wikiTarget(value: string): string {
+		return value.replace(/\|/g, "\\|").replace(/\]/g, "\\]");
+	}
+
+	private async findManagedImportFiles(): Promise<Map<string, TFile>> {
+		const byId = new Map<string, TFile>();
+		const rootsToInspect = new Set([
+			`${this.getSyncBaseDir()}/`,
+			"AmazingMarvin/",
+		]);
+		for (const file of this.app.vault.getMarkdownFiles()) {
+			const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+			let itemId = managedImportItemId("", frontmatter, file.path);
+			if (
+				!itemId
+				&& [...rootsToInspect].some((root) => file.path.startsWith(root))
+			) {
+				const content = await this.app.vault.cachedRead(file);
+				itemId = managedImportItemId(content, frontmatter, file.path);
+			}
+			if (!itemId) {
+				continue;
+			}
+			const duplicate = byId.get(itemId);
+			if (duplicate && duplicate.path !== file.path) {
+				throw new Error(
+					`Multiple Obsidian notes claim Amazing Marvin item ${itemId}: ${duplicate.path} and ${file.path}`,
+				);
+			}
+			byId.set(itemId, file);
+		}
+		return byId;
 	}
 
 	private getMarvinRouter(): MarvinRouter {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,7 @@ import {
 	categoryNotePath,
 	normalizeManagedFolder,
 } from "./marvin/categoryPaths";
+import { marvinParentIdFromFrontmatter } from "./marvin/noteContext";
 import {
 	ObsidianSourceActionStore,
 } from "./marvin/obsidianSourceActions";
@@ -180,10 +181,11 @@ export default class AmazingMarvinPlugin extends Plugin {
 			editorCallback: async (editor, view) => {
         // Fetch categories first and make sure they are loaded
         try {
+			const defaultParentId = this.marvinParentIdForFile(view.file);
           // If a region of text is selected, at least 3 characters long, use that to add a new task and skip the modal
           if (editor.somethingSelected() && editor.getSelection().length > 2) {
             try {
-              const task = await this.addMarvinTask('', editor.getSelection(), view.file?.path, this.app.vault.getName());
+              const task = await this.addMarvinTask(defaultParentId ?? '', editor.getSelection(), view.file?.path, this.app.vault.getName());
               editor.replaceSelection(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`);
             } catch (error) {
               console.error('Could not create Marvin task:', error);
@@ -199,7 +201,7 @@ export default class AmazingMarvinPlugin extends Plugin {
             } catch (error) {
               console.error('Could not create Marvin task:', error);
             }
-          }).open();
+          }, defaultParentId).open();
         } catch (error) {
           console.error('Error fetching categories:', error);
           new Notice('Failed to load categories from Amazing Marvin.');
@@ -313,6 +315,15 @@ export default class AmazingMarvinPlugin extends Plugin {
 			);
 			throw error;
 		}
+	}
+
+	private marvinParentIdForFile(file: TFile | null): string | undefined {
+		if (!file) {
+			return undefined;
+		}
+		return marvinParentIdFromFrontmatter(
+			this.app.metadataCache.getFileCache(file)?.frontmatter,
+		);
 	}
 
 	onunload() { }

--- a/src/main.ts
+++ b/src/main.ts
@@ -834,13 +834,25 @@ export default class AmazingMarvinPlugin extends Plugin {
 		]);
 		for (const file of this.app.vault.getMarkdownFiles()) {
 			const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
-			let itemId = managedImportItemId("", frontmatter, file.path);
+			const isLegacyLocation = [...rootsToInspect].some(
+				(root) => file.path.startsWith(root),
+			);
+			let itemId = managedImportItemId(
+				"",
+				frontmatter,
+				file.path,
+			);
 			if (
 				!itemId
-				&& [...rootsToInspect].some((root) => file.path.startsWith(root))
+				&& isLegacyLocation
 			) {
 				const content = await this.app.vault.cachedRead(file);
-				itemId = managedImportItemId(content, frontmatter, file.path);
+				itemId = managedImportItemId(
+					content,
+					frontmatter,
+					file.path,
+					true,
+				);
 			}
 			if (!itemId) {
 				continue;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import {
 	Notice,
 	Plugin,
+	TFile,
+	moment,
 	normalizePath,
 	requestUrl,
 	stringifyYaml,
@@ -14,9 +16,14 @@ import {
 	type AddTaskRequest,
 	type MarvinItem,
 	type MarvinReadResult,
+	type TaskOrProject,
+	type EnsureSourceActionResult,
 	MarvinApiClient,
 	MarvinError,
+	MarvinRouteError,
 	MarvinRouter,
+	SourceActionError,
+	SourceActionService,
 	marvinDeepLink,
 } from "@open-horizon/marvin-client";
 
@@ -27,17 +34,39 @@ import {
 } from "./settings";
 
 import {
-	getDateFromFile
+	getAllDailyNotes,
+	getDailyNote,
+	getDateFromFile,
 } from "obsidian-daily-notes-interface";
 import { amTaskWatcher } from "./amTaskWatcher";
 import { AddTaskModal } from "./addTaskModal";
+import type {
+	AmazingMarvinApi,
+	EnsureTaskForSourceInput,
+	RefreshTodayTasksInput,
+	RefreshTodayTasksResult,
+} from "./api";
+import {
+	buildSourceActionTaskNote,
+} from "./marvin/obsidianLinks";
+import {
+	ObsidianSourceActionStore,
+} from "./marvin/obsidianSourceActions";
 import { createObsidianTransport } from "./marvin/obsidianTransport";
+import {
+	hasTodayRegion,
+	type TodayProjectionItem,
+} from "./marvin/todayProjection";
+import { runTodayProjection } from "./marvin/todayWorkflow";
 
 function getAMTimezoneOffset() {
 	return new Date().getTimezoneOffset() * -1;
 }
 
 const animateNotice = (notice: Notice) => {
+	if (!notice.noticeEl.isConnected) {
+		return;
+	}
 	let message = notice.noticeEl.innerText;
 	const dots = [...message].filter((c) => c === ".").length;
 	if (dots == 0) {
@@ -64,6 +93,41 @@ export default class AmazingMarvinPlugin extends Plugin {
 	categories: Category[] = [];
 	private marvinRouter?: MarvinRouter;
 	private marvinRouterKey = "";
+	private sourceActionStore?: ObsidianSourceActionStore;
+	private sourceActionService?: SourceActionService;
+	private sourceActionRouter?: MarvinRouter;
+	private readonly todayRefreshes = new Map<string, Promise<RefreshTodayTasksResult>>();
+	private lastAutomaticRefreshAt = 0;
+	private lastAutomaticRefreshError = "";
+
+	readonly api: AmazingMarvinApi = {
+		getToday: (date) => this.getMarvinRouter().getTodayItems(date),
+		getDue: (date) => this.getMarvinRouter().getDueItems(date),
+		getTodayAndDue: (date) => this.getMarvinRouter().getTodayAndDue(date),
+		createTask: async (task) => {
+			const created = await this.getMarvinRouter().addTask(task);
+			this.queueManagedTodayRefresh("creating a task");
+			return created;
+		},
+		ensureTaskForSource: (input) => this.ensureTaskForSource(input),
+		resolvePendingSourceAction: async (input) => {
+			const result = await this.getSourceActionService().resolvePending({
+				sourceKey: input.sourcePath,
+				actionKey: input.actionKey,
+				taskId: input.taskId,
+				...(input.title === undefined ? {} : { title: input.title }),
+			});
+			this.queueManagedTodayRefresh("resolving a contextual task");
+			return result;
+		},
+		clearPendingSourceAction: (input) => (
+			this.getSourceActionService().clearPending({
+				sourceKey: input.sourcePath,
+				actionKey: input.actionKey,
+			})
+		),
+		refreshTodayTasks: (input) => this.refreshTodayTasks(input),
+	};
 
 	createFolder = async (path: string) => {
 		try {
@@ -87,6 +151,21 @@ export default class AmazingMarvinPlugin extends Plugin {
 		if (this.settings.attemptToMarkTasksAsDone) {
 			this.registerEditorExtension(amTaskWatcher(this.app, this));
 		}
+		this.registerEvent(this.app.metadataCache.on("changed", (file, _data, cache) => {
+			if (
+				this.sourceActionStore?.shouldInvalidateFor(
+					file.path,
+					cache.frontmatter,
+				)
+			) {
+				this.sourceActionStore.invalidateIndex(true);
+			}
+		}));
+		this.registerEvent(this.app.metadataCache.on("deleted", (file) => {
+			if (this.sourceActionStore?.shouldInvalidateFor(file.path, undefined)) {
+				this.sourceActionStore.invalidateIndex(true);
+			}
+		}));
 
 		this.addCommand({
 			id: "create-task",
@@ -138,36 +217,46 @@ export default class AmazingMarvinPlugin extends Plugin {
       });
 		this.addCommand({
 			id: "import-today",
-			name: "Import today's tasks",
-			editorCallback: async (editor, view) => {
+			name: "Refresh today's tasks",
+			editorCallback: async (_editor, view) => {
 				try {
-					const today = new Date().toISOString().split('T')[0];
-					const fileDate = view.file ? getDateFromFile(view.file, "day")?.format("YYYY-MM-DD") : today;
-
-					const date = fileDate ? fileDate : today;
-					let tasks: (Task | Category)[];
-					if (this.settings.todayTasksToShow === 'both') {
-						const result = await this.getMarvinRouter().getTodayAndDue(date);
-						this.reportReadState(result, "today and due tasks");
-						tasks = result.data.map(item => this.decorateWithDeepLink(item));
-					} else if (this.settings.todayTasksToShow === 'due') {
-						tasks = await this.getDueTasks(date);
-					} else {
-						tasks = await this.getScheduledTasks(date);
+					if (!view.file) {
+						throw new Error("Open the daily note you want to refresh");
 					}
-
-					editor.replaceRange(this.formatItems(tasks, 0, false), editor.getCursor());
+					const fileDate = getDateFromFile(view.file, "day");
+					if (!fileDate) {
+						throw new Error(`${view.file.path} is not recognized as a daily note`);
+					}
+					const date = fileDate.format("YYYY-MM-DD");
+					const result = await this.refreshTodayTasks({
+						date,
+						filePath: view.file.path,
+					});
+					new Notice(
+						result.changed
+							? `Refreshed Amazing Marvin tasks for ${date}.`
+							: `Amazing Marvin tasks for ${date} are already current.`,
+					);
 				} catch (error) {
-					new Notice(`Error importing scheduled tasks: ${error}`);
-					console.error(`Error importing scheduled tasks: ${error}`);
+					new Notice(`Error refreshing today's tasks: ${this.errorMessage(error)}`);
+					console.error("Error refreshing today's tasks:", error);
 				}
 			}
 		});
 
+		this.registerDomEvent(window, "focus", () => {
+			void this.runAutomaticTodayRefresh("window focus");
+		});
+		this.registerInterval(window.setInterval(() => {
+			void this.runAutomaticTodayRefresh("interval");
+		}, 60_000));
+		this.app.workspace.onLayoutReady(() => {
+			void this.runAutomaticTodayRefresh("startup");
+		});
 	}
 	async addMarvinTask(catId: string, taskTitle: string, notePath: string = '', vaultName: string = ''): Promise<Task> {
 		const requestBody: AddTaskRequest = {
-			title: taskTitle,
+			title: taskTitle.trim(),
 			timeZoneOffset: getAMTimezoneOffset(),
 		};
 
@@ -175,21 +264,40 @@ export default class AmazingMarvinPlugin extends Plugin {
 			requestBody.parentId = catId;
 		}
 
-		if (notePath && notePath !== '') {
-			let link = `obsidian://open?file=${encodeURI(notePath)}${vaultName !== '' ? `&vault=${encodeURI(vaultName)}` : ''}`;
-			if (this.settings.linkBackToObsidianText !== '') {
-				requestBody.note = `[${this.settings.linkBackToObsidianText}](${link})`;
-			} else {
-				requestBody.note = link;
-			}
-	}
-
 		try {
-			const task = await this.getMarvinRouter().addTask(requestBody);
+			let task: TaskOrProject;
+			if (notePath) {
+				const actionKey = `manual-${this.newOperationId()}`;
+				requestBody.note = buildSourceActionTaskNote({
+					vaultName: vaultName || this.app.vault.getName(),
+					sourcePath: notePath,
+					actionKey,
+					linkText: this.settings.linkBackToObsidianText,
+					format: this.settings.obsidianLinkFormat,
+				});
+				const ensured = await this.getSourceActionService().ensure({
+					sourceKey: notePath,
+					actionKey,
+					task: requestBody,
+				});
+				if (!ensured.task) {
+					throw new Error(
+						`Manual source action unexpectedly reused Marvin task ${ensured.taskId}`,
+					);
+				}
+				task = ensured.task;
+			} else {
+				task = await this.getMarvinRouter().addTask(requestBody);
+			}
 			new Notice("Task added in Amazing Marvin.");
+			this.queueManagedTodayRefresh("creating a task");
 			return this.decorateWithDeepLink(task) as Task;
 		} catch (error) {
 			console.error('Error creating task:', error);
+			if (error instanceof SourceActionError) {
+				new Notice(error.message, 0);
+				throw error;
+			}
 			this.showManualActionError(
 				this.isThrottle(error)
 					? 'Your request was throttled by Amazing Marvin. Wait before trying again, or do it '
@@ -203,15 +311,18 @@ export default class AmazingMarvinPlugin extends Plugin {
 	onunload() { }
 
 	async loadSettings() {
-		this.settings = Object.assign(
-			DEFAULT_SETTINGS,
-			await this.loadData()
-		);
+		const stored = await this.loadData() as Partial<AmazingMarvinPluginSettings> | null;
+		this.settings = {
+			...DEFAULT_SETTINGS,
+			...(stored ?? {}),
+		};
 	}
 
 	async saveSettings() {
 		this.marvinRouter = undefined;
 		this.marvinRouterKey = "";
+		this.sourceActionService = undefined;
+		this.sourceActionRouter = undefined;
 		await this.saveData(this.settings);
 	}
 
@@ -229,6 +340,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 			note.append(a);
 			note.appendText(' marked as done in Amazing Marvin.');
 			new Notice(note, 5000);
+			this.queueManagedTodayRefresh("completing a task");
 			return result;
 		} catch (error) {
 			console.error('Error marking task as done:', error);
@@ -240,6 +352,204 @@ export default class AmazingMarvinPlugin extends Plugin {
 			);
 			throw error;
 		}
+	}
+
+	async ensureTaskForSource(
+		input: EnsureTaskForSourceInput,
+	): Promise<EnsureSourceActionResult> {
+		const request: AddTaskRequest = {
+			title: input.title.trim(),
+			timeZoneOffset: getAMTimezoneOffset(),
+			note: buildSourceActionTaskNote({
+				vaultName: this.app.vault.getName(),
+				sourcePath: input.sourcePath,
+				actionKey: input.actionKey,
+				linkText: this.settings.linkBackToObsidianText,
+				format: this.settings.obsidianLinkFormat,
+				...(input.note === undefined ? {} : { note: input.note }),
+			}),
+			...(input.parentId === undefined ? {} : { parentId: input.parentId }),
+			...(input.day === undefined ? {} : { day: input.day }),
+			...(input.dueDate === undefined ? {} : { dueDate: input.dueDate }),
+			...(input.labelIds === undefined ? {} : { labelIds: input.labelIds }),
+		};
+		const result = await this.getSourceActionService().ensure({
+			sourceKey: input.sourcePath,
+			actionKey: input.actionKey,
+			task: request,
+		});
+		this.queueManagedTodayRefresh("creating a contextual task");
+		return result;
+	}
+
+	async refreshTodayTasks(
+		input: RefreshTodayTasksInput,
+	): Promise<RefreshTodayTasksResult> {
+		const date = this.requireDate(input.date);
+		const file = this.resolveDailyNote(date, input.filePath);
+		const key = `${file.path}\u0000${date}`;
+		const existing = this.todayRefreshes.get(key);
+		if (existing) {
+			return existing;
+		}
+
+		const pending = this.refreshTodayTasksOnce(date, file).finally(() => {
+			this.todayRefreshes.delete(key);
+		});
+		this.todayRefreshes.set(key, pending);
+		return pending;
+	}
+
+	private async refreshTodayTasksOnce(
+		date: string,
+		file: TFile,
+	): Promise<RefreshTodayTasksResult> {
+		const workflow = await runTodayProjection({
+			date,
+			read: () => this.readTodaySelection(date),
+			project: (data) => this.toTodayProjectionItems(data),
+			process: async (update) => {
+				await this.app.vault.process(file, update);
+			},
+		});
+		const { read, projection } = workflow;
+		this.reportReadState(read, `tasks for ${date}`);
+		return {
+			date,
+			filePath: file.path,
+			changed: projection.changed,
+			createdRegion: projection.createdRegion,
+			morningIds: projection.morningIds,
+			lateIds: projection.lateIds,
+			freshness: read.freshness,
+			origin: read.origin,
+			warnings: read.warnings,
+		};
+	}
+
+	private toTodayProjectionItems(data: TaskOrProject[]): TodayProjectionItem[] {
+		const sourceLinks = this.getSourceActionStore().findLinkedTasks(
+			data.map((item) => item._id),
+		);
+		return data.map((item) => {
+			const deepLink = marvinDeepLink({
+				...item,
+				type: item.type ?? "task",
+			});
+			const source = sourceLinks.get(item._id);
+			const details = this.formatTaskDetails(item as Task, "").trim();
+			return {
+				id: item._id,
+				title: item.title,
+				done: Boolean(item.done),
+				deepLink,
+				...(details ? { details } : {}),
+				...(source === undefined
+					? {}
+					: {
+						sourcePath: source.sourcePath,
+						sourceTitle: item.title,
+					}),
+			};
+		});
+	}
+
+	private async readTodaySelection(
+		date: string,
+	): Promise<MarvinReadResult<TaskOrProject[]>> {
+		if (this.settings.todayTasksToShow === "due") {
+			return this.getMarvinRouter().getDueItems(date);
+		}
+		if (this.settings.todayTasksToShow === "scheduled") {
+			return this.getMarvinRouter().getTodayItems(date);
+		}
+		return this.getMarvinRouter().getTodayAndDue(date);
+	}
+
+	private resolveDailyNote(date: string, filePath?: string): TFile {
+		if (filePath) {
+			const file = this.app.vault.getAbstractFileByPath(filePath);
+			if (!(file instanceof TFile)) {
+				throw new Error(`Daily note not found: ${filePath}`);
+			}
+			return file;
+		}
+		const file = getDailyNote(
+			moment(date, "YYYY-MM-DD", true),
+			getAllDailyNotes(),
+		);
+		if (!file) {
+			throw new Error(`No daily note exists for ${date}`);
+		}
+		return file;
+	}
+
+	private requireDate(date: string): string {
+		const normalized = date.trim();
+		if (!moment(normalized, "YYYY-MM-DD", true).isValid()) {
+			throw new Error(`Expected a date in YYYY-MM-DD format, received: ${date}`);
+		}
+		return normalized;
+	}
+
+	private async runAutomaticTodayRefresh(reason: string): Promise<void> {
+		if (!this.settings.autoRefreshTodayTasks) {
+			return;
+		}
+		const now = Date.now();
+		const minimumDelay = reason === "interval"
+			? Math.max(1, this.settings.todayRefreshIntervalMinutes) * 60_000
+			: 15_000;
+		if (now - this.lastAutomaticRefreshAt < minimumDelay) {
+			return;
+		}
+		this.lastAutomaticRefreshAt = now;
+		try {
+			await this.refreshManagedTodayIfPresent();
+			this.lastAutomaticRefreshError = "";
+		} catch (error) {
+			const message = this.errorMessage(error);
+			console.warn(
+				`Could not automatically refresh Amazing Marvin tasks after ${reason}:`,
+				error,
+			);
+			if (message !== this.lastAutomaticRefreshError) {
+				this.lastAutomaticRefreshError = message;
+				new Notice(
+					`Amazing Marvin automatic refresh failed; the existing daily-note tasks were left unchanged. ${message}`,
+					10_000,
+				);
+			}
+		}
+	}
+
+	private async refreshManagedTodayIfPresent(): Promise<boolean> {
+		const date = moment().format("YYYY-MM-DD");
+		let file: TFile;
+		try {
+			file = this.resolveDailyNote(date);
+		} catch {
+			return false;
+		}
+		const content = await this.app.vault.cachedRead(file);
+		if (!hasTodayRegion(content, date)) {
+			return false;
+		}
+		await this.refreshTodayTasks({ date, filePath: file.path });
+		return true;
+	}
+
+	private queueManagedTodayRefresh(context: string): void {
+		void this.refreshManagedTodayIfPresent().catch((error) => {
+			console.warn(
+				`Amazing Marvin succeeded at ${context}, but the managed daily-note refresh failed:`,
+				error,
+			);
+			new Notice(
+				`Amazing Marvin succeeded at ${context}, but today's managed task region could not be refreshed. ${this.errorMessage(error)}`,
+				10_000,
+			);
+		});
 	}
 
 
@@ -486,6 +796,24 @@ export default class AmazingMarvinPlugin extends Plugin {
 		return this.marvinRouter;
 	}
 
+	private getSourceActionStore(): ObsidianSourceActionStore {
+		this.sourceActionStore ??= new ObsidianSourceActionStore(this.app);
+		return this.sourceActionStore;
+	}
+
+	private getSourceActionService(): SourceActionService {
+		const router = this.getMarvinRouter();
+		if (this.sourceActionService && this.sourceActionRouter === router) {
+			return this.sourceActionService;
+		}
+		this.sourceActionService = new SourceActionService({
+			router,
+			store: this.getSourceActionStore(),
+		});
+		this.sourceActionRouter = router;
+		return this.sourceActionService;
+	}
+
 	private reportReadState<T>(result: MarvinReadResult<T>, description: string) {
 		if (result.freshness === "stale") {
 			new Notice(
@@ -502,7 +830,25 @@ export default class AmazingMarvinPlugin extends Plugin {
 	}
 
 	private isThrottle(error: unknown): boolean {
-		return error instanceof MarvinError && error.status === 429;
+		if (error instanceof MarvinError) {
+			return error.status === 429;
+		}
+		if (error instanceof MarvinRouteError) {
+			return error.attempts.some((attempt) => attempt.status === 429);
+		}
+		if (error instanceof SourceActionError) {
+			return this.isThrottle(error.cause);
+		}
+		return false;
+	}
+
+	private newOperationId(): string {
+		return globalThis.crypto?.randomUUID?.()
+			?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	}
+
+	private errorMessage(error: unknown): string {
+		return error instanceof Error ? error.message : String(error);
 	}
 
 	private showManualActionError(message: string, href: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,22 @@ import {
 	Plugin,
 	normalizePath,
 	requestUrl,
-  stringifyYaml,
+	stringifyYaml,
 } from "obsidian";
 
 import {
 	Category,
 	Task
 } from "./interfaces";
+import {
+	type AddTaskRequest,
+	type MarvinItem,
+	type MarvinReadResult,
+	MarvinApiClient,
+	MarvinError,
+	MarvinRouter,
+	marvinDeepLink,
+} from "@open-horizon/marvin-client";
 
 import {
 	AmazingMarvinSettingsTab,
@@ -22,6 +31,7 @@ import {
 } from "obsidian-daily-notes-interface";
 import { amTaskWatcher } from "./amTaskWatcher";
 import { AddTaskModal } from "./addTaskModal";
+import { createObsidianTransport } from "./marvin/obsidianTransport";
 
 function getAMTimezoneOffset() {
 	return new Date().getTimezoneOffset() * -1;
@@ -45,18 +55,15 @@ const animateNotice = (notice: Notice) => {
 
 const CONSTANTS = {
 	baseDir: "AmazingMarvin",
-	categoriesEndpoint: '/api/categories',
-	childrenEndpoint: '/api/children',
-	scheduledOnDayEndpoint: '/api/todayItems',
-	dueOnDayEndpoint: '/api/dueItems',
-	addTaskEndpoint: '/api/addTask',
-}
+};
 
 
 export default class AmazingMarvinPlugin extends Plugin {
 
 	settings: AmazingMarvinPluginSettings;
 	categories: Category[] = [];
+	private marvinRouter?: MarvinRouter;
+	private marvinRouterKey = "";
 
 	createFolder = async (path: string) => {
 		try {
@@ -93,26 +100,20 @@ export default class AmazingMarvinPlugin extends Plugin {
               const task = await this.addMarvinTask('', editor.getSelection(), view.file?.path, this.app.vault.getName());
               editor.replaceSelection(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`);
             } catch (error) {
-              new Notice('Could not create Marvin task: ' + error.message);
+              console.error('Could not create Marvin task:', error);
             }
             return;
           }
 
-          const categories = await this.fetchTasksAndCategories(CONSTANTS.categoriesEndpoint);
-          // Ensure categories are fetched before initializing the modal
-          if (categories.length > 0) {
-            new AddTaskModal(this.app, categories, async (taskDetails: { catId: string, task: string }) => {
-              try {
-                const task = await this.addMarvinTask(taskDetails.catId, taskDetails.task, view.file?.path, this.app.vault.getName());
-                editor.replaceRange(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`, editor.getCursor());
-              } catch (error) {
-                new Notice('Could not create Marvin task: ' + error.message);
-              }
-            }).open();
-          } else {
-            // Handle the case where categories could not be loaded
-            new Notice('Failed to load categories from Amazing Marvin.');
-          }
+          const categories = await this.getCategories();
+          new AddTaskModal(this.app, categories, async (taskDetails: { catId: string, task: string }) => {
+            try {
+              const task = await this.addMarvinTask(taskDetails.catId, taskDetails.task, view.file?.path, this.app.vault.getName());
+              editor.replaceRange(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`, editor.getCursor());
+            } catch (error) {
+              console.error('Could not create Marvin task:', error);
+            }
+          }).open();
         } catch (error) {
           console.error('Error fetching categories:', error);
           new Notice('Failed to load categories from Amazing Marvin.');
@@ -144,17 +145,18 @@ export default class AmazingMarvinPlugin extends Plugin {
 					const fileDate = view.file ? getDateFromFile(view.file, "day")?.format("YYYY-MM-DD") : today;
 
 					const date = fileDate ? fileDate : today;
-					let tasks = new Set<Task | Category>();
-					if (this.settings.todayTasksToShow === 'due' || this.settings.todayTasksToShow === 'both') {
-						const dueTasks = await this.getDueTasks(date);
-						dueTasks.forEach(task => tasks.add(task));;
-					}
-					if (this.settings.todayTasksToShow === 'scheduled' || this.settings.todayTasksToShow === 'both') {
-						const scheduledTasks = await this.getScheduledTasks(date);
-						scheduledTasks.forEach(task => tasks.add(task));;
+					let tasks: (Task | Category)[];
+					if (this.settings.todayTasksToShow === 'both') {
+						const result = await this.getMarvinRouter().getTodayAndDue(date);
+						this.reportReadState(result, "today and due tasks");
+						tasks = result.data.map(item => this.decorateWithDeepLink(item));
+					} else if (this.settings.todayTasksToShow === 'due') {
+						tasks = await this.getDueTasks(date);
+					} else {
+						tasks = await this.getScheduledTasks(date);
 					}
 
-					editor.replaceRange(this.formatItems(Array.from(tasks), 0, false), editor.getCursor());
+					editor.replaceRange(this.formatItems(tasks, 0, false), editor.getCursor());
 				} catch (error) {
 					new Notice(`Error importing scheduled tasks: ${error}`);
 					console.error(`Error importing scheduled tasks: ${error}`);
@@ -164,9 +166,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 	}
 	async addMarvinTask(catId: string, taskTitle: string, notePath: string = '', vaultName: string = ''): Promise<Task> {
-		const opt = this.settings;
-
-		let requestBody: any = {
+		const requestBody: AddTaskRequest = {
 			title: taskTitle,
 			timeZoneOffset: getAMTimezoneOffset(),
 		};
@@ -185,45 +185,19 @@ export default class AmazingMarvinPlugin extends Plugin {
 	}
 
 		try {
-			const remoteResponse = await requestUrl({
-				url: `https://serv.amazingmarvin.com/api/addTask`,
-				method: 'POST',
-				headers: {
-					'X-API-Token': opt.apiKey,
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify(requestBody)
-			});
-
-			if (remoteResponse.status === 200) {
-				new Notice("Task added in Amazing Marvin.");
-				return this.decorateWithDeepLink(remoteResponse.json) as Task;
-			} else if (remoteResponse.status === 429) {
-
-				const errorNote = document.createDocumentFragment();
-				errorNote.appendText('Your request was throttled by Amazing Marvin. Wait a few minutes and try again. Or do it ');
-				const a = document.createElement('a');
-				a.href = 'https://app.amazingmarvin.com/';
-				a.text = 'manually';
-				a.target = '_blank';
-				errorNote.appendChild(a);
-				errorNote.appendText('.');
-				new Notice(errorNote,);
-			}
+			const task = await this.getMarvinRouter().addTask(requestBody);
+			new Notice("Task added in Amazing Marvin.");
+			return this.decorateWithDeepLink(task) as Task;
 		} catch (error) {
-			const errorNote = document.createDocumentFragment();
-			errorNote.appendText('Error creating task in Amazing Marvin. You can try again or do it ');
 			console.error('Error creating task:', error);
-			const a = document.createElement('a');
-			a.href = 'https://app.amazingmarvin.com/';
-			a.text = 'manually';
-			a.target = '_blank';
-			errorNote.appendChild(a);
-			errorNote.appendText('.');
-
-			new Notice(errorNote, 0);
+			this.showManualActionError(
+				this.isThrottle(error)
+					? 'Your request was throttled by Amazing Marvin. Wait before trying again, or do it '
+					: 'Error creating task in Amazing Marvin. You can try again or do it ',
+				'https://app.amazingmarvin.com/',
+			);
+			throw error;
 		}
-		return Promise.reject(new Error('Error creating task'));
 	}
 
 	onunload() { }
@@ -235,183 +209,91 @@ export default class AmazingMarvinPlugin extends Plugin {
 		);
 	}
 
-	saveSettings() {
-		this.saveData(this.settings);
+	async saveSettings() {
+		this.marvinRouter = undefined;
+		this.marvinRouterKey = "";
+		await this.saveData(this.settings);
 	}
 
 	async markDone(taskId: string) {
-		const opt = this.settings;
-		const requestBody = {
-			itemId: taskId,
-			timeZoneOffset: getAMTimezoneOffset()
-		};
-
 		try {
-			const remoteResponse = await requestUrl({
-				url: `https://serv.amazingmarvin.com/api/markDone`,
-				method: 'POST',
-				headers: {
-					'X-API-Token': opt.apiKey,
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify(requestBody)
-			});
-
+			const result = await this.getMarvinRouter().markDone(
+				taskId,
+				getAMTimezoneOffset(),
+			);
 			const note = document.createDocumentFragment();
 			const a = document.createElement('a');
 			a.href = 'https://app.amazingmarvin.com/#t=' + taskId;
-
 			a.target = '_blank';
-
-			if (remoteResponse.status === 200) {
-				a.text = 'Task';
-				note.append(a);
-				note.appendText(' marked as done in Amazing Marvin.');
-				new Notice(note, 5000);
-				return remoteResponse.json;
-			} else if (remoteResponse.status === 429) {
-				a.text = 'manually';
-				note.appendText('Your request was throttled by Amazing Marvin. Do it manually at ');
-				console.error('Your request was throttled by Amazing Marvin. Wait a few minutes and try again. Or do it manually.');
-				note.appendChild(a);
-
-				new Notice(note, 0);
-			}
+			a.text = 'Task';
+			note.append(a);
+			note.appendText(' marked as done in Amazing Marvin.');
+			new Notice(note, 5000);
+			return result;
 		} catch (error) {
-			const errorNote = document.createDocumentFragment();
-			errorNote.appendText('Error marking task as done in Amazing Marvin. You should do it ');
 			console.error('Error marking task as done:', error);
-
-			const a = document.createElement('a');
-			a.href = 'https://app.amazingmarvin.com/#t=' + taskId;
-			a.text = 'manually';
-			a.target = '_blank';
-			errorNote.appendChild(a);
-
-			new Notice(errorNote, 0);
+			this.showManualActionError(
+				this.isThrottle(error)
+					? 'Your request was throttled by Amazing Marvin. Wait before trying again, or do it '
+					: 'Error marking task as done in Amazing Marvin. You should do it ',
+				'https://app.amazingmarvin.com/#t=' + taskId,
+			);
+			throw error;
 		}
-	}
-
-
-	async fetchMarvinData(endpoint: string) {
-		const opt = this.settings;
-		let response;
-		let errorMessage = '';
-
-		const url = `http://${opt.localServerHost}:${opt.localServerPort}${endpoint}`;
-		try {
-			response = await requestUrl({
-				url: url,
-				headers: { 'X-API-Token': opt.apiKey }
-			});
-
-			if (response.status === 200) {
-				return response.json;
-			}
-
-			errorMessage = `[${response.status}] ${await response.text}`;
-		} catch (err) {
-			errorMessage = err.message;
-			console.debug('Failed while fetching from local server, will try the public server next:', err);
-		}
-
-		if (!opt.useLocalServer || errorMessage) {
-			try {
-				response = await requestUrl({
-          url: `https://serv.amazingmarvin.com${endpoint}`,
-					headers: { 'X-API-Token': opt.apiKey }
-				});
-
-				if (response.status === 200) {
-					return response.json;
-				}
-
-				errorMessage = `[${response.status}] ${await response.text}`;
-			} catch (err) {
-				if (response?.status === 429) {
-					errorMessage = 'Your request was throttled by Amazing Marvin.';
-				} else {
-					errorMessage = err.message;
-				}
-			}
-		}
-
-		throw new Error(`Error fetching data: ${errorMessage}`);
 	}
 
 
 	async sync() {
-		try {
-			const baseDirPath = normalizePath(CONSTANTS.baseDir);
-        const baseDir = this.app.vault.getAbstractFileByPath(baseDirPath);
-        if (baseDir) {
-            await this.app.vault.delete(baseDir, true);
-        }
-
-			this.categories = await this.fetchTasksAndCategories(CONSTANTS.categoriesEndpoint);
-
-			this.processCategories();
-			this.processInbox();
-		} catch (error) {
-			console.error('Error syncing Amazing Marvin data:', error);
+		const categories = await this.getCategories();
+		const baseDirPath = normalizePath(CONSTANTS.baseDir);
+		const baseDir = this.app.vault.getAbstractFileByPath(baseDirPath);
+		if (baseDir) {
+			await this.app.vault.delete(baseDir, true);
 		}
+
+		this.categories = categories;
+		await this.processCategories();
+		await this.processInbox();
 	}
 
-	async fetchTasksAndCategories(url: string): Promise<(Task | Category)[]> {
-		try {
-			const items = await this.fetchMarvinData(url) as (Task | Category)[];
-			return items.map(item => this.decorateWithDeepLink(item));
-		} catch (error) {
-			console.error('Error fetching data from:', url, error);
-			return [];
-		}
+	async getCategories(): Promise<Category[]> {
+		const result = await this.getMarvinRouter().getCategories();
+		this.reportReadState(result, "categories");
+		return result.data.map(item => this.decorateWithDeepLink(item, "category") as Category);
 	}
 
-	getScheduledTasks(date: string): Promise<(Task | Category)[]> {
-		let errorMessages = [];
-
-		try {
-			return this.fetchTasksAndCategories(`${CONSTANTS.scheduledOnDayEndpoint}?date=${date}`);
-		} catch (error) {
-			console.error(`Error fetching scheduled tasks: ${error}`);
-			errorMessages.push(`Error fetching scheduled tasks`);
-		}
-
-		if (errorMessages.length > 0) {
-			const message = `Encountered errors while fetching tasks:\n\n${errorMessages.join('\n')}\nSee console for details.`;
-			new Notice(message);
-		}
-		return Promise.resolve([]);
+	async getChildren(parentId: string): Promise<(Task | Category)[]> {
+		const result = await this.getMarvinRouter().getChildren(parentId);
+		this.reportReadState(result, `children of ${parentId}`);
+		return result.data.map(item => this.decorateWithDeepLink(item));
 	}
 
-	getDueTasks(date: string): Promise<(Task | Category)[]> {
-		let errorMessages = [];
-
-		try {
-			return this.fetchTasksAndCategories(`${CONSTANTS.dueOnDayEndpoint}?date=${date}`);
-		} catch (error) {
-			console.error(`Error fetching scheduled tasks: ${error}`);
-			errorMessages.push(`Error fetching scheduled tasks`);
-		}
-
-		if (errorMessages.length > 0) {
-			const message = `Encountered errors while fetching tasks:\n\n${errorMessages.join('\n')}\nSee console for details.`;
-			new Notice(message);
-		}
-		return Promise.resolve([]);
+	async getScheduledTasks(date: string): Promise<(Task | Category)[]> {
+		const result = await this.getMarvinRouter().getTodayItems(date);
+		this.reportReadState(result, "scheduled tasks");
+		return result.data.map(item => this.decorateWithDeepLink(item));
 	}
 
-	decorateWithDeepLink(item: Task | Category): Task | Category {
-		const isTask = !item.type || item.type === 'task';
+	async getDueTasks(date: string): Promise<(Task | Category)[]> {
+		const result = await this.getMarvinRouter().getDueItems(date);
+		this.reportReadState(result, "due tasks");
+		return result.data.map(item => this.decorateWithDeepLink(item));
+	}
+
+	decorateWithDeepLink(
+		item: MarvinItem,
+		defaultType: "task" | "category" = "task",
+	): Task | Category {
+		const type = item.type ?? defaultType;
 		return {
 			...item,
-			deepLink: `https://app.amazingmarvin.com/#${isTask ? 't' : 'p'}=${item._id}`,
-			type: isTask ? 'task' : item.type
-		};
+			deepLink: marvinDeepLink({ ...item, type }),
+			type,
+		} as Task | Category;
 	}
 
 	async processInbox() {
-		const inboxItems = await this.fetchTasksAndCategories(`${CONSTANTS.childrenEndpoint}?parentId=unassigned`);
+		const inboxItems = await this.getChildren("unassigned");
 		const content = this.formatItems(inboxItems);
 
 		// Define the path for the Inbox file
@@ -474,12 +356,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		for (const category of this.categories) {
 			const path = this.getPathForCategory(category);
 			const content = this.createContentForCategory(category);
-
-			try {
-				await this.createOrUpdate(path, await content);
-			} catch (e) {
-				console.error(`Error creating file for ${path}:`, e);
-			}
+			await this.createOrUpdate(path, await content);
 		}
 	}
 
@@ -506,7 +383,11 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 				// Recursively format sub-tasks if any
 				if ('subtasks' in item && item.subtasks && Object.keys(item.subtasks).length > 0) {
-					const subtasks = Object.values(item.subtasks);
+					const subtasks = Object.values(item.subtasks).map(subtask => ({
+						...subtask,
+						type: "task" as const,
+						deepLink: "",
+					})) as Task[];
 					taskContent += this.formatItems(subtasks, level + 1, true); // Pass true for isSubtask
 				}
 			}
@@ -564,10 +445,76 @@ export default class AmazingMarvinPlugin extends Plugin {
 			}
 		}
 		// Fetch and format tasks
-		const children = await this.fetchTasksAndCategories(`${CONSTANTS.childrenEndpoint}?parentId=${category._id}`);
+		const children = await this.getChildren(category._id);
 		content += this.formatItems(children);
 
 		return yamlFrontmatter + content;
+	}
+
+	private getMarvinRouter(): MarvinRouter {
+		const key = [
+			this.settings.apiKey,
+			this.settings.useLocalServer,
+			this.settings.localServerHost,
+			this.settings.localServerPort,
+		].join("\u0000");
+		if (this.marvinRouter && this.marvinRouterKey === key) {
+			return this.marvinRouter;
+		}
+
+		const transport = createObsidianTransport(requestUrl);
+		const publicClient = new MarvinApiClient({
+			apiToken: this.settings.apiKey,
+			baseUrl: "https://serv.amazingmarvin.com/api",
+			origin: "public",
+			transport,
+		});
+		const localClient = this.settings.useLocalServer
+			? new MarvinApiClient({
+				apiToken: this.settings.apiKey,
+				baseUrl: `http://${this.settings.localServerHost}:${this.settings.localServerPort}/api`,
+				origin: "local",
+				transport,
+			})
+			: undefined;
+
+		this.marvinRouter = new MarvinRouter({
+			publicClient,
+			...(localClient === undefined ? {} : { localClient }),
+		});
+		this.marvinRouterKey = key;
+		return this.marvinRouter;
+	}
+
+	private reportReadState<T>(result: MarvinReadResult<T>, description: string) {
+		if (result.freshness === "stale") {
+			new Notice(
+				`Amazing Marvin is unavailable. Showing stale ${description} from ${new Date(result.fetchedAt).toLocaleTimeString()}.`,
+				8000,
+			);
+			console.warn(`Using stale Amazing Marvin ${description}`, result.warnings);
+		} else if (result.warnings.length > 0) {
+			console.debug(
+				`Amazing Marvin ${description} loaded via ${result.origin} fallback`,
+				result.warnings,
+			);
+		}
+	}
+
+	private isThrottle(error: unknown): boolean {
+		return error instanceof MarvinError && error.status === 429;
+	}
+
+	private showManualActionError(message: string, href: string) {
+		const errorNote = document.createDocumentFragment();
+		errorNote.appendText(message);
+		const link = document.createElement('a');
+		link.href = href;
+		link.text = 'manually';
+		link.target = '_blank';
+		errorNote.appendChild(link);
+		errorNote.appendText('.');
+		new Notice(errorNote, 0);
 	}
 
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
 } from "./interfaces";
 import {
 	type AddTaskRequest,
+	type Label,
 	type MarvinItem,
 	type MarvinReadResult,
 	type TaskOrProject,
@@ -71,6 +72,13 @@ import {
 	type TodayProjectionItem,
 } from "./marvin/todayProjection";
 import { runTodayProjection } from "./marvin/todayWorkflow";
+import {
+	formatTaskMetadata,
+	formatMarvinLabelTags,
+	orderTaskBody,
+	taskTitleComesFirst,
+	type TaskFormattingOptions,
+} from "./marvin/taskFormatting";
 
 function getAMTimezoneOffset() {
 	return new Date().getTimezoneOffset() * -1;
@@ -104,6 +112,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 	private sourceActionStore?: ObsidianSourceActionStore;
 	private sourceActionService?: SourceActionService;
 	private sourceActionRouter?: MarvinRouter;
+	private marvinLabelsById = new Map<string, Label>();
 	private readonly todayRefreshes = new Map<string, Promise<RefreshTodayTasksResult>>();
 	private lastAutomaticRefreshAt = 0;
 	private lastAutomaticRefreshError = "";
@@ -112,6 +121,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		getToday: (date) => this.getMarvinRouter().getTodayItems(date),
 		getDue: (date) => this.getMarvinRouter().getDueItems(date),
 		getTodayAndDue: (date) => this.getMarvinRouter().getTodayAndDue(date),
+		getLabels: () => this.getMarvinRouter().getLabels(),
 		createTask: async (task) => {
 			const created = await this.getMarvinRouter().addTask(task);
 			this.queueManagedTodayRefresh("creating a task");
@@ -182,11 +192,14 @@ export default class AmazingMarvinPlugin extends Plugin {
         // Fetch categories first and make sure they are loaded
         try {
 			const defaultParentId = this.marvinParentIdForFile(view.file);
+			await this.refreshLabelsForProjection();
           // If a region of text is selected, at least 3 characters long, use that to add a new task and skip the modal
           if (editor.somethingSelected() && editor.getSelection().length > 2) {
             try {
               const task = await this.addMarvinTask(defaultParentId ?? '', editor.getSelection(), view.file?.path, this.app.vault.getName());
-              editor.replaceSelection(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`);
+              editor.replaceSelection(
+				`- [${task.done ? 'x' : ' '}] ${this.renderTaskBody(task)}`,
+			  );
             } catch (error) {
               console.error('Could not create Marvin task:', error);
             }
@@ -197,7 +210,10 @@ export default class AmazingMarvinPlugin extends Plugin {
           new AddTaskModal(this.app, categories, async (taskDetails: { catId: string, task: string }) => {
             try {
               const task = await this.addMarvinTask(taskDetails.catId, taskDetails.task, view.file?.path, this.app.vault.getName());
-              editor.replaceRange(`- [${task.done ? 'x' : ' '}] [⚓](${task.deepLink}) ${this.formatTaskDetails(task as Task, '')} ${task.title}`, editor.getCursor());
+              editor.replaceRange(
+				`- [${task.done ? 'x' : ' '}] ${this.renderTaskBody(task)}`,
+				editor.getCursor(),
+			  );
             } catch (error) {
               console.error('Could not create Marvin task:', error);
             }
@@ -422,6 +438,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		date: string,
 		file: TFile,
 	): Promise<RefreshTodayTasksResult> {
+		await this.refreshLabelsForProjection();
 		const workflow = await runTodayProjection({
 			date,
 			read: () => this.readTodaySelection(date),
@@ -455,7 +472,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 				type: item.type ?? "task",
 			});
 			const source = sourceLinks.get(item._id);
-			const details = this.formatTaskDetails(item as Task, "").trim();
+			const details = this.formatTaskDetails(item as Task);
 			return {
 				id: item._id,
 				title: item.title,
@@ -572,6 +589,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 
 
 	async sync() {
+		await this.refreshLabelsForProjection();
 		const categories = await this.getCategories();
 		this.categories = categories;
 		const existingFiles = await this.findManagedImportFiles();
@@ -711,12 +729,11 @@ export default class AmazingMarvinPlugin extends Plugin {
 				categoryContent += `${indentation}- [[${this.wikiTarget(path)}|${this.wikiAlias(item.title)}]] [⚓](${item.deepLink})\n`;
 			} else {
 				if (!isSubtask) { // Only add deep links to top-level tasks
-					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] [⚓](${item.deepLink}) ${this.formatTaskDetails(item as Task, indentation)}`;
+					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] ${this.renderTaskBody(item as Task)}`;
 				} else {
-					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] `;
+					taskContent += `${indentation}- [${item.done ? 'x' : ' '}] ${this.inlineMarkdown(item.title)}`;
 				}
-
-				taskContent += `${this.inlineMarkdown(item.title)}\n`;
+				taskContent += "\n";
 
 				// Recursively format sub-tasks if any
 				if ('subtasks' in item && item.subtasks && Object.keys(item.subtasks).length > 0) {
@@ -743,25 +760,55 @@ export default class AmazingMarvinPlugin extends Plugin {
 		return content;
 	}
 
-	formatTaskDetails(task: Task, indentation: string) {
-		let details = '';
-		const settings = this.settings;
+	formatTaskDetails(task: Task): string {
+		return formatTaskMetadata(
+			task,
+			this.taskFormattingOptions(),
+			this.marvinLabelsById,
+		);
+	}
 
-		if (settings.showDueDate && task.dueDate) {
-			details += `Due Date:: [[${task.dueDate}]] `;
-		}
-		if (settings.showStartDate && task.startDate) {
-			details += `Start Date:: [[${task.startDate}]] `;
-		}
-		if (settings.showScheduledDate && task.day && task.day !== 'unassigned') {
-			details += `Scheduled Date:: [[${task.day}]] `;
-		}
+	private renderTaskBody(task: Task): string {
+		const options = this.taskFormattingOptions();
+		return orderTaskBody(
+			this.inlineMarkdown(task.title),
+			task.deepLink,
+			formatTaskMetadata(task, options, this.marvinLabelsById),
+			taskTitleComesFirst(options),
+		);
+	}
 
-		return details;
+	private taskFormattingOptions(): TaskFormattingOptions {
+		return {
+			format: this.settings.taskMetadataFormat,
+			titleFirst: this.settings.taskTitleFirst,
+			showDueDate: this.settings.showDueDate,
+			showStartDate: this.settings.showStartDate,
+			showScheduledDate: this.settings.showScheduledDate,
+			taskTag: this.settings.taskTag,
+			showMarvinLabelsAsTags: this.settings.showMarvinLabelsAsTags,
+			labelTagPrefix: this.settings.marvinLabelTagPrefix,
+			dateLinkTarget: (date) => {
+				const parsed = moment(date, "YYYY-MM-DD", true);
+				return parsed.isValid()
+					? parsed.format(this.settings.taskDateLinkFormat)
+					: date;
+			},
+		};
 	}
 
 	async createContentForCategory(category: Category): Promise<string> {
-		let content = `# [⚓](${category.deepLink}) ${this.inlineMarkdown(category.title)}\n\n`;
+		const labelTags = this.settings.showMarvinLabelsAsTags
+			? formatMarvinLabelTags(
+				category.labelIds,
+				this.settings.marvinLabelTagPrefix,
+				this.marvinLabelsById,
+			)
+			: [];
+		let content = [
+			`# [⚓](${category.deepLink}) ${this.inlineMarkdown(category.title)}`,
+			...labelTags,
+		].join(" ") + "\n\n";
 
 		// Link to parent category, if it exists
 		if (category.parentId && category.parentId !== "root") {
@@ -877,6 +924,18 @@ export default class AmazingMarvinPlugin extends Plugin {
 			byId.set(itemId, file);
 		}
 		return byId;
+	}
+
+	private async refreshLabelsForProjection(): Promise<void> {
+		if (!this.settings.showMarvinLabelsAsTags) {
+			this.marvinLabelsById.clear();
+			return;
+		}
+		const result = await this.getMarvinRouter().getLabels();
+		this.reportReadState(result, "labels");
+		this.marvinLabelsById = new Map(
+			result.data.map((label) => [label._id, label]),
+		);
 	}
 
 	private getMarvinRouter(): MarvinRouter {

--- a/src/marvin/categoryPaths.test.ts
+++ b/src/marvin/categoryPaths.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	categoryNotePath,
+	normalizeManagedFolder,
+	safePathSegment,
+} from "./categoryPaths";
+
+const categories = [
+	{ _id: "work", title: "Work", type: "category", parentId: "root" },
+	{ _id: "project", title: "Agent / Work", type: "project", parentId: "work" },
+	{ _id: "child", title: "Research", type: "project", parentId: "project" },
+];
+
+describe("category/project paths", () => {
+	it("uses the configured folder and full Marvin hierarchy", () => {
+		expect(categoryNotePath(categories[1]!, categories, "Areas/Tasks")).toBe(
+			"Areas/Tasks/Work/Agent Work/Agent Work.md",
+		);
+		expect(categoryNotePath(categories[2]!, categories, "Areas/Tasks")).toBe(
+			"Areas/Tasks/Work/Agent Work/Research.md",
+		);
+	});
+
+	it("rejects unsafe roots and hierarchy cycles instead of writing elsewhere", () => {
+		expect(() => normalizeManagedFolder("../")).toThrow("Invalid");
+		expect(() => normalizeManagedFolder(".obsidian/Plugins")).toThrow("Invalid");
+		expect(() => categoryNotePath(
+			{ _id: "a", title: "A", type: "category", parentId: "b" },
+			[
+				{ _id: "a", title: "A", type: "category", parentId: "b" },
+				{ _id: "b", title: "B", type: "category", parentId: "a" },
+			],
+			"AmazingMarvin",
+		)).toThrow("cycle");
+	});
+
+	it("uses an ID when a title cannot form a safe path", () => {
+		expect(safePathSegment("///", "fallback-id")).toBe("fallback-id");
+	});
+});

--- a/src/marvin/categoryPaths.ts
+++ b/src/marvin/categoryPaths.ts
@@ -1,0 +1,70 @@
+export interface CategoryPathItem {
+	_id: string;
+	title: string;
+	type?: string;
+	parentId?: string;
+}
+
+export function normalizeManagedFolder(configured: string): string {
+	const value = configured.trim() || "AmazingMarvin";
+	const segments = value
+		.replace(/\\/g, "/")
+		.replace(/^\/+|\/+$/g, "")
+		.split("/");
+	if (
+		segments.length === 0
+		|| segments.some((segment) => !segment || segment === "." || segment === "..")
+		|| segments[0]?.toLowerCase() === ".obsidian"
+	) {
+		throw new Error(`Invalid Amazing Marvin managed folder: ${configured}`);
+	}
+	return segments.join("/");
+}
+
+export function categoryNotePath(
+	category: CategoryPathItem,
+	categories: CategoryPathItem[],
+	baseFolder: string,
+): string {
+	const byId = new Map(categories.map((item) => [item._id, item]));
+	const pathSegments: string[] = [];
+	const visited = new Set<string>();
+	let current: CategoryPathItem | undefined = category;
+	while (current) {
+		if (visited.has(current._id)) {
+			throw new Error(
+				`Amazing Marvin category hierarchy contains a cycle at ${current._id}`,
+			);
+		}
+		visited.add(current._id);
+		pathSegments.unshift(safePathSegment(current.title, current._id));
+		if (!current.parentId || current.parentId === "root") {
+			break;
+		}
+		const childId = current._id;
+		const parentId = current.parentId;
+		current = byId.get(parentId);
+		if (!current) {
+			throw new Error(
+				`Amazing Marvin parent ${parentId} for ${childId} was not returned by the API`,
+			);
+		}
+	}
+
+	const hasContainerChildren = categories.some((item) => (
+		item.parentId === category._id
+		&& (item.type === "project" || item.type === "category")
+	));
+	const path = `${normalizeManagedFolder(baseFolder)}/${pathSegments.join("/")}`;
+	return hasContainerChildren
+		? `${path}/${safePathSegment(category.title, category._id)}.md`
+		: `${path}.md`;
+}
+
+export function safePathSegment(title: string, fallback: string): string {
+	return title
+		.replace(/[\\/:*?"<>|#^\[\]]/g, "")
+		.replace(/\s+/g, " ")
+		.trim()
+		|| fallback;
+}

--- a/src/marvin/categoryProjection.test.ts
+++ b/src/marvin/categoryProjection.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	CATEGORY_REGION_END,
+	MANAGED_PROPERTIES_KEY,
+	CategoryProjectionError,
+	managedImportItemId,
+	marvinFrontmatter,
+	refreshCategoryRegion,
+	repairLegacyMarvinFrontmatter,
+	updateMarvinFrontmatter,
+} from "./categoryProjection";
+
+const rendered = [
+	"# [⚓](https://app.amazingmarvin.com/#p=project-1) Project One",
+	"",
+	"## Tasks",
+	"- [ ] [⚓](https://app.amazingmarvin.com/#t=task-2) Current task",
+].join("\n");
+
+describe("category/project managed regions", () => {
+	it("adopts legacy generated content without overwriting surrounding prose", () => {
+		const original = [
+			"---",
+			"_id: project-1",
+			"type: project",
+			"custom: keep me",
+			"---",
+			"Context before.",
+			"",
+			"# [⚓](https://app.amazingmarvin.com/#p=project-1) Old title",
+			"",
+			"Back to [[Parent]]",
+			"",
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=old) Old task",
+			"  - [ ] Old subtask",
+			"",
+			"Why and how notes remain here.",
+		].join("\n");
+
+		const result = refreshCategoryRegion(original, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+
+		expect(result.content).toContain("Context before.");
+		expect(result.content).toContain("Why and how notes remain here.");
+		expect(result.content).not.toContain("Old task");
+		expect(result.content).toContain("Current task");
+		expect(result.content).toContain(CATEGORY_REGION_END);
+	});
+
+	it("does not adopt a user checklist separated from generated tasks", () => {
+		const original = [
+			"# [⚓](https://app.amazingmarvin.com/#p=project-1) Project",
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=old) Old task",
+			"",
+			"  - [ ] User-authored nested checklist",
+		].join("\n");
+		const result = refreshCategoryRegion(original, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+
+		expect(result.content).toContain("User-authored nested checklist");
+	});
+
+	it("is idempotent and preserves CRLF outside an existing region", () => {
+		const initial = refreshCategoryRegion("Before\r\nAfter\r\n", {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+		const repeated = refreshCategoryRegion(initial.content, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+
+		expect(repeated.changed).toBe(false);
+		expect(repeated.content).toBe(initial.content);
+		expect(repeated.content).toContain("\r\n");
+		expect(repeated.content).toContain("Before\r\nAfter\r\n");
+	});
+
+	it("adopts a legacy Inbox task section", () => {
+		const result = refreshCategoryRegion([
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=old) Old inbox task",
+			"",
+			"Inbox notes.",
+		].join("\n"), {
+			itemId: "unassigned",
+			rendered: [
+				"## Tasks",
+				"- [ ] [⚓](https://app.amazingmarvin.com/#t=new) New inbox task",
+			].join("\n"),
+			legacyKind: "inbox",
+		});
+
+		expect(result.content).toContain("New inbox task");
+		expect(result.content).toContain("Inbox notes.");
+		expect(result.content).not.toContain("Old inbox task");
+	});
+
+	it("does not mistake a user-owned task section for legacy import content", () => {
+		const result = refreshCategoryRegion([
+			"## Tasks",
+			"- [ ] Write the project brief",
+			"",
+			"A helpful Marvin link follows in prose: https://app.amazingmarvin.com/#t=reference",
+		].join("\n"), {
+			itemId: "unassigned",
+			rendered: "## Tasks\n- [ ] [⚓](https://app.amazingmarvin.com/#t=new) New inbox task",
+			legacyKind: "inbox",
+		});
+
+		expect(result.content).toContain("Write the project brief");
+		expect(result.content).toContain("#t=reference");
+		expect(result.content).toContain("New inbox task");
+	});
+
+	it("refuses malformed or cross-item managed regions", () => {
+		expect(() => refreshCategoryRegion(
+			"<!-- obsidian-am:category no-json -->\nGenerated",
+			{ itemId: "project-1", rendered, legacyKind: "category" },
+		)).toThrow(CategoryProjectionError);
+
+		const other = refreshCategoryRegion("", {
+			itemId: "other",
+			rendered: "Other",
+			legacyKind: "category",
+		});
+		expect(() => refreshCategoryRegion(other.content, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		})).toThrow("another item");
+	});
+});
+
+describe("Marvin frontmatter migration", () => {
+	it("repairs the legacy invalid list syntax without touching the note body", () => {
+		const original = [
+			"---",
+			"_id: project-1",
+			"",
+			"labelIds: - label-a",
+			"- label-b",
+			"",
+			"title: Project",
+			"---",
+			"Body remains byte-for-byte.",
+		].join("\n");
+
+		const repaired = repairLegacyMarvinFrontmatter(original);
+
+		expect(repaired).toContain("labelIds:\n  - label-a\n  - label-b");
+		expect(repaired).toContain("Body remains byte-for-byte.");
+		expect(repairLegacyMarvinFrontmatter(repaired)).toBe(repaired);
+	});
+
+	it("updates owned fields as native values while preserving custom properties", () => {
+		const frontmatter: Record<string, unknown> = {
+			_id: "old",
+			dueDate: "yesterday",
+			custom: "keep",
+			removedApiField: true,
+			[MANAGED_PROPERTIES_KEY]: ["_id", "dueDate", "removedApiField"],
+		};
+		updateMarvinFrontmatter(frontmatter, {
+			_id: "project-1",
+			title: "Project",
+			type: "project",
+			labelIds: ["label-a", "label-b"],
+		});
+
+		expect(frontmatter).toMatchObject({
+			_id: "project-1",
+			title: "Project",
+			type: "project",
+			labelIds: ["label-a", "label-b"],
+			custom: "keep",
+		});
+		expect(frontmatter).not.toHaveProperty("dueDate");
+		expect(frontmatter).not.toHaveProperty("removedApiField");
+		expect(frontmatter[MANAGED_PROPERTIES_KEY]).toContain("labelIds");
+		expect(marvinFrontmatter({
+			_id: "project-1",
+			labelIds: ["label-a", "label-b"],
+		})).toMatchObject({
+			_id: "project-1",
+			labelIds: ["label-a", "label-b"],
+		});
+	});
+
+	it("finds managed IDs through cached, marker, malformed-legacy, and Inbox forms", () => {
+		expect(managedImportItemId("", {
+			_id: "cached",
+			deepLink: "https://app.amazingmarvin.com/#p=cached",
+		}, "Elsewhere.md")).toBe("cached");
+
+		const marked = refreshCategoryRegion("", {
+			itemId: "marked",
+			rendered,
+			legacyKind: "category",
+		});
+		expect(managedImportItemId(marked.content, undefined, "Moved.md")).toBe("marked");
+
+		expect(managedImportItemId([
+			"---",
+			"_id: legacy",
+			"labelIds: - broken",
+			"deepLink: https://app.amazingmarvin.com/#p=legacy",
+			"---",
+		].join("\n"), undefined, "Legacy.md")).toBe("legacy");
+
+		expect(managedImportItemId([
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=task) Task",
+		].join("\n"), undefined, "AmazingMarvin/Inbox.md")).toBe("unassigned");
+	});
+});

--- a/src/marvin/categoryProjection.test.ts
+++ b/src/marvin/categoryProjection.test.ts
@@ -52,6 +52,25 @@ describe("category/project managed regions", () => {
 		expect(result.content).toContain(CATEGORY_REGION_END);
 	});
 
+	it("does not adopt a legacy region for a similarly prefixed project ID", () => {
+		const original = [
+			"# [⚓](https://app.amazingmarvin.com/#p=project-10) Another project",
+			"",
+			"## Tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=old) Keep this task",
+		].join("\n");
+
+		const result = refreshCategoryRegion(original, {
+			itemId: "project-1",
+			rendered,
+			legacyKind: "category",
+		});
+
+		expect(result.content).toContain("Another project");
+		expect(result.content).toContain("Keep this task");
+		expect(result.content).toContain("Current task");
+	});
+
 	it("does not adopt a user checklist separated from generated tasks", () => {
 		const original = [
 			"# [⚓](https://app.amazingmarvin.com/#p=project-1) Project",

--- a/src/marvin/categoryProjection.test.ts
+++ b/src/marvin/categoryProjection.test.ts
@@ -198,11 +198,31 @@ describe("Marvin frontmatter migration", () => {
 		});
 	});
 
-	it("finds managed IDs through cached, marker, malformed-legacy, and Inbox forms", () => {
+	it("finds owned IDs without claiming unrelated Marvin-linked notes", () => {
 		expect(managedImportItemId("", {
 			_id: "cached",
 			deepLink: "https://app.amazingmarvin.com/#p=cached",
+			[MANAGED_PROPERTIES_KEY]: ["_id", "deepLink"],
 		}, "Elsewhere.md")).toBe("cached");
+		expect(managedImportItemId("", {
+			_id: "personal",
+			deepLink: "https://app.amazingmarvin.com/#p=personal",
+		}, "Elsewhere.md")).toBeUndefined();
+		expect(managedImportItemId([
+			"---",
+			"_id: personal",
+			"deepLink: https://app.amazingmarvin.com/#p=personal",
+			"---",
+			"Personal notes without an imported heading.",
+		].join("\n"), {
+			_id: "personal",
+			deepLink: "https://app.amazingmarvin.com/#p=personal",
+		}, "AmazingMarvin/Personal.md", true)).toBeUndefined();
+		expect(managedImportItemId("", {
+			_id: "project-1",
+			deepLink: "https://app.amazingmarvin.com/#p=project-10",
+			[MANAGED_PROPERTIES_KEY]: ["_id", "deepLink"],
+		}, "Elsewhere.md")).toBeUndefined();
 
 		const marked = refreshCategoryRegion("", {
 			itemId: "marked",
@@ -217,11 +237,12 @@ describe("Marvin frontmatter migration", () => {
 			"labelIds: - broken",
 			"deepLink: https://app.amazingmarvin.com/#p=legacy",
 			"---",
-		].join("\n"), undefined, "Legacy.md")).toBe("legacy");
+			"# [⚓](https://app.amazingmarvin.com/#p=legacy) Legacy project",
+		].join("\n"), undefined, "Legacy.md", true)).toBe("legacy");
 
 		expect(managedImportItemId([
 			"## Tasks",
 			"- [ ] [⚓](https://app.amazingmarvin.com/#t=task) Task",
-		].join("\n"), undefined, "AmazingMarvin/Inbox.md")).toBe("unassigned");
+		].join("\n"), undefined, "AmazingMarvin/Inbox.md", true)).toBe("unassigned");
 	});
 });

--- a/src/marvin/categoryProjection.ts
+++ b/src/marvin/categoryProjection.ts
@@ -1,0 +1,369 @@
+export const CATEGORY_REGION_END = "<!-- /obsidian-am:category -->";
+export const MANAGED_PROPERTIES_KEY = "amazing-marvin-managed-properties";
+
+const CATEGORY_REGION_PREFIX = "<!-- obsidian-am:category ";
+const MARVIN_LINK = /https:\/\/app\.amazingmarvin\.com\/#(?:t|p)=([^)\s]+)/;
+const OWNED_FRONTMATTER_KEYS = [
+	"_id",
+	"_rev",
+	"createdAt",
+	"updatedAt",
+	"title",
+	"type",
+	"parentId",
+	"day",
+	"firstScheduled",
+	"startDate",
+	"dueDate",
+	"endDate",
+	"done",
+	"doneDate",
+	"doneAt",
+	"completedAt",
+	"note",
+	"labelIds",
+	"timeEstimate",
+	"priority",
+	"rank",
+	"recurring",
+	"isRecurring",
+	"deepLink",
+] as const;
+
+interface CategoryRegionMetadata {
+	version: 1;
+	itemId: string;
+}
+
+export interface RefreshCategoryRegionOptions {
+	itemId: string;
+	rendered: string;
+	legacyKind: "category" | "inbox";
+}
+
+export interface RefreshCategoryRegionResult {
+	content: string;
+	changed: boolean;
+	createdRegion: boolean;
+}
+
+export class CategoryProjectionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CategoryProjectionError";
+	}
+}
+
+export function refreshCategoryRegion(
+	original: string,
+	options: RefreshCategoryRegionOptions,
+): RefreshCategoryRegionResult {
+	const newline = original.includes("\r\n") ? "\r\n" : "\n";
+	const hadTrailingNewline = original.endsWith("\n");
+	const lines = original === ""
+		? []
+		: original.replace(/\r\n/g, "\n").split("\n");
+	if (hadTrailingNewline) {
+		lines.pop();
+	}
+
+	const existing = findManagedRegion(lines, options.itemId);
+	if (!existing && lines.some((line) => parseStartMarker(line) !== undefined)) {
+		throw new CategoryProjectionError(
+			"This note already contains a managed Amazing Marvin region for another item",
+		);
+	}
+	const legacy = existing
+		? undefined
+		: findLegacyRegion(lines, options.itemId, options.legacyKind);
+	const replaceFrom = existing?.start ?? legacy?.start ?? lines.length;
+	const replaceTo = existing
+		? existing.end + 1
+		: legacy?.end ?? lines.length;
+	const block = renderBlock(options.itemId, options.rendered);
+
+	if (!existing && !legacy && lines.length > 0 && lines[lines.length - 1] !== "") {
+		lines.push("");
+	}
+	const insertion = !existing && !legacy ? lines.length : replaceFrom;
+	lines.splice(insertion, replaceTo - replaceFrom, ...block);
+	const next = lines.join("\n") + (hadTrailingNewline ? "\n" : "");
+	const content = newline === "\n" ? next : next.replace(/\n/g, "\r\n");
+	return {
+		content,
+		changed: content !== original,
+		createdRegion: !existing,
+	};
+}
+
+export function updateMarvinFrontmatter(
+	frontmatter: Record<string, unknown>,
+	item: Record<string, unknown>,
+): void {
+	const owned = new Set<string>(OWNED_FRONTMATTER_KEYS);
+	const previous = frontmatter[MANAGED_PROPERTIES_KEY];
+	if (Array.isArray(previous)) {
+		for (const key of previous) {
+			if (typeof key === "string") {
+				owned.add(key);
+			}
+		}
+	}
+	for (const key of owned) {
+		delete frontmatter[key];
+	}
+
+	const next = Object.fromEntries(
+		Object.entries(item).filter(([, value]) => (
+			value !== undefined && value !== null
+		)),
+	);
+	for (const [key, value] of Object.entries(next)) {
+		frontmatter[key] = value;
+	}
+	frontmatter[MANAGED_PROPERTIES_KEY] = Object.keys(next).sort();
+}
+
+export function marvinFrontmatter(
+	item: Record<string, unknown>,
+): Record<string, unknown> {
+	const frontmatter: Record<string, unknown> = {};
+	updateMarvinFrontmatter(frontmatter, item);
+	return frontmatter;
+}
+
+/**
+ * Repairs the invalid list shape emitted by older versions:
+ * `labelIds: - first` followed by top-level `- next`.
+ */
+export function repairLegacyMarvinFrontmatter(content: string): string {
+	const newline = content.includes("\r\n") ? "\r\n" : "\n";
+	const lines = content.replace(/\r\n/g, "\n").split("\n");
+	if (lines[0]?.trim() !== "---") {
+		return content;
+	}
+	let closing = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+	if (closing === -1) {
+		return content;
+	}
+
+	let repairingList = false;
+	let changed = false;
+	for (let index = 1; index < closing; index += 1) {
+		const line = lines[index] ?? "";
+		const brokenStart = line.match(/^([^ \t#][^:]*):\s+-\s+(.+)$/);
+		if (brokenStart?.[1] && brokenStart[2]) {
+			lines.splice(
+				index,
+				1,
+				`${brokenStart[1]}:`,
+				`  - ${brokenStart[2]}`,
+			);
+			closing += 1;
+			index += 1;
+			repairingList = true;
+			changed = true;
+			continue;
+		}
+		if (repairingList && /^-\s+/.test(line)) {
+			lines[index] = `  ${line}`;
+			changed = true;
+			continue;
+		}
+		if (line.trim() && !/^\s/.test(line)) {
+			repairingList = false;
+		}
+	}
+	if (!changed) {
+		return content;
+	}
+	return lines.join(newline);
+}
+
+export function managedImportItemId(
+	content: string,
+	frontmatter: Record<string, unknown> | undefined,
+	path: string,
+): string | undefined {
+	const cachedId = frontmatter?._id;
+	const cachedLink = frontmatter?.deepLink;
+	if (
+		typeof cachedId === "string"
+		&& typeof cachedLink === "string"
+		&& cachedLink.includes(`/#p=${cachedId}`)
+	) {
+		return cachedId;
+	}
+	if (cachedId === "unassigned" && frontmatter?.type === "inbox") {
+		return "unassigned";
+	}
+
+	for (const line of content.replace(/\r\n/g, "\n").split("\n")) {
+		const metadata = parseStartMarker(line);
+		if (metadata) {
+			return metadata.itemId;
+		}
+	}
+
+	const frontmatterLines = frontmatterSlice(content);
+	const id = frontmatterLines.match(/^_id:\s*([^\s#]+)\s*$/m)?.[1];
+	const deepLink = frontmatterLines.match(
+		/^deepLink:\s*https:\/\/app\.amazingmarvin\.com\/#p=([^\s]+)\s*$/m,
+	)?.[1];
+	if (id && deepLink === id) {
+		return id;
+	}
+
+	if (
+		/(^|\/)AmazingMarvin\/Inbox\.md$/.test(path)
+		&& /^## Tasks$/m.test(content)
+		&& MARVIN_LINK.test(content)
+	) {
+		return "unassigned";
+	}
+	return undefined;
+}
+
+function findManagedRegion(
+	lines: string[],
+	itemId: string,
+): { start: number; end: number } | undefined {
+	for (let index = 0; index < lines.length; index += 1) {
+		const metadata = parseStartMarker(lines[index] ?? "");
+		if (!metadata || metadata.itemId !== itemId) {
+			continue;
+		}
+		const end = lines.indexOf(CATEGORY_REGION_END, index + 1);
+		if (end === -1) {
+			throw new CategoryProjectionError(
+				`The managed Amazing Marvin region for ${itemId} has no closing marker`,
+			);
+		}
+		return { start: index, end };
+	}
+	return undefined;
+}
+
+function parseStartMarker(line: string): CategoryRegionMetadata | undefined {
+	if (!line.startsWith(CATEGORY_REGION_PREFIX) || !line.endsWith(" -->")) {
+		return undefined;
+	}
+	let value: unknown;
+	try {
+		value = JSON.parse(line.slice(CATEGORY_REGION_PREFIX.length, -4));
+	} catch {
+		throw new CategoryProjectionError(
+			"A managed Amazing Marvin category region has invalid metadata",
+		);
+	}
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| (value as Partial<CategoryRegionMetadata>).version !== 1
+		|| typeof (value as Partial<CategoryRegionMetadata>).itemId !== "string"
+	) {
+		throw new CategoryProjectionError(
+			"A managed Amazing Marvin category region has unsupported metadata",
+		);
+	}
+	return value as CategoryRegionMetadata;
+}
+
+function findLegacyRegion(
+	lines: string[],
+	itemId: string,
+	kind: RefreshCategoryRegionOptions["legacyKind"],
+): { start: number; end: number } | undefined {
+	const bodyStart = frontmatterEnd(lines);
+	let start = -1;
+	if (kind === "category") {
+		start = lines.findIndex((line, index) => (
+			index >= bodyStart
+			&& line.startsWith("# ")
+			&& line.includes(`https://app.amazingmarvin.com/#p=${itemId}`)
+		));
+	} else {
+		start = lines.findIndex((line, index) => (
+			index >= bodyStart
+			&& line.trim() === "## Tasks"
+			&& firstNonBlankLine(lines, index + 1) !== undefined
+			&& MARVIN_LINK.test(firstNonBlankLine(lines, index + 1) ?? "")
+		));
+	}
+	if (start === -1) {
+		return undefined;
+	}
+
+	let end = start + 1;
+	let pendingBlank = -1;
+	let allowSubtask = false;
+	for (let index = start + 1; index < lines.length; index += 1) {
+		const line = lines[index] ?? "";
+		if (!line.trim()) {
+			pendingBlank = pendingBlank === -1 ? index : pendingBlank;
+			continue;
+		}
+		const isSubtask = /^\s+[-*+]\s+\[[ xX]\]\s+/.test(line);
+		if (isSubtask && allowSubtask && pendingBlank === -1) {
+			end = index + 1;
+			continue;
+		}
+		if (!isLegacyGeneratedLine(line, false)) {
+			break;
+		}
+		end = index + 1;
+		pendingBlank = -1;
+		allowSubtask = /https:\/\/app\.amazingmarvin\.com\/#t=/.test(line);
+	}
+	if (pendingBlank !== -1) {
+		end = Math.min(end, pendingBlank);
+	}
+	return { start, end };
+}
+
+function firstNonBlankLine(lines: string[], start: number): string | undefined {
+	for (let index = start; index < lines.length; index += 1) {
+		const line = lines[index] ?? "";
+		if (line.trim()) {
+			return line;
+		}
+	}
+	return undefined;
+}
+
+function isLegacyGeneratedLine(line: string, includeSubtasks = true): boolean {
+	return line.startsWith("Back to [[")
+		|| line === "## Categories and Projects"
+		|| line === "## Tasks"
+		|| MARVIN_LINK.test(line)
+		|| (includeSubtasks && /^\s+[-*+]\s+\[[ xX]\]\s+/.test(line));
+}
+
+function frontmatterEnd(lines: string[]): number {
+	if (lines[0]?.trim() !== "---") {
+		return 0;
+	}
+	const closing = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+	return closing === -1 ? 0 : closing + 1;
+}
+
+function frontmatterSlice(content: string): string {
+	const normalized = content.replace(/\r\n/g, "\n");
+	if (!normalized.startsWith("---\n")) {
+		return "";
+	}
+	const end = normalized.indexOf("\n---", 4);
+	return end === -1 ? "" : normalized.slice(4, end);
+}
+
+function renderBlock(itemId: string, rendered: string): string[] {
+	const metadata: CategoryRegionMetadata = {
+		version: 1,
+		itemId,
+	};
+	return [
+		`${CATEGORY_REGION_PREFIX}${JSON.stringify(metadata)} -->`,
+		...rendered.trim().split(/\r?\n/),
+		CATEGORY_REGION_END,
+	];
+}

--- a/src/marvin/categoryProjection.ts
+++ b/src/marvin/categoryProjection.ts
@@ -184,17 +184,26 @@ export function managedImportItemId(
 	content: string,
 	frontmatter: Record<string, unknown> | undefined,
 	path: string,
+	allowLegacyIdentity = false,
 ): string | undefined {
 	const cachedId = frontmatter?._id;
 	const cachedLink = frontmatter?.deepLink;
+	const hasManagedProperties = Array.isArray(
+		frontmatter?.[MANAGED_PROPERTIES_KEY],
+	);
 	if (
 		typeof cachedId === "string"
 		&& typeof cachedLink === "string"
-		&& cachedLink.includes(`/#p=${cachedId}`)
+		&& cachedLink === `https://app.amazingmarvin.com/#p=${cachedId}`
+		&& hasManagedProperties
 	) {
 		return cachedId;
 	}
-	if (cachedId === "unassigned" && frontmatter?.type === "inbox") {
+	if (
+		cachedId === "unassigned"
+		&& frontmatter?.type === "inbox"
+		&& hasManagedProperties
+	) {
 		return "unassigned";
 	}
 
@@ -205,21 +214,43 @@ export function managedImportItemId(
 		}
 	}
 
-	const frontmatterLines = frontmatterSlice(content);
-	const id = frontmatterLines.match(/^_id:\s*([^\s#]+)\s*$/m)?.[1];
-	const deepLink = frontmatterLines.match(
-		/^deepLink:\s*https:\/\/app\.amazingmarvin\.com\/#p=([^\s]+)\s*$/m,
-	)?.[1];
-	if (id && deepLink === id) {
-		return id;
-	}
+	if (allowLegacyIdentity) {
+		const frontmatterLines = frontmatterSlice(content);
+		const rawId = frontmatterLines.match(/^_id:\s*([^\s#]+)\s*$/m)?.[1];
+		const rawDeepLinkId = frontmatterLines.match(
+			/^deepLink:\s*https:\/\/app\.amazingmarvin\.com\/#p=([^\s]+)\s*$/m,
+		)?.[1];
+		const legacyId = (
+			typeof cachedId === "string"
+			&& typeof cachedLink === "string"
+			&& cachedLink === `https://app.amazingmarvin.com/#p=${cachedId}`
+		)
+			? cachedId
+			: rawId && rawDeepLinkId === rawId
+				? rawId
+				: undefined;
+		if (
+			legacyId
+			&& content
+				.replace(/\r\n/g, "\n")
+				.split("\n")
+				.some((line) => (
+					line.startsWith("# ")
+					&& line.includes(
+						`[⚓](https://app.amazingmarvin.com/#p=${legacyId})`,
+					)
+				))
+		) {
+			return legacyId;
+		}
 
-	if (
-		/(^|\/)AmazingMarvin\/Inbox\.md$/.test(path)
-		&& /^## Tasks$/m.test(content)
-		&& MARVIN_LINK.test(content)
-	) {
-		return "unassigned";
+		if (
+			/(^|\/)AmazingMarvin\/Inbox\.md$/.test(path)
+			&& /^## Tasks$/m.test(content)
+			&& MARVIN_LINK.test(content)
+		) {
+			return "unassigned";
+		}
 	}
 	return undefined;
 }

--- a/src/marvin/categoryProjection.ts
+++ b/src/marvin/categoryProjection.ts
@@ -311,7 +311,7 @@ function findLegacyRegion(
 		start = lines.findIndex((line, index) => (
 			index >= bodyStart
 			&& line.startsWith("# ")
-			&& line.includes(`https://app.amazingmarvin.com/#p=${itemId}`)
+			&& hasProjectAnchor(line, itemId)
 		));
 	} else {
 		start = lines.findIndex((line, index) => (
@@ -350,6 +350,12 @@ function findLegacyRegion(
 		end = Math.min(end, pendingBlank);
 	}
 	return { start, end };
+}
+
+function hasProjectAnchor(line: string, itemId: string): boolean {
+	return line.includes(
+		`[⚓](https://app.amazingmarvin.com/#p=${itemId})`,
+	);
 }
 
 function firstNonBlankLine(lines: string[], start: number): string | undefined {

--- a/src/marvin/couchChanges.test.ts
+++ b/src/marvin/couchChanges.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	CouchChangesClient,
+	CouchChangesError,
+	type CouchChangesRequest,
+	type CouchChangesTransport,
+} from "./couchChanges";
+
+class FakeTransport implements CouchChangesTransport {
+	readonly requests: CouchChangesRequest[] = [];
+
+	constructor(private readonly response: { status: number; text: string }) {}
+
+	async request(request: CouchChangesRequest) {
+		this.requests.push(request);
+		return this.response;
+	}
+}
+
+describe("CouchChangesClient", () => {
+	it("keeps credentials out of the URL and round-trips opaque checkpoints", async () => {
+		const transport = new FakeTransport({
+			status: 200,
+			text: JSON.stringify({
+				results: [{
+					id: "task-1",
+					seq: { shard: 4 },
+					doc: { _id: "task-1", db: "Tasks", title: "Draft" },
+				}],
+				last_seq: { shard: 5 },
+				pending: 0,
+			}),
+		});
+		const client = new CouchChangesClient({
+			databaseUri: "https://sync.example.test/account-db",
+			databaseUser: "private-user",
+			databasePassword: "secret",
+		}, transport);
+
+		const page = await client.changes({
+			since: { shard: 4 },
+			feed: "longpoll",
+		});
+
+		const request = transport.requests[0]!;
+		expect(request.url).not.toContain("private-user");
+		expect(request.url).not.toContain("secret");
+		expect(new URL(request.url).searchParams.get("since")).toBe(
+			JSON.stringify({ shard: 4 }),
+		);
+		expect(request.headers.Authorization).toMatch(/^Basic /);
+		expect(page.lastSeq).toEqual({ shard: 5 });
+		expect(page.results[0]?.doc).toMatchObject({ db: "Tasks" });
+	});
+
+	it("rejects insecure, credential-bearing, and database-less URLs", () => {
+		const transport = new FakeTransport({ status: 200, text: "{}" });
+		expect(() => new CouchChangesClient({
+			databaseUri: "http://sync.example.test/db",
+			databaseUser: "user",
+			databasePassword: "secret",
+		}, transport)).toThrow("HTTPS");
+		expect(() => new CouchChangesClient({
+			databaseUri: "https://user:secret@sync.example.test/db",
+			databaseUser: "user",
+			databasePassword: "secret",
+		}, transport)).toThrow("separate fields");
+		expect(() => new CouchChangesClient({
+			databaseUri: "https://sync.example.test/",
+			databaseUser: "user",
+			databasePassword: "secret",
+		}, transport)).toThrow("database name");
+	});
+
+	it("surfaces HTTP and invalid-success responses without response bodies", async () => {
+		const unauthorized = new CouchChangesClient({
+			databaseUri: "https://sync.example.test/db",
+			databaseUser: "user",
+			databasePassword: "wrong",
+		}, new FakeTransport({ status: 401, text: "credential details" }));
+		await expect(unauthorized.changes({ since: "now" })).rejects.toMatchObject({
+			status: 401,
+			message: "Amazing Marvin changes feed failed with HTTP 401",
+		});
+
+		const malformed = new CouchChangesClient({
+			databaseUri: "https://sync.example.test/db",
+			databaseUser: "user",
+			databasePassword: "secret",
+		}, new FakeTransport({ status: 200, text: "{}" }));
+		await expect(malformed.changes({ since: "now" })).rejects.toBeInstanceOf(
+			CouchChangesError,
+		);
+
+		const invalidJson = new CouchChangesClient({
+			databaseUri: "https://sync.example.test/db",
+			databaseUser: "user",
+			databasePassword: "secret",
+		}, new FakeTransport({
+			status: 200,
+			text: "sensitive response contents",
+		}));
+		await expect(invalidJson.changes({ since: "now" })).rejects.toMatchObject({
+			message: "Amazing Marvin changes feed returned invalid JSON",
+		});
+		try {
+			await invalidJson.changes({ since: "now" });
+		} catch (error) {
+			expect(String(error)).not.toContain("sensitive response contents");
+			expect(error).not.toHaveProperty("cause");
+		}
+	});
+
+	it("does not retain transport errors that could contain authorization details", async () => {
+		const client = new CouchChangesClient({
+			databaseUri: "https://sync.example.test/db",
+			databaseUser: "user",
+			databasePassword: "secret",
+		}, {
+			async request() {
+				throw new Error("Authorization: Basic sensitive-value");
+			},
+		});
+
+		try {
+			await client.changes({ since: "now" });
+		} catch (error) {
+			expect(String(error)).toBe(
+				"CouchChangesError: Could not reach the Amazing Marvin changes feed",
+			);
+			expect(error).not.toHaveProperty("cause");
+		}
+	});
+});

--- a/src/marvin/couchChanges.ts
+++ b/src/marvin/couchChanges.ts
@@ -1,0 +1,227 @@
+export type CouchSequence = unknown;
+
+export interface MarvinDatabaseDocument extends Record<string, unknown> {
+	_id: string;
+	_rev?: string;
+	_deleted?: boolean;
+	db?: string;
+	title?: string;
+	type?: string;
+	parentId?: string;
+	done?: boolean;
+	deletedAt?: number;
+}
+
+export interface CouchChange {
+	seq: CouchSequence;
+	id: string;
+	deleted?: boolean;
+	doc?: MarvinDatabaseDocument;
+}
+
+export interface CouchChangesPage {
+	results: CouchChange[];
+	lastSeq: CouchSequence;
+	pending?: number;
+}
+
+export interface CouchChangesRequest {
+	url: string;
+	headers: Record<string, string>;
+}
+
+export interface CouchChangesResponse {
+	status: number;
+	text: string;
+}
+
+export interface CouchChangesTransport {
+	request(request: CouchChangesRequest): Promise<CouchChangesResponse>;
+}
+
+export interface CouchChangesCredentials {
+	databaseUri: string;
+	databaseUser: string;
+	databasePassword: string;
+}
+
+export class CouchChangesError extends Error {
+	constructor(
+		message: string,
+		readonly status?: number,
+	) {
+		super(message);
+		this.name = "CouchChangesError";
+	}
+}
+
+export class CouchChangesClient {
+	private readonly databaseUrl: URL;
+	private readonly authorization: string;
+
+	constructor(
+		credentials: CouchChangesCredentials,
+		private readonly transport: CouchChangesTransport,
+	) {
+		this.databaseUrl = validatedDatabaseUrl(credentials.databaseUri);
+		if (!credentials.databaseUser.trim() || !credentials.databasePassword) {
+			throw new Error("Amazing Marvin database user and password are required");
+		}
+		this.authorization = `Basic ${base64Utf8(
+			`${credentials.databaseUser}:${credentials.databasePassword}`,
+		)}`;
+	}
+
+	async changes(options: {
+		since: CouchSequence | "now";
+		feed?: "normal" | "longpoll";
+		limit?: number;
+		timeoutMs?: number;
+		includeDocs?: boolean;
+	}): Promise<CouchChangesPage> {
+		const url = new URL(
+			`${this.databaseUrl.pathname.replace(/\/+$/, "")}/_changes`,
+			this.databaseUrl,
+		);
+		url.searchParams.set("since", serializeSequence(options.since));
+		url.searchParams.set("feed", options.feed ?? "normal");
+		url.searchParams.set("include_docs", String(options.includeDocs ?? true));
+		url.searchParams.set("limit", String(options.limit ?? 500));
+		if (options.feed === "longpoll") {
+			url.searchParams.set("timeout", String(options.timeoutMs ?? 25_000));
+		}
+
+		let response: CouchChangesResponse;
+		try {
+			response = await this.transport.request({
+				url: url.toString(),
+				headers: {
+					Accept: "application/json",
+					Authorization: this.authorization,
+				},
+			});
+		} catch {
+			throw new CouchChangesError(
+				"Could not reach the Amazing Marvin changes feed",
+			);
+		}
+		if (response.status < 200 || response.status >= 300) {
+			throw new CouchChangesError(
+				`Amazing Marvin changes feed failed with HTTP ${response.status}`,
+				response.status,
+			);
+		}
+
+		let value: unknown;
+		try {
+			value = JSON.parse(response.text) as unknown;
+		} catch {
+			throw new CouchChangesError(
+				"Amazing Marvin changes feed returned invalid JSON",
+				response.status,
+			);
+		}
+		return parseChangesPage(value);
+	}
+}
+
+function validatedDatabaseUrl(value: string): URL {
+	let url: URL;
+	try {
+		url = new URL(value.trim());
+	} catch {
+		throw new Error("Amazing Marvin database URI is invalid");
+	}
+	if (url.username || url.password) {
+		throw new Error(
+			"Keep Amazing Marvin database credentials in their separate fields",
+		);
+	}
+	const local = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+	if (url.protocol !== "https:" && !(local && url.protocol === "http:")) {
+		throw new Error("Amazing Marvin database URI must use HTTPS");
+	}
+	if (!url.pathname || url.pathname === "/") {
+		throw new Error("Amazing Marvin database URI must include the database name");
+	}
+	url.search = "";
+	url.hash = "";
+	return url;
+}
+
+function serializeSequence(sequence: CouchSequence | "now"): string {
+	if (sequence === "now" || typeof sequence === "string") {
+		return sequence;
+	}
+	return JSON.stringify(sequence);
+}
+
+function parseChangesPage(value: unknown): CouchChangesPage {
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| !Array.isArray((value as { results?: unknown }).results)
+		|| !("last_seq" in value)
+	) {
+		throw new CouchChangesError(
+			"Amazing Marvin changes feed returned an invalid page",
+		);
+	}
+	const raw = value as {
+		results: unknown[];
+		last_seq: unknown;
+		pending?: unknown;
+	};
+	const results = raw.results.map((entry): CouchChange => {
+		if (
+			typeof entry !== "object"
+			|| entry === null
+			|| typeof (entry as { id?: unknown }).id !== "string"
+			|| !("seq" in entry)
+		) {
+			throw new CouchChangesError(
+				"Amazing Marvin changes feed returned an invalid change",
+			);
+		}
+		const change = entry as {
+			id: string;
+			seq: unknown;
+			deleted?: unknown;
+			doc?: unknown;
+		};
+		if (
+			change.doc !== undefined
+			&& (
+				typeof change.doc !== "object"
+				|| change.doc === null
+				|| typeof (change.doc as { _id?: unknown })._id !== "string"
+			)
+		) {
+			throw new CouchChangesError(
+				"Amazing Marvin changes feed returned an invalid document",
+			);
+		}
+		return {
+			id: change.id,
+			seq: change.seq,
+			...(change.deleted === true ? { deleted: true } : {}),
+			...(change.doc === undefined
+				? {}
+				: { doc: change.doc as MarvinDatabaseDocument }),
+		};
+	});
+	return {
+		results,
+		lastSeq: raw.last_seq,
+		...(typeof raw.pending === "number" ? { pending: raw.pending } : {}),
+	};
+}
+
+function base64Utf8(value: string): string {
+	const bytes = new TextEncoder().encode(value);
+	let binary = "";
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary);
+}

--- a/src/marvin/dailyWorkflow.e2e.test.ts
+++ b/src/marvin/dailyWorkflow.e2e.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	SourceActionService,
+	type AddTaskRequest,
+	type SourceActionKey,
+	type SourceActionRecord,
+	type SourceActionStore,
+	type Task,
+} from "@open-horizon/marvin-client";
+
+import { buildSourceActionTaskNote } from "./obsidianLinks";
+import {
+	marvinIdsInMarkdown,
+	refreshTodayRegion,
+	type TodayProjectionItem,
+} from "./todayProjection";
+
+class FixtureSourceNote implements SourceActionStore {
+	readonly associations = new Map<string, SourceActionRecord>();
+
+	async get(key: SourceActionKey): Promise<SourceActionRecord | undefined> {
+		return this.associations.get(key.actionKey);
+	}
+
+	async set(record: SourceActionRecord): Promise<void> {
+		this.associations.set(record.actionKey, record);
+	}
+
+	async delete(key: SourceActionKey): Promise<void> {
+		this.associations.delete(key.actionKey);
+	}
+}
+
+describe("contextual daily-note workflow", () => {
+	it("links an opportunity note to one Marvin task and one safely refreshable checklist entry", async () => {
+		const sourcePath = "Opportunities/Titan AI.md";
+		const sourceNote = new FixtureSourceNote();
+		const createdTask: Task = {
+			_id: "titan-decision",
+			title: "Decide whether to pursue Titan AI",
+			done: false,
+			day: "2026-07-23",
+		};
+		const addTask = vi.fn(async (_request: AddTaskRequest) => createdTask);
+		const sourceActions = new SourceActionService({
+			router: { addTask },
+			store: sourceNote,
+			now: () => 1_000,
+			requestId: () => "opportunity-run-1",
+		});
+		const request: AddTaskRequest = {
+			title: createdTask.title,
+			day: "2026-07-23",
+			note: buildSourceActionTaskNote({
+				vaultName: "Work",
+				sourcePath,
+				actionKey: "decide-whether-to-pursue",
+				linkText: "Open opportunity note",
+				format: "advanced-uri",
+			}),
+		};
+
+		const first = await sourceActions.ensure({
+			sourceKey: sourcePath,
+			actionKey: "decide-whether-to-pursue",
+			task: request,
+		});
+		const repeatedCreation = await sourceActions.ensure({
+			sourceKey: sourcePath,
+			actionKey: "decide-whether-to-pursue",
+			task: request,
+		});
+
+		expect(first.created).toBe(true);
+		expect(repeatedCreation.created).toBe(false);
+		expect(addTask).toHaveBeenCalledTimes(1);
+		expect(request.note).toContain("obsidian://adv-uri?");
+		expect(sourceNote.associations.get("decide-whether-to-pursue")).toMatchObject({
+			state: "linked",
+			taskId: "titan-decision",
+		});
+
+		const morning: TodayProjectionItem = {
+			id: "morning-task",
+			title: "Existing morning task",
+			done: false,
+			deepLink: "https://app.amazingmarvin.com/#t=morning-task",
+		};
+		const initialDailyNote = [
+			"# Thursday",
+			"",
+			"## Today's tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=morning-task) Existing morning task",
+			"",
+			"## Notes",
+			"User-authored context survives.",
+		].join("\n");
+		const linkedTask: TodayProjectionItem = {
+			id: createdTask._id,
+			title: createdTask.title,
+			done: createdTask.done,
+			deepLink: first.deepLink,
+			sourcePath,
+			sourceTitle: createdTask.title,
+		};
+
+		// The duplicate models the same task appearing in both due and scheduled reads.
+		const firstRefresh = refreshTodayRegion(initialDailyNote, {
+			date: "2026-07-23",
+			items: [morning, linkedTask, linkedTask],
+		});
+		const repeatedRefresh = refreshTodayRegion(firstRefresh.content, {
+			date: "2026-07-23",
+			items: [morning, linkedTask, linkedTask],
+		});
+
+		expect(marvinIdsInMarkdown(firstRefresh.content)).toEqual([
+			"morning-task",
+			"titan-decision",
+		]);
+		expect(firstRefresh.content).toContain("### Added since morning");
+		expect(firstRefresh.content).toContain(
+			"[[Opportunities/Titan AI.md|Decide whether to pursue Titan AI]]",
+		);
+		expect(firstRefresh.content).toContain(
+			"[⚓](https://app.amazingmarvin.com/#t=titan-decision)",
+		);
+		expect(firstRefresh.content).toContain("User-authored context survives.");
+		expect(repeatedRefresh.changed).toBe(false);
+		expect(repeatedRefresh.content).toBe(firstRefresh.content);
+	});
+});

--- a/src/marvin/incrementalCache.test.ts
+++ b/src/marvin/incrementalCache.test.ts
@@ -1,0 +1,505 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+	CouchChangesPage,
+	CouchSequence,
+} from "./couchChanges";
+import {
+	IncrementalMarvinCache,
+	IncrementalRetryBackoff,
+	applyCouchChanges,
+	type IncrementalCacheState,
+	type IncrementalCacheStore,
+} from "./incrementalCache";
+
+class MemoryStore implements IncrementalCacheStore {
+	value: unknown;
+	readonly saves: IncrementalCacheState[] = [];
+
+	async load(): Promise<unknown> {
+		return this.value;
+	}
+
+	async save(state: IncrementalCacheState): Promise<void> {
+		this.value = structuredClone(state);
+		this.saves.push(structuredClone(state));
+	}
+
+	async clear(): Promise<void> {
+		this.value = undefined;
+	}
+}
+
+class QueuedChanges {
+	readonly since: CouchSequence[] = [];
+
+	constructor(private readonly pages: CouchChangesPage[]) {}
+
+	async changes(options: { since: CouchSequence | "now" }) {
+		this.since.push(options.since);
+		const page = this.pages.shift();
+		if (!page) {
+			throw new Error("No changes page queued");
+		}
+		return page;
+	}
+}
+
+function state(): IncrementalCacheState {
+	return {
+		version: 1,
+		sourceKey: "source",
+		lastSeq: { seq: 1 },
+		categories: [
+			{ _id: "work", title: "Work", type: "category", parentId: "root" },
+			{ _id: "project", title: "Project", type: "project", parentId: "work" },
+			{ _id: "child", title: "Child", type: "project", parentId: "project" },
+		],
+		children: {
+			work: [{ _id: "project", title: "Project", type: "project", parentId: "work" }],
+			project: [
+				{ _id: "child", title: "Child", type: "project", parentId: "project" },
+				{ _id: "task", title: "Draft", type: "task", done: false, parentId: "project" },
+			],
+			child: [],
+			unassigned: [],
+		},
+		lastSuccessfulSyncAt: 1_000,
+		projectionPending: false,
+	};
+}
+
+describe("incremental Marvin cache", () => {
+	it("checkpoints before REST hydration and catches up without a gap", async () => {
+		const store = new MemoryStore();
+		const changes = new QueuedChanges([
+			{ results: [], lastSeq: { seq: 10 }, pending: 0 },
+			{
+				results: [{
+					id: "task-new",
+					seq: { seq: 11 },
+					doc: {
+						_id: "task-new",
+						db: "Tasks",
+						title: "Arrived during hydration",
+						parentId: "project",
+						done: false,
+					},
+				}],
+				lastSeq: { seq: 11 },
+				pending: 0,
+			},
+		]);
+		const snapshot = {
+			getCategories: vi.fn(async () => state().categories),
+			getChildren: vi.fn(async (parentId: string) => (
+				state().children[parentId] ?? []
+			)),
+		};
+		const cache = new IncrementalMarvinCache({
+			sourceKey: "source",
+			changes,
+			snapshot,
+			store,
+			now: () => 2_000,
+		});
+
+		const update = await cache.sync();
+
+		expect(changes.since).toEqual(["now", { seq: 10 }]);
+		expect(update).toMatchObject({
+			fullRefresh: true,
+			changed: true,
+			affectedContainerIds: ["project"],
+		});
+		expect(cache.getChildren("project")?.map((item) => item._id)).toContain(
+			"task-new",
+		);
+		expect(store.saves.at(-1)?.lastSeq).toEqual({ seq: 11 });
+		expect(store.saves.at(-1)?.projectionPending).toBe(true);
+		await cache.acknowledgeProjection();
+		expect(store.saves.at(-1)?.projectionPending).toBe(false);
+	});
+
+	it("resumes an opaque checkpoint, coalesces concurrent polls, and persists it", async () => {
+		const store = new MemoryStore();
+		store.value = state();
+		let release: ((page: CouchChangesPage) => void) | undefined;
+		const changes = {
+			changes: vi.fn(() => new Promise<CouchChangesPage>((resolve) => {
+				release = resolve;
+			})),
+		};
+		const cache = new IncrementalMarvinCache({
+			sourceKey: "source",
+			changes,
+			snapshot: {
+				getCategories: async () => [],
+				getChildren: async () => [],
+			},
+			store,
+			now: () => 2_000,
+		});
+
+		const first = cache.sync("longpoll");
+		const second = cache.sync("longpoll");
+		await vi.waitFor(() => expect(release).toBeTypeOf("function"));
+		release?.({ results: [], lastSeq: { seq: 2 }, pending: 0 });
+
+		expect(await first).toEqual(await second);
+		expect(changes.changes).toHaveBeenCalledTimes(1);
+		expect(changes.changes).toHaveBeenCalledWith(expect.objectContaining({
+			since: { seq: 1 },
+			feed: "longpoll",
+		}));
+		expect(store.saves.at(-1)?.lastSeq).toEqual({ seq: 2 });
+	});
+
+	it("waits for an active poll before clearing persistent state", async () => {
+		const store = new MemoryStore();
+		store.value = state();
+		let release: ((page: CouchChangesPage) => void) | undefined;
+		const cache = new IncrementalMarvinCache({
+			sourceKey: "source",
+			changes: {
+				changes: () => new Promise<CouchChangesPage>((resolve) => {
+					release = resolve;
+				}),
+			},
+			snapshot: {
+				getCategories: async () => [],
+				getChildren: async () => [],
+			},
+			store,
+		});
+
+		const sync = cache.sync("longpoll");
+		await vi.waitFor(() => expect(release).toBeTypeOf("function"));
+		const clearing = cache.clear();
+		await expect(cache.sync()).rejects.toThrow("being reset");
+		expect(store.value).toBeDefined();
+		release?.({ results: [], lastSeq: 2, pending: 0 });
+		await sync;
+		await clearing;
+
+		expect(store.value).toBeUndefined();
+		expect(cache.getCategories()).toBeUndefined();
+	});
+
+	it("replays a pending projection after restart even with no new changes", async () => {
+		const store = new MemoryStore();
+		store.value = { ...state(), projectionPending: true };
+		const changes = new QueuedChanges([
+			{ results: [], lastSeq: { seq: 2 }, pending: 0 },
+		]);
+		const cache = new IncrementalMarvinCache({
+			sourceKey: "source",
+			changes,
+			snapshot: {
+				getCategories: async () => [],
+				getChildren: async () => [],
+			},
+			store,
+		});
+
+		await expect(cache.sync()).resolves.toMatchObject({
+			fullRefresh: true,
+			changed: false,
+		});
+	});
+
+	it("rehydrates instead of trusting malformed persisted items", async () => {
+		const store = new MemoryStore();
+		store.value = {
+			...state(),
+			categories: [{ _id: "broken", title: 42, type: "category" }],
+		};
+		const changes = new QueuedChanges([
+			{ results: [], lastSeq: 10, pending: 0 },
+			{ results: [], lastSeq: 10, pending: 0 },
+		]);
+		const snapshot = {
+			getCategories: vi.fn(async () => state().categories),
+			getChildren: vi.fn(async (parentId: string) => (
+				state().children[parentId] ?? []
+			)),
+		};
+		const cache = new IncrementalMarvinCache({
+			sourceKey: "source",
+			changes,
+			snapshot,
+			store,
+		});
+
+		await expect(cache.sync()).resolves.toMatchObject({
+			fullRefresh: true,
+		});
+		expect(changes.since).toEqual(["now", 10]);
+		expect(snapshot.getCategories).toHaveBeenCalledOnce();
+	});
+
+	it("restarts checkpoint-first hydration after a recoverable snapshot failure", async () => {
+		const store = new MemoryStore();
+		const events: string[] = [];
+		const pages: CouchChangesPage[] = [
+			{ results: [], lastSeq: 10, pending: 0 },
+			{ results: [], lastSeq: 20, pending: 0 },
+			{ results: [], lastSeq: 20, pending: 0 },
+		];
+		const changes = {
+			async changes(options: { since: CouchSequence | "now" }) {
+				events.push(`changes:${JSON.stringify(options.since)}`);
+				return pages.shift()!;
+			},
+		};
+		let snapshotAttempts = 0;
+		const cache = new IncrementalMarvinCache({
+			sourceKey: "source",
+			changes,
+			snapshot: {
+				async getCategories() {
+					events.push("snapshot:categories");
+					return [];
+				},
+				async getChildren(parentId) {
+					events.push(`snapshot:children:${parentId}`);
+					snapshotAttempts += 1;
+					if (snapshotAttempts === 1) {
+						throw new Error("offline");
+					}
+					return [];
+				},
+			},
+			store,
+		});
+
+		await expect(cache.sync()).rejects.toThrow("offline");
+		await expect(cache.sync()).resolves.toMatchObject({
+			fullRefresh: true,
+		});
+		expect(events).toEqual([
+			'changes:"now"',
+			"snapshot:categories",
+			"snapshot:children:unassigned",
+			'changes:"now"',
+			"snapshot:categories",
+			"snapshot:children:unassigned",
+			"changes:20",
+		]);
+	});
+
+	it("applies replayed task moves/completion idempotently and targets parents", () => {
+		const cacheState = state();
+		const moved = {
+			id: "task",
+			seq: 2,
+			doc: {
+				_id: "task",
+				_rev: "2-moved",
+				db: "Tasks",
+				title: "Draft",
+				parentId: "unassigned",
+				done: false,
+			},
+		};
+
+		const first = applyCouchChanges(cacheState, [moved]);
+		const replay = applyCouchChanges(cacheState, [moved]);
+
+		expect(first.affectedContainerIds).toEqual(new Set(["project"]));
+		expect(first.inboxChanged).toBe(true);
+		expect(cacheState.children.project).toHaveLength(1);
+		expect(cacheState.children.unassigned.map((item) => item._id)).toEqual([
+			"task",
+		]);
+		expect(replay.changed).toBe(false);
+		expect(replay.inboxChanged).toBe(false);
+		expect(cacheState.children.unassigned).toHaveLength(1);
+
+		applyCouchChanges(cacheState, [{
+			...moved,
+			seq: 3,
+			doc: { ...moved.doc, _rev: "3-done", done: true },
+		}]);
+		expect(cacheState.children.unassigned).toEqual([]);
+	});
+
+	it("targets descendants and old/new parents after a category move", () => {
+		const cacheState = state();
+		const update = applyCouchChanges(cacheState, [{
+			id: "project",
+			seq: 2,
+			doc: {
+				_id: "project",
+				db: "Categories",
+				type: "project",
+				title: "Renamed",
+				parentId: "other",
+				done: false,
+			},
+		}]);
+
+		expect(update.affectedContainerIds).toEqual(new Set([
+			"work",
+			"other",
+			"project",
+			"child",
+		]));
+		expect(cacheState.categories.find(
+			(item) => item._id === "project",
+		)).toMatchObject({ title: "Renamed", parentId: "other" });
+	});
+
+	it("repairs inconsistent category copies even when one already has the revision", () => {
+		const cacheState = state();
+		cacheState.children.work[0] = {
+			...cacheState.children.work[0]!,
+			_rev: "2-current",
+			title: "Current",
+		};
+		cacheState.categories[1] = {
+			...cacheState.categories[1]!,
+			_rev: "1-stale",
+			title: "Stale",
+		};
+
+		const update = applyCouchChanges(cacheState, [{
+			id: "project",
+			seq: 2,
+			doc: {
+				_id: "project",
+				_rev: "2-current",
+				db: "Categories",
+				type: "project",
+				title: "Current",
+				parentId: "work",
+				done: false,
+			},
+		}]);
+
+		expect(update.changed).toBe(true);
+		expect(cacheState.categories[1]).toMatchObject({
+			_rev: "2-current",
+			title: "Current",
+		});
+		expect(cacheState.children.work[0]).toMatchObject({
+			_rev: "2-current",
+			title: "Current",
+		});
+	});
+
+	it("retains completed projects for hierarchy but removes their open-child link", () => {
+		const cacheState = state();
+		applyCouchChanges(cacheState, [{
+			id: "project",
+			seq: 2,
+			doc: {
+				_id: "project",
+				_rev: "2-done",
+				db: "Categories",
+				type: "project",
+				title: "Project",
+				parentId: "work",
+				done: true,
+			},
+		}]);
+
+		expect(cacheState.categories.map((item) => item._id)).toContain("project");
+		expect(cacheState.children.work).toEqual([]);
+	});
+
+	it("removes deleted cache items but leaves their note disposition to the projection", () => {
+		const cacheState = state();
+		const update = applyCouchChanges(cacheState, [{
+			id: "task",
+			seq: 2,
+			deleted: true,
+		}]);
+
+		expect(cacheState.children.project.map((item) => item._id)).not.toContain(
+			"task",
+		);
+		expect(update.affectedContainerIds).toEqual(new Set(["project"]));
+	});
+
+	it("hides orphaned descendants after container deletion and restores them safely", async () => {
+		const store = new MemoryStore();
+		const cacheState = state();
+		applyCouchChanges(cacheState, [{
+			id: "project",
+			seq: 2,
+			deleted: true,
+		}]);
+		store.value = cacheState;
+		const changes = new QueuedChanges([
+			{ results: [], lastSeq: 2, pending: 0 },
+			{
+				results: [{
+					id: "project",
+					seq: 3,
+					doc: {
+						_id: "project",
+						_rev: "3-restored",
+						db: "Categories",
+						type: "project",
+						title: "Project",
+						parentId: "work",
+						done: false,
+					},
+				}],
+				lastSeq: 3,
+				pending: 0,
+			},
+		]);
+		const cache = new IncrementalMarvinCache({
+			sourceKey: "source",
+			changes,
+			snapshot: {
+				getCategories: async () => [],
+				getChildren: async () => [],
+			},
+			store,
+		});
+
+		await cache.sync();
+		expect(cache.getCategories()?.map((item) => item._id)).toEqual(["work"]);
+		await cache.sync();
+		expect(new Set(cache.getCategories()?.map((item) => item._id))).toEqual(new Set([
+			"work",
+			"project",
+			"child",
+		]));
+	});
+
+	it("backs off without retry amplification and resets after recovery", () => {
+		let now = 1_000;
+		const backoff = new IncrementalRetryBackoff(() => now, 5_000, 20_000);
+
+		expect(backoff.recordFailure()).toBe(5_000);
+		expect(backoff.canRun()).toBe(false);
+		now += 5_000;
+		expect(backoff.canRun()).toBe(true);
+		expect(backoff.recordFailure()).toBe(10_000);
+		now += 10_000;
+		backoff.recordSuccess();
+		expect(backoff.canRun()).toBe(true);
+		expect(backoff.recordFailure()).toBe(5_000);
+	});
+
+	it("rejects malformed relevant documents before changing cache state", () => {
+		const cacheState = state();
+		const before = structuredClone(cacheState);
+
+		expect(() => applyCouchChanges(cacheState, [{
+			id: "task",
+			seq: 2,
+			doc: {
+				_id: "different",
+				db: "Tasks",
+				title: "Bad",
+				parentId: "project",
+			},
+		}])).toThrow("contained document");
+		expect(cacheState).toEqual(before);
+	});
+});

--- a/src/marvin/incrementalCache.ts
+++ b/src/marvin/incrementalCache.ts
@@ -1,0 +1,732 @@
+import type {
+	Category,
+	Project,
+	Task,
+} from "@open-horizon/marvin-client";
+
+import type {
+	CouchChange,
+	CouchChangesPage,
+	CouchSequence,
+	MarvinDatabaseDocument,
+} from "./couchChanges";
+
+export type CachedMarvinItem = Category | Project | Task;
+export type CachedMarvinContainer = Category | Project;
+
+export interface IncrementalCacheState {
+	version: 1;
+	sourceKey: string;
+	lastSeq: CouchSequence;
+	categories: CachedMarvinContainer[];
+	children: Record<string, CachedMarvinItem[]>;
+	lastSuccessfulSyncAt: number;
+	projectionPending: boolean;
+}
+
+export interface IncrementalCacheStore {
+	load(): Promise<unknown>;
+	save(state: IncrementalCacheState): Promise<void>;
+	clear(): Promise<void>;
+}
+
+export interface IncrementalSnapshotSource {
+	getCategories(): Promise<CachedMarvinContainer[]>;
+	getChildren(parentId: string): Promise<CachedMarvinItem[]>;
+}
+
+export interface IncrementalChangesSource {
+	changes(options: {
+		since: CouchSequence | "now";
+		feed?: "normal" | "longpoll";
+		limit?: number;
+		timeoutMs?: number;
+		includeDocs?: boolean;
+	}): Promise<CouchChangesPage>;
+}
+
+export interface IncrementalUpdate {
+	fullRefresh: boolean;
+	changed: boolean;
+	affectedContainerIds: string[];
+	inboxChanged: boolean;
+	lastSuccessfulSyncAt: number;
+}
+
+interface AppliedChanges {
+	changed: boolean;
+	affectedContainerIds: Set<string>;
+	inboxChanged: boolean;
+}
+
+export class IncrementalMarvinCache {
+	private state: IncrementalCacheState | undefined;
+	private inFlight: Promise<IncrementalUpdate> | undefined;
+	private resetting = false;
+
+	constructor(private readonly options: {
+		sourceKey: string;
+		changes: IncrementalChangesSource;
+		snapshot: IncrementalSnapshotSource;
+		store: IncrementalCacheStore;
+		now?: () => number;
+		maxPagesPerSync?: number;
+	}) {}
+
+	sync(feed: "normal" | "longpoll" = "normal"): Promise<IncrementalUpdate> {
+		if (this.resetting) {
+			return Promise.reject(
+				new Error("Incremental Amazing Marvin cache is being reset"),
+			);
+		}
+		if (this.inFlight) {
+			return this.inFlight;
+		}
+		const pending = this.syncOnce(feed).finally(() => {
+			this.inFlight = undefined;
+		});
+		this.inFlight = pending;
+		return pending;
+	}
+
+	getCategories(): CachedMarvinContainer[] | undefined {
+		return this.state
+			? projectableCategories(this.state.categories).map((item) => ({ ...item }))
+			: undefined;
+	}
+
+	getChildren(parentId: string): CachedMarvinItem[] | undefined {
+		const children = this.state?.children[parentId];
+		if (!children || !this.state) {
+			return undefined;
+		}
+		const projectableIds = new Set(
+			projectableCategories(this.state.categories).map((item) => item._id),
+		);
+		return children
+			.filter((item) => (
+				item.type !== "category"
+				&& item.type !== "project"
+				|| projectableIds.has(item._id)
+			))
+			.map((item) => ({ ...item }));
+	}
+
+	getStatus(): {
+		hydrated: boolean;
+		lastSuccessfulSyncAt?: number;
+	} {
+		return {
+			hydrated: this.state !== undefined,
+			...(this.state === undefined
+				? {}
+				: { lastSuccessfulSyncAt: this.state.lastSuccessfulSyncAt }),
+		};
+	}
+
+	async clear(): Promise<void> {
+		this.resetting = true;
+		try {
+			await this.inFlight?.catch(() => undefined);
+			this.state = undefined;
+			await this.options.store.clear();
+		} finally {
+			this.resetting = false;
+		}
+	}
+
+	async acknowledgeProjection(): Promise<void> {
+		if (!this.state || !this.state.projectionPending) {
+			return;
+		}
+		this.state.projectionPending = false;
+		await this.options.store.save(this.state);
+	}
+
+	private async syncOnce(
+		feed: "normal" | "longpoll",
+	): Promise<IncrementalUpdate> {
+		const hydrated = await this.ensureHydrated();
+		if (hydrated) {
+			return hydrated;
+		}
+		return this.pullChanges(feed);
+	}
+
+	private async ensureHydrated(): Promise<IncrementalUpdate | undefined> {
+		if (this.state) {
+			return undefined;
+		}
+		const stored = parseStoredState(
+			await this.options.store.load(),
+			this.options.sourceKey,
+		);
+		if (stored) {
+			this.state = stored;
+			return undefined;
+		}
+
+		const checkpoint = await this.options.changes.changes({
+			since: "now",
+			feed: "normal",
+			limit: 1,
+			includeDocs: false,
+		});
+		const categories = await this.options.snapshot.getCategories();
+		const children: Record<string, CachedMarvinItem[]> = {};
+		for (const category of categories) {
+			children[category._id] = await this.options.snapshot.getChildren(
+				category._id,
+			);
+		}
+		children.unassigned = await this.options.snapshot.getChildren("unassigned");
+
+		const now = this.options.now?.() ?? Date.now();
+		this.state = {
+			version: 1,
+			sourceKey: this.options.sourceKey,
+			lastSeq: checkpoint.lastSeq,
+			categories: dedupeItems(categories),
+			children: Object.fromEntries(
+				Object.entries(children).map(([parentId, items]) => [
+					parentId,
+					dedupeItems(items),
+				]),
+			),
+			lastSuccessfulSyncAt: now,
+			projectionPending: true,
+		};
+		await this.options.store.save(this.state);
+		const caughtUp = await this.pullChanges("normal");
+		return {
+			...caughtUp,
+			fullRefresh: true,
+			changed: true,
+		};
+	}
+
+	private async pullChanges(
+		initialFeed: "normal" | "longpoll",
+	): Promise<IncrementalUpdate> {
+		if (!this.state) {
+			throw new Error("Incremental Marvin cache is not hydrated");
+		}
+		const combined: AppliedChanges = {
+			changed: false,
+			affectedContainerIds: new Set(),
+			inboxChanged: false,
+		};
+		const projectionWasPending = this.state.projectionPending;
+		const maxPages = this.options.maxPagesPerSync ?? 100;
+		for (let pageNumber = 0; pageNumber < maxPages; pageNumber += 1) {
+			const page = await this.options.changes.changes({
+				since: this.state.lastSeq,
+				feed: pageNumber === 0 ? initialFeed : "normal",
+				limit: 500,
+				timeoutMs: 25_000,
+				includeDocs: true,
+			});
+			const applied = applyCouchChanges(this.state, page.results);
+			this.state.projectionPending ||= applied.changed;
+			this.state.lastSeq = page.lastSeq;
+			this.state.lastSuccessfulSyncAt = this.options.now?.() ?? Date.now();
+			mergeApplied(combined, applied);
+			await this.options.store.save(this.state);
+
+			if ((page.pending ?? 0) <= 0 && page.results.length < 500) {
+				break;
+			}
+			if (pageNumber === maxPages - 1) {
+				throw new Error(
+					"Incremental Marvin sync exceeded its bounded page limit",
+				);
+			}
+		}
+		return {
+			fullRefresh: projectionWasPending,
+			changed: combined.changed,
+			affectedContainerIds: [...combined.affectedContainerIds],
+			inboxChanged: combined.inboxChanged,
+			lastSuccessfulSyncAt: this.state.lastSuccessfulSyncAt,
+		};
+	}
+}
+
+export class IncrementalRetryBackoff {
+	private failures = 0;
+	private retryAt = 0;
+
+	constructor(
+		private readonly now: () => number = Date.now,
+		private readonly baseDelayMs = 5_000,
+		private readonly maximumDelayMs = 5 * 60_000,
+	) {}
+
+	canRun(): boolean {
+		return this.now() >= this.retryAt;
+	}
+
+	recordFailure(): number {
+		const delay = Math.min(
+			this.maximumDelayMs,
+			this.baseDelayMs * (2 ** this.failures),
+		);
+		this.failures += 1;
+		this.retryAt = this.now() + delay;
+		return delay;
+	}
+
+	recordSuccess(): void {
+		this.failures = 0;
+		this.retryAt = 0;
+	}
+}
+
+export function applyCouchChanges(
+	state: IncrementalCacheState,
+	changes: readonly CouchChange[],
+): AppliedChanges {
+	validateRelevantChanges(changes);
+	const affectedContainerIds = new Set<string>();
+	let inboxChanged = false;
+	let changed = false;
+	const oldCategories = state.categories.map((item) => ({ ...item }));
+	const changedCategoryIds = new Set<string>();
+
+	for (const change of changes) {
+		const previousCategory = state.categories.find(
+			(item) => item._id === change.id,
+		);
+		const previousLocations = childLocations(state.children, change.id);
+		const previousChildren = previousLocations
+			.flatMap((parentId) => state.children[parentId] ?? [])
+			.filter((item) => item._id === change.id);
+		const previousCopies = [
+			...(previousCategory ? [previousCategory] : []),
+			...previousChildren,
+		];
+		if (
+			change.doc?._rev
+			&& previousCopies.length > 0
+			&& previousCopies.every((item) => item._rev === change.doc?._rev)
+		) {
+			continue;
+		}
+		const previousCategoryIndex = state.categories.findIndex(
+			(item) => item._id === change.id,
+		);
+		state.categories = state.categories.filter(
+			(item) => item._id !== change.id,
+		);
+		for (const parentId of previousLocations) {
+			state.children[parentId] = (state.children[parentId] ?? []).filter(
+				(item) => item._id !== change.id,
+			);
+			markParent(parentId, affectedContainerIds, () => {
+				inboxChanged = true;
+			});
+		}
+
+		const doc = change.doc;
+		const physicallyDeleted = change.deleted || doc?._deleted;
+		if (
+			!physicallyDeleted
+			&& doc
+			&& doc.db === "Categories"
+		) {
+			changedCategoryIds.add(change.id);
+			const category = categoryFromDocument(doc);
+			if (category && isPresentDocument(doc)) {
+				const insertion = previousCategoryIndex >= 0
+					? previousCategoryIndex
+					: state.categories.length;
+				state.categories.splice(insertion, 0, category);
+				state.children[category._id] ??= [];
+				if (doc.done !== true) {
+					addChild(state.children, category.parentId, category);
+					markParent(category.parentId, affectedContainerIds, () => {
+						inboxChanged = true;
+					});
+				}
+				affectedContainerIds.add(category._id);
+			}
+			changed = true;
+			continue;
+		}
+
+		if (!physicallyDeleted && doc?.db === "Tasks") {
+			const task = taskFromDocument(doc);
+			if (task && isPresentDocument(doc) && doc.done !== true) {
+				addChild(state.children, task.parentId, task);
+				markParent(task.parentId, affectedContainerIds, () => {
+					inboxChanged = true;
+				});
+			}
+			changed = true;
+			continue;
+		}
+
+		if (previousCategory) {
+			changedCategoryIds.add(change.id);
+			affectedContainerIds.add(change.id);
+			changed = true;
+		} else if (previousLocations.length > 0) {
+			changed = true;
+		}
+	}
+
+	for (const categoryId of changedCategoryIds) {
+		for (const item of [
+			...descendantsOf(categoryId, oldCategories),
+			...descendantsOf(categoryId, state.categories),
+		]) {
+			affectedContainerIds.add(item);
+		}
+		const oldParent = oldCategories.find(
+			(item) => item._id === categoryId,
+		)?.parentId;
+		const newParent = state.categories.find(
+			(item) => item._id === categoryId,
+		)?.parentId;
+		markParent(oldParent, affectedContainerIds, () => {
+			inboxChanged = true;
+		});
+		markParent(newParent, affectedContainerIds, () => {
+			inboxChanged = true;
+		});
+	}
+
+	return { changed, affectedContainerIds, inboxChanged };
+}
+
+function parseStoredState(
+	value: unknown,
+	sourceKey: string,
+): IncrementalCacheState | undefined {
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| (value as Partial<IncrementalCacheState>).version !== 1
+		|| (value as Partial<IncrementalCacheState>).sourceKey !== sourceKey
+		|| !Array.isArray((value as Partial<IncrementalCacheState>).categories)
+		|| typeof (value as Partial<IncrementalCacheState>).children !== "object"
+		|| (value as Partial<IncrementalCacheState>).children === null
+		|| Array.isArray((value as Partial<IncrementalCacheState>).children)
+		|| typeof (value as Partial<IncrementalCacheState>).lastSuccessfulSyncAt !== "number"
+		|| !("lastSeq" in value)
+		|| (value as Partial<IncrementalCacheState>).lastSeq === undefined
+	) {
+		return undefined;
+	}
+	const stored = value as IncrementalCacheState;
+	if (
+		!stored.categories.every(isCachedContainer)
+		|| !Object.values(stored.children).every((items) => (
+			Array.isArray(items) && items.every(isCachedItem)
+		))
+	) {
+		return undefined;
+	}
+	return {
+		...stored,
+		projectionPending: stored.projectionPending !== false,
+	};
+}
+
+function isCachedContainer(value: unknown): value is CachedMarvinContainer {
+	return (
+		isCachedItem(value)
+		&& (value.type === "category" || value.type === "project")
+	);
+}
+
+function isCachedItem(value: unknown): value is CachedMarvinItem {
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| typeof (value as { _id?: unknown })._id !== "string"
+		|| typeof (value as { title?: unknown }).title !== "string"
+	) {
+		return false;
+	}
+	const item = value as {
+		type?: unknown;
+		done?: unknown;
+		parentId?: unknown;
+	};
+	if (
+		item.type !== undefined
+		&& item.type !== "task"
+		&& item.type !== "category"
+		&& item.type !== "project"
+	) {
+		return false;
+	}
+	if (item.parentId !== undefined && typeof item.parentId !== "string") {
+		return false;
+	}
+	return (
+		item.type === "category"
+		|| item.type === "project"
+		|| typeof item.done === "boolean"
+	);
+}
+
+function projectableCategories(
+	categories: readonly CachedMarvinContainer[],
+): CachedMarvinContainer[] {
+	const byId = new Map(categories.map((item) => [item._id, item]));
+	const projectable = new Set<string>();
+	const rejected = new Set<string>();
+
+	const reachesRoot = (item: CachedMarvinContainer): boolean => {
+		const path: string[] = [];
+		const visited = new Set<string>();
+		let current: CachedMarvinContainer | undefined = item;
+		while (current) {
+			if (projectable.has(current._id)) {
+				for (const id of path) {
+					projectable.add(id);
+				}
+				return true;
+			}
+			if (rejected.has(current._id) || visited.has(current._id)) {
+				for (const id of path) {
+					rejected.add(id);
+				}
+				return false;
+			}
+			visited.add(current._id);
+			path.push(current._id);
+			if (!current.parentId || current.parentId === "root") {
+				for (const id of path) {
+					projectable.add(id);
+				}
+				return true;
+			}
+			current = byId.get(current.parentId);
+			if (!current) {
+				for (const id of path) {
+					rejected.add(id);
+				}
+				return false;
+			}
+		}
+		return false;
+	};
+
+	return categories.filter(reachesRoot);
+}
+
+function categoryFromDocument(
+	doc: MarvinDatabaseDocument,
+): CachedMarvinContainer | undefined {
+	if (typeof doc.title !== "string") {
+		return undefined;
+	}
+	const common = commonFields(doc);
+	if (doc.type === "project") {
+		return {
+			...common,
+			title: doc.title,
+			type: "project",
+			...(typeof doc.parentId === "string" ? { parentId: doc.parentId } : {}),
+			...categoryOptionalFields(doc),
+		};
+	}
+	return {
+		...common,
+		title: doc.title,
+		type: "category",
+		...(typeof doc.parentId === "string" ? { parentId: doc.parentId } : {}),
+		...categoryOptionalFields(doc),
+	};
+}
+
+function taskFromDocument(
+	doc: MarvinDatabaseDocument,
+): Task | undefined {
+	if (typeof doc.title !== "string") {
+		return undefined;
+	}
+	return {
+		...commonFields(doc),
+		title: doc.title,
+		type: "task",
+		done: doc.done === true,
+		...(typeof doc.parentId === "string" ? { parentId: doc.parentId } : {}),
+		...taskOptionalFields(doc),
+	};
+}
+
+function commonFields(doc: MarvinDatabaseDocument) {
+	return {
+		_id: doc._id,
+		...(typeof doc._rev === "string" ? { _rev: doc._rev } : {}),
+		...(typeof doc.createdAt === "number" ? { createdAt: doc.createdAt } : {}),
+		...(typeof doc.updatedAt === "number" ? { updatedAt: doc.updatedAt } : {}),
+	};
+}
+
+function categoryOptionalFields(doc: MarvinDatabaseDocument) {
+	return copyDefined(doc, [
+		"day",
+		"firstScheduled",
+		"startDate",
+		"dueDate",
+		"endDate",
+		"done",
+		"doneDate",
+		"note",
+		"labelIds",
+		"timeEstimate",
+		"priority",
+		"rank",
+		"recurring",
+	] as const);
+}
+
+function taskOptionalFields(doc: MarvinDatabaseDocument) {
+	return copyDefined(doc, [
+		"day",
+		"firstScheduled",
+		"startDate",
+		"dueDate",
+		"endDate",
+		"doneAt",
+		"completedAt",
+		"note",
+		"labelIds",
+		"timeEstimate",
+		"priority",
+		"rank",
+		"recurring",
+		"isRecurring",
+		"subtasks",
+	] as const);
+}
+
+function copyDefined(
+	source: MarvinDatabaseDocument,
+	keys: readonly string[],
+): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const key of keys) {
+		if (source[key] !== undefined && source[key] !== null) {
+			result[key] = source[key];
+		}
+	}
+	return result;
+}
+
+function isPresentDocument(doc: MarvinDatabaseDocument): boolean {
+	const restoredAt = typeof doc.restoredAt === "number" ? doc.restoredAt : 0;
+	const deletedAt = typeof doc.deletedAt === "number" ? doc.deletedAt : 0;
+	return !(deletedAt > restoredAt);
+}
+
+function validateRelevantChanges(changes: readonly CouchChange[]): void {
+	for (const change of changes) {
+		const doc = change.doc;
+		if (!doc || change.deleted || doc._deleted) {
+			continue;
+		}
+		if (doc._id !== change.id) {
+			throw new Error(
+				`Amazing Marvin change ${change.id} contained document ${doc._id}`,
+			);
+		}
+		if (
+			(doc.db === "Tasks" || doc.db === "Categories")
+			&& (
+				typeof doc.title !== "string"
+				|| typeof doc.parentId !== "string"
+			)
+		) {
+			throw new Error(
+				`Amazing Marvin ${doc.db} document ${doc._id} is malformed`,
+			);
+		}
+	}
+}
+
+function childLocations(
+	children: Record<string, CachedMarvinItem[]>,
+	itemId: string,
+): string[] {
+	return Object.entries(children)
+		.filter(([, items]) => items.some((item) => item._id === itemId))
+		.map(([parentId]) => parentId);
+}
+
+function addChild(
+	children: Record<string, CachedMarvinItem[]>,
+	parentId: string | undefined,
+	item: CachedMarvinItem,
+): void {
+	if (!parentId || parentId === "root") {
+		return;
+	}
+	const existing = children[parentId] ?? [];
+	const index = existing.findIndex((candidate) => candidate._id === item._id);
+	if (index === -1) {
+		children[parentId] = [...existing, item];
+	} else {
+		const next = [...existing];
+		next[index] = item;
+		children[parentId] = next;
+	}
+}
+
+function markParent(
+	parentId: string | undefined,
+	affected: Set<string>,
+	inbox: () => void,
+): void {
+	if (!parentId || parentId === "root") {
+		return;
+	}
+	if (parentId === "unassigned") {
+		inbox();
+		return;
+	}
+	affected.add(parentId);
+}
+
+function descendantsOf(
+	rootId: string,
+	categories: readonly CachedMarvinContainer[],
+): string[] {
+	const descendants: string[] = [];
+	const queue = [rootId];
+	const visited = new Set(queue);
+	for (let index = 0; index < queue.length; index += 1) {
+		const parentId = queue[index]!;
+		for (const item of categories) {
+			if (item.parentId === parentId && !visited.has(item._id)) {
+				visited.add(item._id);
+				descendants.push(item._id);
+				queue.push(item._id);
+			}
+		}
+	}
+	return descendants;
+}
+
+function dedupeItems<T extends { _id: string }>(items: readonly T[]): T[] {
+	const byId = new Map<string, T>();
+	for (const item of items) {
+		if (!byId.has(item._id)) {
+			byId.set(item._id, item);
+		}
+	}
+	return [...byId.values()];
+}
+
+function mergeApplied(target: AppliedChanges, source: AppliedChanges): void {
+	target.changed ||= source.changed;
+	target.inboxChanged ||= source.inboxChanged;
+	for (const id of source.affectedContainerIds) {
+		target.affectedContainerIds.add(id);
+	}
+}

--- a/src/marvin/noteContext.test.ts
+++ b/src/marvin/noteContext.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { marvinParentIdFromFrontmatter } from "./noteContext";
+
+describe("Marvin note context", () => {
+	it("uses an imported category or project as the task parent", () => {
+		expect(marvinParentIdFromFrontmatter({
+			_id: "project-1",
+			type: "project",
+			deepLink: "https://app.amazingmarvin.com/#p=project-1",
+		})).toBe("project-1");
+	});
+
+	it("does not treat unrelated frontmatter or tasks as a parent", () => {
+		expect(marvinParentIdFromFrontmatter({
+			_id: "task-1",
+			type: "task",
+			deepLink: "https://app.amazingmarvin.com/#t=task-1",
+		})).toBeUndefined();
+		expect(marvinParentIdFromFrontmatter({ _id: "project-1" })).toBeUndefined();
+		expect(marvinParentIdFromFrontmatter({
+			_id: "project-1",
+			type: "project",
+			deepLink: "https://app.amazingmarvin.com/#p=project-10",
+		})).toBeUndefined();
+	});
+});

--- a/src/marvin/noteContext.ts
+++ b/src/marvin/noteContext.ts
@@ -1,0 +1,16 @@
+export function marvinParentIdFromFrontmatter(
+	frontmatter: Record<string, unknown> | undefined,
+): string | undefined {
+	const itemId = frontmatter?._id;
+	const deepLink = frontmatter?.deepLink;
+	const type = frontmatter?.type;
+	if (
+		type !== "category" && type !== "project"
+		|| typeof itemId !== "string"
+		|| typeof deepLink !== "string"
+		|| deepLink !== `https://app.amazingmarvin.com/#p=${itemId}`
+	) {
+		return undefined;
+	}
+	return itemId;
+}

--- a/src/marvin/obsidianIncremental.test.ts
+++ b/src/marvin/obsidianIncremental.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	ObsidianIncrementalCacheStore,
+	type IncrementalFileAdapter,
+} from "./obsidianIncremental";
+import type { IncrementalCacheState } from "./incrementalCache";
+
+class MemoryAdapter implements IncrementalFileAdapter {
+	readonly files = new Map<string, string>();
+
+	async exists(path: string) {
+		return this.files.has(path);
+	}
+
+	async read(path: string) {
+		const value = this.files.get(path);
+		if (value === undefined) {
+			throw new Error("missing");
+		}
+		return value;
+	}
+
+	async write(path: string, data: string) {
+		this.files.set(path, data);
+	}
+
+	async process(path: string, update: (data: string) => string) {
+		const value = update(await this.read(path));
+		this.files.set(path, value);
+		return value;
+	}
+
+	async remove(path: string) {
+		this.files.delete(path);
+	}
+}
+
+const state: IncrementalCacheState = {
+	version: 1,
+	sourceKey: "source",
+	lastSeq: { opaque: true },
+	categories: [],
+	children: {},
+	lastSuccessfulSyncAt: 1_000,
+	projectionPending: false,
+};
+
+describe("Obsidian incremental cache store", () => {
+	it("persists opaque checkpoints without database credentials", async () => {
+		const adapter = new MemoryAdapter();
+		const store = new ObsidianIncrementalCacheStore(
+			adapter,
+			".obsidian/plugins/cloudatlas-o-am",
+		);
+
+		await store.save(state);
+		const serialized = adapter.files.get(store.path) ?? "";
+
+		expect(await store.load()).toEqual(state);
+		expect(serialized).not.toContain("password");
+		await store.clear();
+		expect(await store.load()).toBeUndefined();
+	});
+
+	it("surfaces a recoverable corrupt-cache error", async () => {
+		const adapter = new MemoryAdapter();
+		const store = new ObsidianIncrementalCacheStore(adapter, "plugin");
+		adapter.files.set(store.path, "{");
+
+		await expect(store.load()).rejects.toThrow("reset it");
+	});
+});

--- a/src/marvin/obsidianIncremental.ts
+++ b/src/marvin/obsidianIncremental.ts
@@ -1,0 +1,84 @@
+import type {
+	CouchChangesTransport,
+} from "./couchChanges";
+import type {
+	IncrementalCacheState,
+	IncrementalCacheStore,
+} from "./incrementalCache";
+import type { ObsidianRequestUrl } from "./obsidianTransport";
+
+export interface IncrementalFileAdapter {
+	exists(path: string): Promise<boolean>;
+	read(path: string): Promise<string>;
+	write(path: string, data: string): Promise<void>;
+	process(path: string, update: (data: string) => string): Promise<string>;
+	remove(path: string): Promise<void>;
+}
+
+export function createObsidianCouchTransport(
+	request: ObsidianRequestUrl,
+): CouchChangesTransport {
+	return {
+		async request(input) {
+			const response = await request({
+				url: input.url,
+				method: "GET",
+				headers: input.headers,
+				throw: false,
+			});
+			return {
+				status: response.status,
+				text: response.text,
+			};
+		},
+	};
+}
+
+export class ObsidianIncrementalCacheStore implements IncrementalCacheStore {
+	readonly path: string;
+
+	constructor(
+		private readonly adapter: IncrementalFileAdapter,
+		pluginDirectory: string,
+	) {
+		this.path = normalizeAdapterPath(
+			`${pluginDirectory}/marvin-incremental-cache-v1.json`,
+		);
+	}
+
+	async load(): Promise<unknown> {
+		if (!await this.adapter.exists(this.path)) {
+			return undefined;
+		}
+		const serialized = await this.adapter.read(this.path);
+		try {
+			return JSON.parse(serialized) as unknown;
+		} catch {
+			throw new Error(
+				"Persistent Amazing Marvin cache is invalid; reset it in plugin settings",
+			);
+		}
+	}
+
+	async save(state: IncrementalCacheState): Promise<void> {
+		const serialized = JSON.stringify(state);
+		if (await this.adapter.exists(this.path)) {
+			await this.adapter.process(this.path, () => serialized);
+		} else {
+			await this.adapter.write(this.path, serialized);
+		}
+	}
+
+	async clear(): Promise<void> {
+		if (await this.adapter.exists(this.path)) {
+			await this.adapter.remove(this.path);
+		}
+	}
+}
+
+function normalizeAdapterPath(path: string): string {
+	return path
+		.replace(/\\/g, "/")
+		.replace(/\/+/g, "/")
+		.replace(/^\/|\/$/g, "");
+}

--- a/src/marvin/obsidianLinks.test.ts
+++ b/src/marvin/obsidianLinks.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	buildObsidianUri,
+	buildSourceActionTaskNote,
+} from "./obsidianLinks";
+
+describe("Obsidian source links", () => {
+	it("builds the Advanced URI format requested by existing workflows", () => {
+		expect(buildObsidianUri({
+			vaultName: "My Vault",
+			filePath: "Opportunities/Titan AI.md",
+			format: "advanced-uri",
+		})).toBe(
+			"obsidian://adv-uri?vault=My%20Vault&filepath=Opportunities%2FTitan%20AI.md",
+		);
+	});
+
+	it("retains an official Obsidian URI option", () => {
+		expect(buildObsidianUri({
+			vaultName: "My Vault",
+			filePath: "Notes/Source.md",
+			format: "standard",
+		})).toBe(
+			"obsidian://open?vault=My%20Vault&file=Notes%2FSource.md",
+		);
+	});
+
+	it("embeds a stable source/action marker without replacing caller notes", () => {
+		const note = buildSourceActionTaskNote({
+			vaultName: "My Vault",
+			sourcePath: "Opportunities/Titan AI.md",
+			actionKey: "decide whether/to pursue",
+			linkText: "Open source note",
+			format: "advanced-uri",
+			note: "Evidence captured by the automation.",
+		});
+
+		expect(note).toContain("Evidence captured by the automation.");
+		expect(note).toContain("[Open source note](obsidian://adv-uri?");
+		expect(note).toContain(
+			"source=Opportunities%2FTitan%20AI.md action=decide%20whether%2Fto%20pursue",
+		);
+	});
+});

--- a/src/marvin/obsidianLinks.ts
+++ b/src/marvin/obsidianLinks.ts
@@ -1,0 +1,49 @@
+export type ObsidianLinkFormat = "advanced-uri" | "standard";
+
+export interface ObsidianSourceLink {
+	vaultName: string;
+	filePath: string;
+	format: ObsidianLinkFormat;
+}
+
+export function buildObsidianUri(options: ObsidianSourceLink): string {
+	const vault = encodeURIComponent(options.vaultName);
+	const filePath = encodeURIComponent(options.filePath);
+	return options.format === "advanced-uri"
+		? `obsidian://adv-uri?vault=${vault}&filepath=${filePath}`
+		: `obsidian://open?vault=${vault}&file=${filePath}`;
+}
+
+export function buildSourceActionTaskNote(options: {
+	vaultName: string;
+	sourcePath: string;
+	actionKey: string;
+	linkText: string;
+	format: ObsidianLinkFormat;
+	note?: string;
+}): string {
+	const uri = buildObsidianUri({
+		vaultName: options.vaultName,
+		filePath: options.sourcePath,
+		format: options.format,
+	});
+	const link = options.linkText
+		? `[${escapeMarkdownLabel(options.linkText)}](${uri})`
+		: uri;
+	const marker = [
+		"<!-- obsidian-am:source-action",
+		"version=1",
+		`source=${encodeURIComponent(options.sourcePath)}`,
+		`action=${encodeURIComponent(options.actionKey)}`,
+		"-->",
+	].join(" ");
+	return [options.note?.trim(), link, marker].filter(Boolean).join("\n\n");
+}
+
+function escapeMarkdownLabel(value: string): string {
+	return value
+		.replace(/[\r\n]+/g, " ")
+		.replace(/\\/g, "\\\\")
+		.replace(/\]/g, "\\]")
+		.trim();
+}

--- a/src/marvin/obsidianSourceActions.test.ts
+++ b/src/marvin/obsidianSourceActions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { App } from "obsidian";
+
+import {
+	ObsidianSourceActionStore,
+	SOURCE_ACTIONS_FRONTMATTER_KEY,
+	readSourceActionRecords,
+} from "./obsidianSourceActions";
+
+describe("source action frontmatter", () => {
+	it("reads pending and linked associations using the note path as source identity", () => {
+		const records = readSourceActionRecords({
+			[SOURCE_ACTIONS_FRONTMATTER_KEY]: [
+				{
+					version: 1,
+					state: "pending",
+					actionKey: "decide",
+					title: "Decide",
+					requestId: "request-1",
+					requestedAt: 100,
+				},
+				{
+					version: 1,
+					state: "linked",
+					actionKey: "apply",
+					title: "Apply",
+					requestId: "request-2",
+					requestedAt: 200,
+					taskId: "task-2",
+					deepLink: "https://app.amazingmarvin.com/#t=task-2",
+					linkedAt: 300,
+				},
+			],
+		}, "Opportunities/Titan.md");
+
+		expect(records).toEqual([
+			expect.objectContaining({
+				state: "pending",
+				sourceKey: "Opportunities/Titan.md",
+				actionKey: "decide",
+			}),
+			expect.objectContaining({
+				state: "linked",
+				sourceKey: "Opportunities/Titan.md",
+				taskId: "task-2",
+			}),
+		]);
+	});
+
+	it("distinguishes no associations from malformed owned metadata", () => {
+		expect(readSourceActionRecords({}, "note.md")).toEqual([]);
+		expect(() => readSourceActionRecords({
+			[SOURCE_ACTIONS_FRONTMATTER_KEY]: "task-1",
+		}, "note.md")).toThrow("must be a list");
+	});
+
+	it("persists a linked association and discovers its source note by task ID", async () => {
+		const file = {
+			path: "Opportunities/Titan.md",
+			basename: "Titan",
+			extension: "md",
+		};
+		const frontmatter: Record<string, unknown> = {};
+		const app = {
+			vault: {
+				getAbstractFileByPath: (path: string) => path === file.path ? file : null,
+				getMarkdownFiles: () => [file],
+			},
+			metadataCache: {
+				getFileCache: () => ({ frontmatter }),
+			},
+			fileManager: {
+				processFrontMatter: async (
+					_file: unknown,
+					mutate: (value: Record<string, unknown>) => void,
+				) => mutate(frontmatter),
+			},
+		} as unknown as App;
+		const store = new ObsidianSourceActionStore(app);
+
+		await store.set({
+			version: 1,
+			state: "linked",
+			sourceKey: file.path,
+			actionKey: "decide",
+			title: "Decide whether to pursue",
+			requestId: "request-1",
+			requestedAt: 100,
+			taskId: "task-1",
+			deepLink: "https://app.amazingmarvin.com/#t=task-1",
+			linkedAt: 200,
+		});
+
+		expect(frontmatter[SOURCE_ACTIONS_FRONTMATTER_KEY]).toEqual([
+			expect.objectContaining({
+				actionKey: "decide",
+				taskId: "task-1",
+			}),
+		]);
+		expect(await store.get({
+			sourceKey: file.path,
+			actionKey: "decide",
+		})).toMatchObject({ state: "linked", taskId: "task-1" });
+		expect(store.findLinkedTasks(["task-1"]).get("task-1")).toEqual({
+			taskId: "task-1",
+			sourcePath: file.path,
+			sourceTitle: "Titan",
+			actionKey: "decide",
+			deepLink: "https://app.amazingmarvin.com/#t=task-1",
+		});
+		expect(store.shouldInvalidateFor(file.path, undefined)).toBe(true);
+		expect(store.shouldInvalidateFor("Daily/2026-07-23.md", {})).toBe(false);
+	});
+});

--- a/src/marvin/obsidianSourceActions.ts
+++ b/src/marvin/obsidianSourceActions.ts
@@ -1,0 +1,281 @@
+import type { App, TFile } from "obsidian";
+import type {
+	LinkedSourceActionRecord,
+	SourceActionKey,
+	SourceActionRecord,
+	SourceActionStore,
+} from "@open-horizon/marvin-client";
+
+export const SOURCE_ACTIONS_FRONTMATTER_KEY = "amazing-marvin-actions";
+
+interface StoredSourceActionRecord {
+	version: 1;
+	state: "pending" | "linked";
+	actionKey: string;
+	title: string;
+	requestId: string;
+	requestedAt: number;
+	taskId?: string;
+	deepLink?: string;
+	linkedAt?: number;
+}
+
+export interface SourceActionLink {
+	taskId: string;
+	sourcePath: string;
+	sourceTitle: string;
+	actionKey: string;
+	deepLink: string;
+}
+
+const DELETED = Symbol("deleted-source-action");
+
+export class ObsidianSourceActionStore implements SourceActionStore {
+	private readonly overlay = new Map<string, SourceActionRecord | typeof DELETED>();
+	private linkedIndex?: Map<string, SourceActionLink>;
+	private indexedSourcePaths = new Set<string>();
+
+	constructor(private readonly app: App) {}
+
+	async get(key: SourceActionKey): Promise<SourceActionRecord | undefined> {
+		const overlay = this.overlay.get(serializedKey(key));
+		if (overlay === DELETED) {
+			return undefined;
+		}
+		if (overlay) {
+			return overlay;
+		}
+		const file = this.requireMarkdownFile(key.sourceKey);
+		return readSourceActionRecords(
+			this.app.metadataCache.getFileCache(file)?.frontmatter,
+			file.path,
+		).find((record) => record.actionKey === key.actionKey);
+	}
+
+	async set(record: SourceActionRecord): Promise<void> {
+		const file = this.requireMarkdownFile(record.sourceKey);
+		await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+			const records = readSourceActionRecords(frontmatter, file.path);
+			const next = records.filter(
+				(candidate) => candidate.actionKey !== record.actionKey,
+			);
+			next.push(record);
+			frontmatter[SOURCE_ACTIONS_FRONTMATTER_KEY] = next.map(toStoredRecord);
+		});
+		this.overlay.set(serializedKey(record), record);
+		this.linkedIndex = undefined;
+	}
+
+	async delete(key: SourceActionKey): Promise<void> {
+		const file = this.requireMarkdownFile(key.sourceKey);
+		await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+			const records = readSourceActionRecords(frontmatter, file.path);
+			const next = records.filter(
+				(candidate) => candidate.actionKey !== key.actionKey,
+			);
+			if (next.length === 0) {
+				delete frontmatter[SOURCE_ACTIONS_FRONTMATTER_KEY];
+			} else {
+				frontmatter[SOURCE_ACTIONS_FRONTMATTER_KEY] = next.map(toStoredRecord);
+			}
+		});
+		this.overlay.set(serializedKey(key), DELETED);
+		this.linkedIndex = undefined;
+	}
+
+	findLinkedTasks(taskIds: Iterable<string>): Map<string, SourceActionLink> {
+		this.linkedIndex ??= this.buildLinkedIndex();
+		const links = new Map<string, SourceActionLink>();
+		for (const taskId of taskIds) {
+			const link = this.linkedIndex.get(taskId);
+			if (link) {
+				links.set(taskId, link);
+			}
+		}
+		return links;
+	}
+
+	invalidateIndex(clearOverlay = false): void {
+		this.linkedIndex = undefined;
+		if (clearOverlay) {
+			this.overlay.clear();
+		}
+	}
+
+	shouldInvalidateFor(
+		sourcePath: string,
+		frontmatter: Record<string, unknown> | undefined,
+	): boolean {
+		if (
+			frontmatter
+			&& Object.prototype.hasOwnProperty.call(
+				frontmatter,
+				SOURCE_ACTIONS_FRONTMATTER_KEY,
+			)
+		) {
+			return true;
+		}
+		if (this.indexedSourcePaths.has(sourcePath)) {
+			return true;
+		}
+		for (const key of this.overlay.keys()) {
+			const [overlaySource] = JSON.parse(key) as [string, string];
+			if (overlaySource === sourcePath) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private buildLinkedIndex(): Map<string, SourceActionLink> {
+		const links = new Map<string, SourceActionLink>();
+		this.indexedSourcePaths = new Set<string>();
+		const files = [...this.app.vault.getMarkdownFiles()]
+			.sort((left, right) => left.path.localeCompare(right.path));
+		for (const file of files) {
+			const records = this.recordsForFile(file);
+			if (records.length > 0) {
+				this.indexedSourcePaths.add(file.path);
+			}
+			for (const record of records) {
+				if (
+					record.state !== "linked"
+					|| links.has(record.taskId)
+				) {
+					continue;
+				}
+				links.set(record.taskId, {
+					taskId: record.taskId,
+					sourcePath: file.path,
+					sourceTitle: file.basename,
+					actionKey: record.actionKey,
+					deepLink: record.deepLink,
+				});
+			}
+		}
+		return links;
+	}
+
+	private recordsForFile(file: TFile): SourceActionRecord[] {
+		const records = new Map(
+			readSourceActionRecords(
+				this.app.metadataCache.getFileCache(file)?.frontmatter,
+				file.path,
+			).map((record) => [record.actionKey, record]),
+		);
+		for (const [key, overlay] of this.overlay) {
+			const [sourceKey, actionKey] = JSON.parse(key) as [string, string];
+			if (sourceKey !== file.path) {
+				continue;
+			}
+			if (overlay === DELETED) {
+				records.delete(actionKey);
+			} else {
+				records.set(actionKey, overlay);
+			}
+		}
+		return [...records.values()];
+	}
+
+	private requireMarkdownFile(path: string): TFile {
+		const file = this.app.vault.getAbstractFileByPath(path);
+		if (!file || !("extension" in file) || file.extension !== "md") {
+			throw new Error(`Obsidian source note not found: ${path}`);
+		}
+		return file as TFile;
+	}
+}
+
+export function readSourceActionRecords(
+	frontmatter: Record<string, unknown> | undefined,
+	sourceKey: string,
+): SourceActionRecord[] {
+	const value = frontmatter?.[SOURCE_ACTIONS_FRONTMATTER_KEY];
+	if (value === undefined) {
+		return [];
+	}
+	if (!Array.isArray(value)) {
+		throw new Error(
+			`${SOURCE_ACTIONS_FRONTMATTER_KEY} in ${sourceKey} must be a list`,
+		);
+	}
+	return value.map((entry, index) => fromStoredRecord(entry, sourceKey, index));
+}
+
+function fromStoredRecord(
+	value: unknown,
+	sourceKey: string,
+	index: number,
+): SourceActionRecord {
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| (value as Partial<StoredSourceActionRecord>).version !== 1
+		|| !["pending", "linked"].includes(
+			(value as Partial<StoredSourceActionRecord>).state ?? "",
+		)
+		|| typeof (value as Partial<StoredSourceActionRecord>).actionKey !== "string"
+		|| typeof (value as Partial<StoredSourceActionRecord>).title !== "string"
+		|| typeof (value as Partial<StoredSourceActionRecord>).requestId !== "string"
+		|| typeof (value as Partial<StoredSourceActionRecord>).requestedAt !== "number"
+	) {
+		throw new Error(
+			`Invalid ${SOURCE_ACTIONS_FRONTMATTER_KEY} entry ${index + 1} in ${sourceKey}`,
+		);
+	}
+	const stored = value as StoredSourceActionRecord;
+	const base = {
+		version: 1 as const,
+		sourceKey,
+		actionKey: stored.actionKey,
+		title: stored.title,
+		requestId: stored.requestId,
+		requestedAt: stored.requestedAt,
+	};
+	if (stored.state === "pending") {
+		return { ...base, state: "pending" };
+	}
+	if (
+		typeof stored.taskId !== "string"
+		|| typeof stored.deepLink !== "string"
+		|| typeof stored.linkedAt !== "number"
+	) {
+		throw new Error(
+			`Invalid linked ${SOURCE_ACTIONS_FRONTMATTER_KEY} entry ${index + 1} in ${sourceKey}`,
+		);
+	}
+	return {
+		...base,
+		state: "linked",
+		taskId: stored.taskId,
+		deepLink: stored.deepLink,
+		linkedAt: stored.linkedAt,
+	};
+}
+
+function toStoredRecord(record: SourceActionRecord): StoredSourceActionRecord {
+	const base: StoredSourceActionRecord = {
+		version: 1,
+		state: record.state,
+		actionKey: record.actionKey,
+		title: record.title,
+		requestId: record.requestId,
+		requestedAt: record.requestedAt,
+	};
+	if (record.state === "linked") {
+		base.taskId = record.taskId;
+		base.deepLink = record.deepLink;
+		base.linkedAt = record.linkedAt;
+	}
+	return base;
+}
+
+function serializedKey(key: SourceActionKey): string {
+	return JSON.stringify([key.sourceKey, key.actionKey]);
+}
+
+export function isLinkedSourceAction(
+	record: SourceActionRecord,
+): record is LinkedSourceActionRecord {
+	return record.state === "linked";
+}

--- a/src/marvin/obsidianTransport.test.ts
+++ b/src/marvin/obsidianTransport.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+	FetchTransport,
+	MarvinApiClient,
+	type FetchLike,
+} from "@open-horizon/marvin-client";
+import { createObsidianTransport } from "./obsidianTransport";
+
+describe("shared transport contract", () => {
+	it("returns the same client result through Obsidian and fetch adapters", async () => {
+		const payload = [{ _id: "task-1", title: "Shared", done: false }];
+		const obsidianRequests: unknown[] = [];
+		const obsidianTransport = createObsidianTransport(async (request) => {
+			obsidianRequests.push(request);
+			return {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+				arrayBuffer: new ArrayBuffer(0),
+				json: payload,
+				text: JSON.stringify(payload),
+			};
+		});
+		const fetchCalls: unknown[] = [];
+		const fetch: FetchLike = async (input, init) => {
+			fetchCalls.push([input, init]);
+			return new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		const obsidianClient = new MarvinApiClient({
+			apiToken: "token",
+			baseUrl: "https://example.test/api",
+			origin: "public",
+			transport: obsidianTransport,
+		});
+		const nodeClient = new MarvinApiClient({
+			apiToken: "token",
+			baseUrl: "https://example.test/api",
+			origin: "public",
+			transport: new FetchTransport(fetch),
+		});
+
+		await expect(obsidianClient.getTodayItems("2026-07-23")).resolves.toEqual(
+			payload,
+		);
+		await expect(nodeClient.getTodayItems("2026-07-23")).resolves.toEqual(payload);
+		expect(obsidianRequests).toMatchObject([
+			{
+				url: "https://example.test/api/todayItems?date=2026-07-23",
+				throw: false,
+			},
+		]);
+		expect(fetchCalls).toHaveLength(1);
+	});
+});

--- a/src/marvin/obsidianTransport.ts
+++ b/src/marvin/obsidianTransport.ts
@@ -1,0 +1,46 @@
+import type {
+	RequestUrlParam,
+	RequestUrlResponse,
+} from "obsidian";
+import type {
+	MarvinTransport,
+	MarvinTransportResponse,
+} from "@open-horizon/marvin-client";
+
+export type ObsidianRequestUrl = (
+	request: RequestUrlParam,
+) => Promise<RequestUrlResponse>;
+
+function normalizeHeaders(headers: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+	);
+}
+
+/**
+ * Adapts Obsidian's CORS-free request API to the shared Marvin transport.
+ *
+ * Obsidian does not expose request cancellation, so timeoutMs is advisory for
+ * this adapter. Automatic retries remain disabled to avoid duplicate writes.
+ */
+export function createObsidianTransport(
+	requestUrl: ObsidianRequestUrl,
+): MarvinTransport {
+	return {
+		async request(request): Promise<MarvinTransportResponse> {
+			const response = await requestUrl({
+				url: request.url,
+				method: request.method,
+				headers: request.headers,
+				...(request.body === undefined ? {} : { body: request.body }),
+				throw: false,
+			});
+
+			return {
+				status: response.status,
+				headers: normalizeHeaders(response.headers),
+				text: response.text,
+			};
+		},
+	};
+}

--- a/src/marvin/sharedContract.test.ts
+++ b/src/marvin/sharedContract.test.ts
@@ -1,0 +1,74 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+	FetchTransport,
+	MarvinApiClient,
+	MarvinRouter,
+	type FetchLike,
+} from "@open-horizon/marvin-client";
+import { describe, expect, it } from "vitest";
+import { createMarvinMcpServer } from "../../packages/marvin-mcp/src/tools";
+import { createObsidianTransport } from "./obsidianTransport";
+
+describe("plugin and MCP shared contract fixture", () => {
+	it("projects the same Marvin response through both runtime adapters", async () => {
+		const payload = [{ _id: "shared-1", title: "One contract", done: false }];
+		const pluginRouter = new MarvinRouter({
+			publicClient: new MarvinApiClient({
+				apiToken: "token",
+				baseUrl: "https://example.test/api",
+				origin: "public",
+				transport: createObsidianTransport(async () => ({
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+					arrayBuffer: new ArrayBuffer(0),
+					json: payload,
+					text: JSON.stringify(payload),
+				})),
+			}),
+		});
+		const fetch: FetchLike = async () => new Response(JSON.stringify(payload), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+		const mcpRouter = new MarvinRouter({
+			publicClient: new MarvinApiClient({
+				apiToken: "token",
+				baseUrl: "https://example.test/api",
+				origin: "public",
+				transport: new FetchTransport(fetch),
+			}),
+		});
+
+		const mcpServer = createMarvinMcpServer(mcpRouter);
+		const mcpClient = new Client({ name: "fixture-client", version: "0.1.0" });
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		await mcpServer.connect(serverTransport);
+		await mcpClient.connect(clientTransport);
+
+		try {
+			const pluginResult = await pluginRouter.getTodayItems("2026-07-23");
+			const mcpResult = await mcpClient.callTool({
+				name: "marvin_today",
+				arguments: { date: "2026-07-23" },
+			});
+
+			expect(pluginResult).toMatchObject({
+				data: payload,
+				freshness: "fresh",
+				origin: "public",
+			});
+			expect(mcpResult.structuredContent).toMatchObject({
+				items: [{
+					id: "shared-1",
+					title: "One contract",
+				}],
+				freshness: pluginResult.freshness,
+				origin: pluginResult.origin,
+			});
+		} finally {
+			await mcpClient.close();
+			await mcpServer.close();
+		}
+	});
+});

--- a/src/marvin/syncSelection.test.ts
+++ b/src/marvin/syncSelection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	categoryProjectionItems,
+	planCategorySync,
+} from "./syncSelection";
+
+const categories = [
+	{ _id: "work", title: "Work", type: "category", parentId: "root" },
+	{ _id: "knowledge", title: "Knowledge", type: "category", parentId: "work" },
+	{ _id: "project", title: "Write book", type: "project", parentId: "knowledge" },
+	{ _id: "chapter", title: "Chapter one", type: "project", parentId: "project" },
+	{ _id: "garden", title: "Garden", type: "project", parentId: "work" },
+];
+
+describe("category sync selection", () => {
+	it("keeps the existing all-items behavior by default", () => {
+		const plan = planCategorySync(categories, "all", []);
+
+		expect([...plan.contentIds]).toEqual(categories.map((item) => item._id));
+		expect(plan.structuralIds.size).toBe(0);
+	});
+
+	it("includes selected roots and descendants with ancestors as structure only", () => {
+		const plan = planCategorySync(categories, "selected", ["project"]);
+
+		expect([...plan.contentIds]).toEqual(["project", "chapter"]);
+		expect([...plan.structuralIds]).toEqual(["knowledge", "work"]);
+		expect(plan.includedIds.has("garden")).toBe(false);
+	});
+
+	it("allows an intentionally empty selection without falling back to all", () => {
+		const plan = planCategorySync(categories, "selected", []);
+
+		expect(plan.includedIds.size).toBe(0);
+		expect(plan.contentIds.size).toBe(0);
+	});
+
+	it("fails closed for stale IDs, missing parents, and cycles", () => {
+		expect(() => planCategorySync(
+			categories,
+			"selected",
+			["missing"],
+		)).toThrow("was not returned");
+		expect(() => planCategorySync(
+			[{ _id: "child", title: "Child", parentId: "missing" }],
+			"selected",
+			["child"],
+		)).toThrow("parent missing");
+		expect(() => planCategorySync(
+			[
+				{ _id: "a", title: "A", parentId: "b" },
+				{ _id: "b", title: "B", parentId: "a" },
+			],
+			"selected",
+			["a"],
+		)).toThrow("cycle");
+	});
+
+	it("renders ancestors as structure only and filters unselected sibling links", () => {
+		const plan = planCategorySync(categories, "selected", ["project"]);
+		const fetchedWorkChildren = [
+			{ _id: "knowledge", title: "Knowledge", type: "category", parentId: "work" },
+			{ _id: "garden", title: "Garden", type: "project", parentId: "work" },
+			{ _id: "task", title: "Repair fence", type: "task", parentId: "work" },
+		];
+
+		expect(categoryProjectionItems(
+			"work",
+			plan,
+			fetchedWorkChildren,
+			fetchedWorkChildren,
+		).map((item) => item._id)).toEqual(["knowledge"]);
+
+		const selectedChildren = [
+			{ _id: "chapter", title: "Chapter one", type: "project", parentId: "project" },
+			{ _id: "draft", title: "Draft outline", type: "task", parentId: "project" },
+			{ _id: "excluded", title: "Excluded", type: "project", parentId: "project" },
+		];
+		expect(categoryProjectionItems(
+			"project",
+			plan,
+			categories,
+			selectedChildren,
+		).map((item) => item._id)).toEqual(["chapter", "draft"]);
+	});
+});

--- a/src/marvin/syncSelection.ts
+++ b/src/marvin/syncSelection.ts
@@ -1,0 +1,110 @@
+import type { CategoryPathItem } from "./categoryPaths";
+
+export type SyncSelectionMode = "all" | "selected";
+
+export interface SyncRootSelection {
+	id: string;
+	title: string;
+}
+
+export interface CategorySyncPlan {
+	includedIds: ReadonlySet<string>;
+	contentIds: ReadonlySet<string>;
+	structuralIds: ReadonlySet<string>;
+}
+
+export interface SyncProjectionItem extends CategoryPathItem {
+	type?: string;
+}
+
+export function planCategorySync(
+	categories: CategoryPathItem[],
+	mode: SyncSelectionMode,
+	rootIds: readonly string[],
+): CategorySyncPlan {
+	const byId = new Map(categories.map((item) => [item._id, item]));
+	if (mode === "all") {
+		const all = new Set(byId.keys());
+		return {
+			includedIds: all,
+			contentIds: all,
+			structuralIds: new Set(),
+		};
+	}
+
+	const contentIds = new Set<string>();
+	const queue: string[] = [];
+	for (const rootId of new Set(rootIds)) {
+		if (!byId.has(rootId)) {
+			throw new Error(
+				`Selected Amazing Marvin item ${rootId} was not returned by the API`,
+			);
+		}
+		contentIds.add(rootId);
+		queue.push(rootId);
+	}
+
+	for (let index = 0; index < queue.length; index += 1) {
+		const parentId = queue[index]!;
+		for (const item of categories) {
+			if (item.parentId === parentId && !contentIds.has(item._id)) {
+				contentIds.add(item._id);
+				queue.push(item._id);
+			}
+		}
+	}
+
+	const includedIds = new Set(contentIds);
+	for (const contentId of contentIds) {
+		let current = byId.get(contentId);
+		const visited = new Set<string>();
+		while (current?.parentId && current.parentId !== "root") {
+			if (visited.has(current._id)) {
+				throw new Error(
+					`Amazing Marvin category hierarchy contains a cycle at ${current._id}`,
+				);
+			}
+			visited.add(current._id);
+			const parent = byId.get(current.parentId);
+			if (!parent) {
+				throw new Error(
+					`Amazing Marvin parent ${current.parentId} for ${current._id} was not returned by the API`,
+				);
+			}
+			includedIds.add(parent._id);
+			current = parent;
+		}
+	}
+
+	return {
+		includedIds,
+		contentIds,
+		structuralIds: new Set(
+			[...includedIds].filter((id) => !contentIds.has(id)),
+		),
+	};
+}
+
+export function categoryProjectionItems<T extends SyncProjectionItem>(
+	parentId: string,
+	plan: CategorySyncPlan,
+	categories: readonly T[],
+	fetchedChildren?: readonly T[],
+): T[] {
+	if (!plan.contentIds.has(parentId)) {
+		return categories.filter((item) => (
+			item.parentId === parentId
+			&& plan.includedIds.has(item._id)
+		));
+	}
+	if (!fetchedChildren) {
+		throw new Error(
+			`Amazing Marvin children were not fetched for selected item ${parentId}`,
+		);
+	}
+	return fetchedChildren.filter((item) => (
+		item.type !== "category"
+		&& item.type !== "project"
+		|| plan.includedIds.has(item._id)
+	));
+}

--- a/src/marvin/taskFormatting.test.ts
+++ b/src/marvin/taskFormatting.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	formatTaskMetadata,
+	formatMarvinLabelTags,
+	orderTaskBody,
+	taskTitleComesFirst,
+	type TaskFormattingOptions,
+} from "./taskFormatting";
+
+const defaults: TaskFormattingOptions = {
+	format: "dataview",
+	titleFirst: false,
+	showDueDate: true,
+	showStartDate: true,
+	showScheduledDate: true,
+	taskTag: "",
+	showMarvinLabelsAsTags: false,
+	labelTagPrefix: "marvin",
+};
+
+const task = {
+	dueDate: "2026-07-25",
+	startDate: "2026-07-22",
+	day: "2026-07-23",
+	labelIds: ["knowledge", "numeric", "missing"],
+};
+
+describe("task formatting", () => {
+	it("preserves the current Dataview format by default", () => {
+		const metadata = formatTaskMetadata(task, defaults);
+
+		expect(metadata).toBe(
+			"Due Date:: [[2026-07-25]] "
+			+ "Start Date:: [[2026-07-22]] "
+			+ "Scheduled Date:: [[2026-07-23]]",
+		);
+		expect(orderTaskBody(
+			"Write brief",
+			"https://app.amazingmarvin.com/#t=task-1",
+			metadata,
+			taskTitleComesFirst(defaults),
+		)).toBe(
+			"[⚓](https://app.amazingmarvin.com/#t=task-1) "
+			+ `${metadata} Write brief`,
+		);
+	});
+
+	it("links Dataview dates to weekly notes with the date as alias", () => {
+		expect(formatTaskMetadata(task, {
+			...defaults,
+			dateLinkTarget: () => "2026-W30",
+		})).toContain("Due Date:: [[2026-W30|2026-07-25]]");
+	});
+
+	it("renders Tasks emoji and Dataview presets after the title", () => {
+		const emoji = {
+			...defaults,
+			format: "tasks-emoji" as const,
+		};
+		expect(formatTaskMetadata(task, emoji)).toBe(
+			"📅 2026-07-25 🛫 2026-07-22 ⏳ 2026-07-23",
+		);
+		expect(taskTitleComesFirst(emoji)).toBe(true);
+
+		expect(formatTaskMetadata(task, {
+			...defaults,
+			format: "tasks-dataview",
+		})).toBe(
+			"[due:: 2026-07-25] "
+			+ "[start:: 2026-07-22] "
+			+ "[scheduled:: 2026-07-23]",
+		);
+	});
+
+	it("adds a query tag and stable namespaced tags for known Marvin labels", () => {
+		const labels = new Map([
+			["knowledge", { _id: "knowledge", title: "Knowledge work" }],
+			["numeric", { _id: "numeric", title: "2026" }],
+			["empty", { _id: "empty", title: "!!!" }],
+		]);
+
+		const metadata = formatTaskMetadata({
+			...task,
+			labelIds: [...task.labelIds, "empty"],
+		}, {
+			...defaults,
+			taskTag: "#task",
+			showMarvinLabelsAsTags: true,
+			labelTagPrefix: "marvin/labels",
+		}, labels);
+		expect(metadata).toContain(
+			"#task #marvin/labels/Knowledge-work #marvin/labels/2026",
+		);
+		expect(metadata.endsWith("#marvin/labels")).toBe(false);
+		expect(formatMarvinLabelTags(
+			["knowledge"],
+			"marvin",
+			labels,
+		)).toEqual(["#marvin/Knowledge-work"]);
+	});
+
+	it("keeps untrusted configured values and labels on one line", () => {
+		const labels = new Map([
+			["unsafe", { _id: "unsafe", title: "A #tag\n<!-- injected -->" }],
+		]);
+
+		const metadata = formatTaskMetadata({
+			day: "2026-07-23",
+			labelIds: ["unsafe"],
+		}, {
+			...defaults,
+			dateLinkTarget: () => "Week|bad]\n<!-- boundary -->",
+			showMarvinLabelsAsTags: true,
+			labelTagPrefix: "marvin",
+		}, labels);
+
+		expect(metadata).not.toContain("\n");
+		expect(metadata).toContain("[[Week\\|bad\\] &lt;!-- boundary --&gt;|2026-07-23]]");
+		expect(metadata).toContain("#marvin/A-tag-injected");
+	});
+});

--- a/src/marvin/taskFormatting.ts
+++ b/src/marvin/taskFormatting.ts
@@ -1,0 +1,170 @@
+import type { Label, Task } from "@open-horizon/marvin-client";
+
+export type TaskMetadataFormat =
+	| "dataview"
+	| "tasks-dataview"
+	| "tasks-emoji";
+
+export interface TaskFormattingOptions {
+	format: TaskMetadataFormat;
+	titleFirst: boolean;
+	showDueDate: boolean;
+	showStartDate: boolean;
+	showScheduledDate: boolean;
+	taskTag: string;
+	showMarvinLabelsAsTags: boolean;
+	labelTagPrefix: string;
+	dateLinkTarget?: (date: string) => string;
+}
+
+export function formatTaskMetadata(
+	task: Pick<Task, "dueDate" | "startDate" | "day" | "labelIds">,
+	options: TaskFormattingOptions,
+	labelsById: ReadonlyMap<string, Pick<Label, "_id" | "title">> = new Map(),
+): string {
+	const tokens: string[] = [];
+	if (options.showDueDate && task.dueDate) {
+		tokens.push(formatDate("due", task.dueDate, options));
+	}
+	if (options.showStartDate && task.startDate) {
+		tokens.push(formatDate("start", task.startDate, options));
+	}
+	if (
+		options.showScheduledDate
+		&& task.day
+		&& task.day !== "unassigned"
+	) {
+		tokens.push(formatDate("scheduled", task.day, options));
+	}
+
+	const taskTag = tagFromPath(options.taskTag);
+	if (taskTag) {
+		tokens.push(taskTag);
+	}
+	if (options.showMarvinLabelsAsTags) {
+		tokens.push(...formatMarvinLabelTags(
+			task.labelIds,
+			options.labelTagPrefix,
+			labelsById,
+		));
+	}
+	return tokens.join(" ");
+}
+
+export function formatMarvinLabelTags(
+	labelIds: readonly string[] | undefined,
+	prefix: string,
+	labelsById: ReadonlyMap<string, Pick<Label, "_id" | "title">>,
+): string[] {
+	const tags: string[] = [];
+	const seen = new Set<string>();
+	for (const labelId of labelIds ?? []) {
+		const label = labelsById.get(labelId);
+		if (!label || !tagSegment(label.title)) {
+			continue;
+		}
+		const path = [prefix, label.title]
+			.filter((part) => part.trim())
+			.join("/");
+		const tag = tagFromPath(path);
+		if (tag && !seen.has(tag)) {
+			seen.add(tag);
+			tags.push(tag);
+		}
+	}
+	return tags;
+}
+
+export function taskTitleComesFirst(options: TaskFormattingOptions): boolean {
+	return options.format !== "dataview" || options.titleFirst;
+}
+
+export function orderTaskBody(
+	title: string,
+	deepLink: string,
+	metadata: string,
+	titleFirst: boolean,
+): string {
+	const anchor = `[⚓](${inlineText(deepLink)})`;
+	return (
+		titleFirst
+			? [title, anchor, metadata]
+			: [anchor, metadata, title]
+	)
+		.filter(Boolean)
+		.join(" ");
+}
+
+function formatDate(
+	kind: "due" | "start" | "scheduled",
+	date: string,
+	options: TaskFormattingOptions,
+): string {
+	if (options.format === "tasks-emoji") {
+		const emoji = {
+			due: "📅",
+			start: "🛫",
+			scheduled: "⏳",
+		}[kind];
+		return `${emoji} ${inlineText(date)}`;
+	}
+	if (options.format === "tasks-dataview") {
+		return `[${kind}:: ${inlineText(date)}]`;
+	}
+
+	const field = {
+		due: "Due Date",
+		start: "Start Date",
+		scheduled: "Scheduled Date",
+	}[kind];
+	return `${field}:: ${dateLink(date, options.dateLinkTarget)}`;
+}
+
+function dateLink(
+	date: string,
+	targetForDate: TaskFormattingOptions["dateLinkTarget"],
+): string {
+	const target = inlineText(targetForDate?.(date) || date);
+	const escapedTarget = escapeWiki(target);
+	const escapedDate = escapeWiki(inlineText(date));
+	return target === date
+		? `[[${escapedTarget}]]`
+		: `[[${escapedTarget}|${escapedDate}]]`;
+}
+
+function tagFromPath(value: string): string | undefined {
+	const segments = value
+		.replace(/^#+/, "")
+		.split("/")
+		.map(tagSegment)
+		.filter(Boolean);
+	if (segments.length === 0) {
+		return undefined;
+	}
+	let path = segments.join("/");
+	if (/^\d+$/.test(path)) {
+		path = `label-${path}`;
+	}
+	return `#${path}`;
+}
+
+function tagSegment(value: string): string {
+	return value
+		.normalize("NFKC")
+		.replace(/[\r\n\t ]+/g, "-")
+		.replace(/[\\/#\[\](){}<>|`"'!?.,:;=+*&^%$@~]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
+}
+
+function escapeWiki(value: string): string {
+	return value.replace(/\|/g, "\\|").replace(/\]/g, "\\]");
+}
+
+function inlineText(value: string): string {
+	return value
+		.replace(/[\r\n]+/g, " ")
+		.replace(/<!--/g, "&lt;!--")
+		.replace(/-->/g, "--&gt;")
+		.trim();
+}

--- a/src/marvin/taskLine.ts
+++ b/src/marvin/taskLine.ts
@@ -1,0 +1,39 @@
+const AM_TASK = /^\s*[-*+]\s\[([ xX])\].*?\[⚓\]\(https:\/\/app\.amazingmarvin\.com\/#t=([^)\s]+)/;
+
+interface MarvinTaskLine {
+	taskId: string;
+	done: boolean;
+}
+
+export function marvinTaskIdFromCompletedLine(line: string): string | undefined {
+	const task = parseMarvinTaskLine(line);
+	return task?.done ? task.taskId : undefined;
+}
+
+export function isNewlyCompletedMarvinTask(
+	before: string,
+	after: string,
+): string | undefined {
+	const previous = parseMarvinTaskLine(before);
+	const next = parseMarvinTaskLine(after);
+	return (
+		previous
+		&& next
+		&& previous.taskId === next.taskId
+		&& !previous.done
+		&& next.done
+	)
+		? next.taskId
+		: undefined;
+}
+
+function parseMarvinTaskLine(line: string): MarvinTaskLine | undefined {
+	const match = line.match(AM_TASK);
+	if (!match?.[1] || !match[2]) {
+		return undefined;
+	}
+	return {
+		taskId: match[2],
+		done: match[1].toLowerCase() === "x",
+	};
+}

--- a/src/marvin/taskWatcher.test.ts
+++ b/src/marvin/taskWatcher.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	isNewlyCompletedMarvinTask,
+	marvinTaskIdFromCompletedLine,
+} from "./taskLine";
+
+describe("Amazing Marvin completion line matching", () => {
+	it("recognizes both legacy and contextual task rendering", () => {
+		expect(marvinTaskIdFromCompletedLine(
+			"- [x] [⚓](https://app.amazingmarvin.com/#t=legacy) Legacy task",
+		)).toBe("legacy");
+		expect(marvinTaskIdFromCompletedLine(
+			"- [X] [[Source note|Contextual action]] [⚓](https://app.amazingmarvin.com/#t=contextual) Due Date:: [[2026-07-23]]",
+		)).toBe("contextual");
+	});
+
+	it("ignores unchecked tasks and Marvin projects", () => {
+		expect(marvinTaskIdFromCompletedLine(
+			"- [ ] Task [⚓](https://app.amazingmarvin.com/#t=open)",
+		)).toBeUndefined();
+		expect(marvinTaskIdFromCompletedLine(
+			"- [x] Project [⚓](https://app.amazingmarvin.com/#p=project)",
+		)).toBeUndefined();
+	});
+
+	it("only emits a completion for the same task changing from unchecked to checked", () => {
+		const open = "- [ ] Action [⚓](https://app.amazingmarvin.com/#t=task-1)";
+		const done = "- [x] Action [⚓](https://app.amazingmarvin.com/#t=task-1)";
+
+		expect(isNewlyCompletedMarvinTask(open, done)).toBe("task-1");
+		expect(isNewlyCompletedMarvinTask(done, done)).toBeUndefined();
+		expect(isNewlyCompletedMarvinTask("", done)).toBeUndefined();
+		expect(isNewlyCompletedMarvinTask(
+			"- [ ] Other [⚓](https://app.amazingmarvin.com/#t=task-2)",
+			done,
+		)).toBeUndefined();
+	});
+});

--- a/src/marvin/todayProjection.test.ts
+++ b/src/marvin/todayProjection.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	TODAY_REGION_END,
+	TodayProjectionError,
+	hasTodayRegion,
+	marvinIdsInMarkdown,
+	refreshTodayRegion,
+	type TodayProjectionItem,
+} from "./todayProjection";
+
+const morningTask: TodayProjectionItem = {
+	id: "morning",
+	title: "Existing morning task",
+	done: false,
+	deepLink: "https://app.amazingmarvin.com/#t=morning",
+};
+const manualLateTask: TodayProjectionItem = {
+	id: "manual-late",
+	title: "Manual Marvin task",
+	done: false,
+	deepLink: "https://app.amazingmarvin.com/#t=manual-late",
+};
+const contextualLateTask: TodayProjectionItem = {
+	id: "contextual-late",
+	title: "Decide whether to pursue Titan AI",
+	done: false,
+	deepLink: "https://app.amazingmarvin.com/#t=contextual-late",
+	sourcePath: "Opportunities/Titan AI.md",
+	sourceTitle: "Titan AI — Principal FDE",
+};
+
+describe("refreshTodayRegion", () => {
+	it("adopts an existing morning checklist and puts new tasks below it", () => {
+		const original = [
+			"# 2026-07-23",
+			"",
+			"## Today's tasks",
+			"- [ ] [⚓](https://app.amazingmarvin.com/#t=morning) Existing morning task",
+			"",
+			"Journal prose that must remain.",
+			"",
+		].join("\n");
+
+		const result = refreshTodayRegion(original, {
+			date: "2026-07-23",
+			items: [morningTask, manualLateTask, contextualLateTask],
+		});
+
+		expect(result.morningIds).toEqual(["morning"]);
+		expect(result.lateIds).toEqual(["manual-late", "contextual-late"]);
+		expect(result.content).toContain("- [ ] Existing morning task [⚓]");
+		expect(result.content).toContain(
+			"### Added since morning\n- [ ] Manual Marvin task [⚓]",
+		);
+		expect(result.content).toContain(
+			"[[Opportunities/Titan AI.md|Titan AI — Principal FDE]] [⚓]",
+		);
+		expect(result.content).toContain("Journal prose that must remain.");
+	});
+
+	it("is idempotent, deduplicates due/scheduled overlap, and reflects completion", () => {
+		const initial = refreshTodayRegion("", {
+			date: "2026-07-23",
+			items: [morningTask],
+		});
+		const completed = { ...morningTask, done: true };
+		const refreshed = refreshTodayRegion(initial.content, {
+			date: "2026-07-23",
+			items: [completed, completed],
+		});
+		const repeated = refreshTodayRegion(refreshed.content, {
+			date: "2026-07-23",
+			items: [completed, completed],
+		});
+
+		expect(marvinIdsInMarkdown(refreshed.content)).toEqual(["morning"]);
+		expect(refreshed.content).toContain("- [x] Existing morning task");
+		expect(repeated.changed).toBe(false);
+		expect(repeated.content).toBe(refreshed.content);
+	});
+
+	it("keeps the initial boundary while late tasks arrive and disappear", () => {
+		const morning = refreshTodayRegion("", {
+			date: "2026-07-23",
+			items: [morningTask],
+		});
+		const afternoon = refreshTodayRegion(morning.content, {
+			date: "2026-07-23",
+			items: [morningTask, manualLateTask],
+		});
+		const evening = refreshTodayRegion(afternoon.content, {
+			date: "2026-07-23",
+			items: [manualLateTask],
+		});
+
+		expect(afternoon.lateIds).toEqual(["manual-late"]);
+		expect(evening.morningIds).toEqual([]);
+		expect(evening.lateIds).toEqual(["manual-late"]);
+		expect(evening.content).not.toContain("Existing morning task");
+	});
+
+	it("preserves CRLF and content outside an existing marker", () => {
+		const original = [
+			"before",
+			`<!-- obsidian-am:today ${JSON.stringify({
+				version: 1,
+				date: "2026-07-23",
+				morningIds: ["morning"],
+			})} -->`,
+			"old generated content",
+			TODAY_REGION_END,
+			"after",
+			"",
+		].join("\r\n");
+
+		const result = refreshTodayRegion(original, {
+			date: "2026-07-23",
+			items: [morningTask],
+		});
+
+		expect(result.content.startsWith("before\r\n")).toBe(true);
+		expect(result.content.endsWith("\r\nafter\r\n")).toBe(true);
+		expect(result.content).not.toContain("old generated content");
+		expect(hasTodayRegion(result.content, "2026-07-23")).toBe(true);
+	});
+
+	it("does not replace the note when managed metadata is malformed", () => {
+		const original = [
+			"before",
+			"<!-- obsidian-am:today not-json -->",
+			"generated",
+			TODAY_REGION_END,
+			"after",
+		].join("\n");
+
+		expect(() => refreshTodayRegion(original, {
+			date: "2026-07-23",
+			items: [],
+		})).toThrow(TodayProjectionError);
+	});
+
+	it("refuses to nest a second date inside an existing managed region", () => {
+		const existing = refreshTodayRegion("", {
+			date: "2026-07-22",
+			items: [morningTask],
+		});
+
+		expect(() => refreshTodayRegion(existing.content, {
+			date: "2026-07-23",
+			items: [morningTask],
+		})).toThrow("another date");
+	});
+
+	it("keeps untrusted task text on one line inside the managed boundary", () => {
+		const result = refreshTodayRegion("", {
+			date: "2026-07-23",
+			items: [{
+				...morningTask,
+				title: `Task title\n${TODAY_REGION_END}\n## Injected`,
+				details: "Due\nDate",
+			}],
+		});
+
+		expect(
+			result.content.split("\n").filter((line) => line === TODAY_REGION_END),
+		).toHaveLength(1);
+		expect(result.content).toContain(
+			"Task title &lt;!-- /obsidian-am:today --&gt; ## Injected",
+		);
+		expect(result.content).toContain("Due Date");
+	});
+
+	it("records a successful empty result rather than treating it as failure", () => {
+		const result = refreshTodayRegion("User prose", {
+			date: "2026-07-23",
+			items: [],
+		});
+
+		expect(result.content).toContain("## Today's tasks");
+		expect(result.content).toContain("No Amazing Marvin tasks for this date.");
+		expect(result.morningIds).toEqual([]);
+		expect(result.lateIds).toEqual([]);
+	});
+});

--- a/src/marvin/todayProjection.ts
+++ b/src/marvin/todayProjection.ts
@@ -1,0 +1,297 @@
+export const TODAY_TASKS_HEADING = "## Today's tasks";
+export const TODAY_REGION_END = "<!-- /obsidian-am:today -->";
+
+const TODAY_REGION_PREFIX = "<!-- obsidian-am:today ";
+const MARVIN_ITEM_LINK = /https:\/\/app\.amazingmarvin\.com\/#(?:t|p)=([^)\s]+)/;
+
+export interface TodayProjectionItem {
+	id: string;
+	title: string;
+	done: boolean;
+	deepLink: string;
+	details?: string;
+	sourcePath?: string;
+	sourceTitle?: string;
+}
+
+export interface TodayRegionMetadata {
+	version: 1;
+	date: string;
+	morningIds: string[];
+}
+
+export interface RefreshTodayRegionOptions {
+	date: string;
+	items: TodayProjectionItem[];
+	heading?: string;
+}
+
+export interface RefreshTodayRegionResult {
+	content: string;
+	changed: boolean;
+	createdRegion: boolean;
+	morningIds: string[];
+	lateIds: string[];
+}
+
+export class TodayProjectionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "TodayProjectionError";
+	}
+}
+
+export function refreshTodayRegion(
+	original: string,
+	options: RefreshTodayRegionOptions,
+): RefreshTodayRegionResult {
+	const heading = options.heading ?? TODAY_TASKS_HEADING;
+	const newline = original.includes("\r\n") ? "\r\n" : "\n";
+	const hadTrailingNewline = original.endsWith("\n");
+	const lines = original === ""
+		? []
+		: original.replace(/\r\n/g, "\n").split("\n");
+	if (hadTrailingNewline) {
+		lines.pop();
+	}
+
+	const existingRegion = findManagedRegion(lines, options.date);
+	if (
+		!existingRegion
+		&& lines.some((line) => parseStartMarker(line) !== undefined)
+	) {
+		throw new TodayProjectionError(
+			`This note already contains a managed Amazing Marvin region for another date`,
+		);
+	}
+	const uniqueItems = dedupeItems(options.items);
+	let morningIds: string[];
+	let replaceFrom: number;
+	let replaceTo: number;
+	let createdRegion = false;
+
+	if (existingRegion) {
+		morningIds = existingRegion.metadata.morningIds;
+		replaceFrom = existingRegion.start;
+		replaceTo = existingRegion.end + 1;
+	} else {
+		const adoption = findLegacyMarvinItems(lines, heading);
+		morningIds = adoption.ids.length > 0
+			? adoption.ids
+			: uniqueItems.map((item) => item.id);
+		replaceFrom = adoption.start;
+		replaceTo = adoption.end;
+		createdRegion = true;
+	}
+
+	const currentIds = new Set(uniqueItems.map((item) => item.id));
+	morningIds = dedupeStrings(morningIds).filter((id) => currentIds.has(id));
+	const morningIdSet = new Set(morningIds);
+	const morning = uniqueItems.filter((item) => morningIdSet.has(item.id));
+	const late = uniqueItems.filter((item) => !morningIdSet.has(item.id));
+	const block = renderManagedBlock(options.date, morningIds, morning, late);
+
+	lines.splice(replaceFrom, replaceTo - replaceFrom, ...block);
+	const next = lines.join("\n") + (hadTrailingNewline ? "\n" : "");
+	const content = newline === "\n" ? next : next.replace(/\n/g, "\r\n");
+
+	return {
+		content,
+		changed: content !== original,
+		createdRegion,
+		morningIds,
+		lateIds: late.map((item) => item.id),
+	};
+}
+
+export function hasTodayRegion(content: string, date?: string): boolean {
+	const lines = content.replace(/\r\n/g, "\n").split("\n");
+	return date === undefined
+		? lines.some((line) => parseStartMarker(line) !== undefined)
+		: findManagedRegion(lines, date) !== undefined;
+}
+
+export function marvinIdsInMarkdown(content: string): string[] {
+	const ids: string[] = [];
+	for (const line of content.replace(/\r\n/g, "\n").split("\n")) {
+		const match = line.match(MARVIN_ITEM_LINK);
+		if (match?.[1]) {
+			ids.push(match[1]);
+		}
+	}
+	return dedupeStrings(ids);
+}
+
+function findManagedRegion(
+	lines: string[],
+	date: string,
+): { start: number; end: number; metadata: TodayRegionMetadata } | undefined {
+	for (let index = 0; index < lines.length; index += 1) {
+		const metadata = parseStartMarker(lines[index] ?? "");
+		if (!metadata || metadata.date !== date) {
+			continue;
+		}
+		const end = lines.indexOf(TODAY_REGION_END, index + 1);
+		if (end === -1) {
+			throw new TodayProjectionError(
+				`The managed Amazing Marvin region for ${date} has no closing marker`,
+			);
+		}
+		return { start: index, end, metadata };
+	}
+	return undefined;
+}
+
+function parseStartMarker(line: string): TodayRegionMetadata | undefined {
+	if (!line.startsWith(TODAY_REGION_PREFIX) || !line.endsWith(" -->")) {
+		return undefined;
+	}
+	const serialized = line.slice(TODAY_REGION_PREFIX.length, -4);
+	let value: unknown;
+	try {
+		value = JSON.parse(serialized);
+	} catch {
+		throw new TodayProjectionError("A managed Amazing Marvin region has invalid metadata");
+	}
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| (value as Partial<TodayRegionMetadata>).version !== 1
+		|| typeof (value as Partial<TodayRegionMetadata>).date !== "string"
+		|| !Array.isArray((value as Partial<TodayRegionMetadata>).morningIds)
+		|| !(value as TodayRegionMetadata).morningIds.every((id) => typeof id === "string")
+	) {
+		throw new TodayProjectionError("A managed Amazing Marvin region has unsupported metadata");
+	}
+	return value as TodayRegionMetadata;
+}
+
+function findLegacyMarvinItems(
+	lines: string[],
+	heading: string,
+): { start: number; end: number; ids: string[] } {
+	const headingIndex = lines.findIndex((line) => line.trim() === heading);
+	if (headingIndex === -1) {
+		const prefix: string[] = [];
+		if (lines.length > 0 && lines[lines.length - 1] !== "") {
+			prefix.push("");
+		}
+		prefix.push(heading);
+		lines.push(...prefix);
+		return {
+			start: lines.length,
+			end: lines.length,
+			ids: [],
+		};
+	}
+
+	let first = -1;
+	let last = -1;
+	const ids: string[] = [];
+	for (let index = headingIndex + 1; index < lines.length; index += 1) {
+		const line = lines[index] ?? "";
+		if (/^#{1,2}\s/.test(line)) {
+			break;
+		}
+		const match = line.match(MARVIN_ITEM_LINK);
+		if (match?.[1]) {
+			first = first === -1 ? index : first;
+			last = index;
+			ids.push(match[1]);
+			continue;
+		}
+		if (
+			first !== -1
+			&& line.trim() !== ""
+			&& !/^\s+[-*+]\s+\[[ xX]\]\s+/.test(line)
+		) {
+			break;
+		}
+		if (first !== -1 && /^\s*$/.test(line)) {
+			break;
+		}
+		if (first !== -1) {
+			last = index;
+		}
+	}
+
+	if (first !== -1) {
+		return {
+			start: first,
+			end: last + 1,
+			ids: dedupeStrings(ids),
+		};
+	}
+	return {
+		start: headingIndex + 1,
+		end: headingIndex + 1,
+		ids: [],
+	};
+}
+
+function renderManagedBlock(
+	date: string,
+	morningIds: string[],
+	morning: TodayProjectionItem[],
+	late: TodayProjectionItem[],
+): string[] {
+	const metadata: TodayRegionMetadata = {
+		version: 1,
+		date,
+		morningIds,
+	};
+	const lines = [
+		`${TODAY_REGION_PREFIX}${JSON.stringify(metadata)} -->`,
+		...morning.map(renderItem),
+	];
+	if (late.length > 0) {
+		if (morning.length > 0) {
+			lines.push("");
+		}
+		lines.push("### Added since morning", ...late.map(renderItem));
+	}
+	if (morning.length === 0 && late.length === 0) {
+		lines.push("<!-- No Amazing Marvin tasks for this date. -->");
+	}
+	lines.push(TODAY_REGION_END);
+	return lines;
+}
+
+function renderItem(item: TodayProjectionItem): string {
+	const status = item.done ? "x" : " ";
+	const title = item.sourcePath
+		? `[[${escapeWikiTarget(item.sourcePath)}|${escapeWikiAlias(item.sourceTitle ?? item.title)}]]`
+		: inlineText(item.title);
+	const details = inlineText(item.details ?? "");
+	return `- [${status}] ${title} [⚓](${item.deepLink})${details ? ` ${details}` : ""}`;
+}
+
+function escapeWikiTarget(value: string): string {
+	return inlineText(value).replace(/\|/g, "\\|").replace(/\]/g, "\\]");
+}
+
+function escapeWikiAlias(value: string): string {
+	return inlineText(value).replace(/\|/g, "\\|").replace(/\]/g, "\\]");
+}
+
+function inlineText(value: string): string {
+	return value
+		.replace(/[\r\n]+/g, " ")
+		.replace(/<!--/g, "&lt;!--")
+		.replace(/-->/g, "--&gt;")
+		.trim();
+}
+
+function dedupeItems(items: TodayProjectionItem[]): TodayProjectionItem[] {
+	const byId = new Map<string, TodayProjectionItem>();
+	for (const item of items) {
+		if (!byId.has(item.id)) {
+			byId.set(item.id, item);
+		}
+	}
+	return [...byId.values()];
+}
+
+function dedupeStrings(values: string[]): string[] {
+	return [...new Set(values)];
+}

--- a/src/marvin/todayWorkflow.test.ts
+++ b/src/marvin/todayWorkflow.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runTodayProjection } from "./todayWorkflow";
+
+describe("runTodayProjection", () => {
+	it("never mutates the note when the Marvin read fails", async () => {
+		const process = vi.fn(async (_update: (content: string) => string) => undefined);
+
+		await expect(runTodayProjection({
+			date: "2026-07-23",
+			read: async () => {
+				throw new Error("Marvin unavailable");
+			},
+			project: () => [],
+			process,
+		})).rejects.toThrow("Marvin unavailable");
+		expect(process).not.toHaveBeenCalled();
+	});
+
+	it("projects a successful empty result and retains read metadata", async () => {
+		let content = "Journal prose";
+		const result = await runTodayProjection({
+			date: "2026-07-23",
+			read: async () => ({
+				data: [],
+				freshness: "fresh" as const,
+				origin: "public" as const,
+				fetchedAt: 100,
+				ageMs: 0,
+				warnings: [],
+			}),
+			project: () => [],
+			process: async (update) => {
+				content = update(content);
+			},
+		});
+
+		expect(content).toContain("No Amazing Marvin tasks for this date.");
+		expect(content).toContain("Journal prose");
+		expect(result.read.freshness).toBe("fresh");
+	});
+});

--- a/src/marvin/todayWorkflow.ts
+++ b/src/marvin/todayWorkflow.ts
@@ -1,0 +1,42 @@
+import type { MarvinReadResult } from "@open-horizon/marvin-client";
+
+import {
+	refreshTodayRegion,
+	type TodayProjectionItem,
+} from "./todayProjection";
+
+export interface RunTodayProjectionOptions<T> {
+	date: string;
+	read: () => Promise<MarvinReadResult<T[]>>;
+	project: (items: T[]) => TodayProjectionItem[];
+	process: (update: (content: string) => string) => Promise<void>;
+}
+
+export interface TodayProjectionWorkflowResult<T> {
+	read: MarvinReadResult<T[]>;
+	projection: ReturnType<typeof refreshTodayRegion>;
+}
+
+/**
+ * Keeps the network read before the atomic note mutation. A failed read never
+ * invokes the note processor and therefore cannot be mistaken for an empty
+ * successful projection.
+ */
+export async function runTodayProjection<T>(
+	options: RunTodayProjectionOptions<T>,
+): Promise<TodayProjectionWorkflowResult<T>> {
+	const read = await options.read();
+	const items = options.project(read.data);
+	let projection: ReturnType<typeof refreshTodayRegion> | undefined;
+	await options.process((content) => {
+		projection = refreshTodayRegion(content, {
+			date: options.date,
+			items,
+		});
+		return projection.content;
+	});
+	if (!projection) {
+		throw new Error("The Today note processor did not run");
+	}
+	return { read, projection };
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { App, Platform, PluginSettingTab, Setting } from "obsidian";
 import AmazingMarvinPlugin from "./main";
+import type { ObsidianLinkFormat } from "./marvin/obsidianLinks";
 
 export interface AmazingMarvinPluginSettings {
 	linkBackToObsidianText: string;
@@ -12,6 +13,9 @@ export interface AmazingMarvinPluginSettings {
 	showStartDate: boolean;
 	showScheduledDate: boolean;
 	todayTasksToShow: 'due' | 'scheduled' | 'both';
+	autoRefreshTodayTasks: boolean;
+	todayRefreshIntervalMinutes: number;
+	obsidianLinkFormat: ObsidianLinkFormat;
 }
 
 export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
@@ -24,7 +28,10 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	showStartDate: true,
 	showScheduledDate: true,
 	todayTasksToShow: 'both',
-	attemptToMarkTasksAsDone: false
+	autoRefreshTodayTasks: true,
+	todayRefreshIntervalMinutes: 5,
+	obsidianLinkFormat: "advanced-uri",
+	attemptToMarkTasksAsDone: false,
 };
 
 export class AmazingMarvinSettingsTab extends PluginSettingTab {
@@ -96,6 +103,32 @@ private a(href: string, text: string) {
 			);
 
 		new Setting(containerEl)
+			.setName("Refresh managed Today tasks automatically")
+			.setDesc("Refresh an initialized managed region while Obsidian is open and when the window regains focus.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.autoRefreshTodayTasks)
+				.onChange(async (value) => {
+					this.plugin.settings.autoRefreshTodayTasks = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Refresh interval")
+			.setDesc("Minutes between background refreshes. Existing notes are only changed after their managed region has been initialized.")
+			.addText(text => text
+				.setPlaceholder("5")
+				.setValue(this.plugin.settings.todayRefreshIntervalMinutes.toString())
+				.onChange(async (value) => {
+					const parsed = Number.parseInt(value, 10);
+					if (Number.isFinite(parsed) && parsed > 0) {
+						this.plugin.settings.todayRefreshIntervalMinutes = parsed;
+						await this.plugin.saveSettings();
+					}
+				})
+			);
+
+		new Setting(containerEl)
 			.setHeading().setName("Task creation");
 
 
@@ -115,6 +148,19 @@ private a(href: string, text: string) {
 						this.plugin.settings.linkBackToObsidianText = value.trim();
 						await this.plugin.saveSettings();
 					})
+			);
+
+		new Setting(containerEl)
+			.setName("Obsidian link format")
+			.setDesc("Advanced URI restores links for workflows using the Advanced URI community plugin; Standard works with Obsidian itself.")
+			.addDropdown(dropdown => dropdown
+				.addOption("advanced-uri", "Advanced URI")
+				.addOption("standard", "Standard Obsidian URI")
+				.setValue(this.plugin.settings.obsidianLinkFormat)
+				.onChange(async (value: ObsidianLinkFormat) => {
+					this.plugin.settings.obsidianLinkFormat = value;
+					await this.plugin.saveSettings();
+				})
 			);
 
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,18 @@
-import { App, Platform, PluginSettingTab, Setting } from "obsidian";
+import {
+	App,
+	FuzzySuggestModal,
+	Notice,
+	Platform,
+	PluginSettingTab,
+	Setting,
+} from "obsidian";
 import AmazingMarvinPlugin from "./main";
+import type { Category } from "./interfaces";
 import type { ObsidianLinkFormat } from "./marvin/obsidianLinks";
+import type {
+	SyncRootSelection,
+	SyncSelectionMode,
+} from "./marvin/syncSelection";
 import type { TaskMetadataFormat } from "./marvin/taskFormatting";
 
 export interface AmazingMarvinPluginSettings {
@@ -24,6 +36,9 @@ export interface AmazingMarvinPluginSettings {
 	todayRefreshIntervalMinutes: number;
 	obsidianLinkFormat: ObsidianLinkFormat;
 	syncFolder: string;
+	syncSelectionMode: SyncSelectionMode;
+	syncRoots: SyncRootSelection[];
+	syncInbox: boolean;
 }
 
 export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
@@ -46,8 +61,58 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	todayRefreshIntervalMinutes: 5,
 	obsidianLinkFormat: "advanced-uri",
 	syncFolder: "AmazingMarvin",
+	syncSelectionMode: "all",
+	syncRoots: [],
+	syncInbox: true,
 	attemptToMarkTasksAsDone: false,
 };
+
+class SyncRootSuggestModal extends FuzzySuggestModal<Category> {
+	constructor(
+		app: App,
+		private readonly categories: Category[],
+		private readonly choose: (category: Category) => void,
+	) {
+		super(app);
+		this.setPlaceholder("Choose a category or project root");
+	}
+
+	getItems(): Category[] {
+		return this.categories;
+	}
+
+	getItemText(category: Category): string {
+		return categoryDisplayPath(category, this.categories);
+	}
+
+	onChooseItem(category: Category): void {
+		this.choose(category);
+	}
+}
+
+function categoryDisplayPath(
+	category: Category,
+	categories: Category[],
+): string {
+	const segments = [category.title];
+	const visited = new Set([category._id]);
+	let parentId = category.parentId;
+	while (parentId && parentId !== "root") {
+		if (visited.has(parentId)) {
+			segments.unshift("[cycle]");
+			break;
+		}
+		visited.add(parentId);
+		const parent = categories.find((item) => item._id === parentId);
+		if (!parent) {
+			segments.unshift("[missing parent]");
+			break;
+		}
+		segments.unshift(parent.title);
+		parentId = parent.parentId;
+	}
+	return segments.join(" / ");
+}
 
 export class AmazingMarvinSettingsTab extends PluginSettingTab {
 	plugin: AmazingMarvinPlugin;
@@ -111,6 +176,92 @@ private a(href: string, text: string) {
 				.setValue(this.plugin.settings.syncFolder)
 				.onChange(async (value) => {
 					this.plugin.settings.syncFolder = value.trim() || "AmazingMarvin";
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Items to import")
+			.setDesc("Import everything, or selected roots with their descendants. Ancestors are retained as navigation structure; excluded notes are never deleted.")
+			.addDropdown(dropdown => dropdown
+				.addOption("all", "All categories and projects")
+				.addOption("selected", "Selected roots")
+				.setValue(this.plugin.settings.syncSelectionMode)
+				.onChange(async (value: SyncSelectionMode) => {
+					this.plugin.settings.syncSelectionMode = value;
+					await this.plugin.saveSettings();
+					this.display();
+				})
+			);
+
+		if (this.plugin.settings.syncSelectionMode === "selected") {
+			for (const root of this.plugin.settings.syncRoots) {
+				new Setting(containerEl)
+					.setName(root.title)
+					.setDesc(`Marvin ID: ${root.id}`)
+					.addButton(button => button
+						.setButtonText("Remove")
+						.onClick(async () => {
+							this.plugin.settings.syncRoots = (
+								this.plugin.settings.syncRoots.filter(
+									(candidate) => candidate.id !== root.id,
+								)
+							);
+							await this.plugin.saveSettings();
+							this.display();
+						})
+					);
+			}
+
+			new Setting(containerEl)
+				.setName("Add import root")
+				.setDesc(
+					this.plugin.settings.syncRoots.length === 0
+						? "No roots selected. Category/project import will make no changes."
+						: "Selecting a root includes every category and project below it.",
+				)
+				.addButton(button => button
+					.setButtonText("Choose")
+					.onClick(async () => {
+						try {
+							const categories = await this.plugin.getCategories();
+							const selected = new Set(
+								this.plugin.settings.syncRoots.map((root) => root.id),
+							);
+							new SyncRootSuggestModal(
+								this.app,
+								categories.filter((category) => !selected.has(category._id)),
+								(category) => {
+									this.plugin.settings.syncRoots.push({
+										id: category._id,
+										title: categoryDisplayPath(category, categories),
+									});
+									void this.plugin.saveSettings()
+										.then(() => this.display())
+										.catch((error) => {
+											console.error(
+												"Could not save Amazing Marvin import root:",
+												error,
+											);
+											new Notice("Could not save the import root.");
+										});
+								},
+							).open();
+						} catch (error) {
+							console.error("Could not load Amazing Marvin import roots:", error);
+							new Notice("Could not load Amazing Marvin categories and projects.");
+						}
+					})
+				);
+		}
+
+		new Setting(containerEl)
+			.setName("Import Inbox")
+			.setDesc("Update the managed Inbox note independently of category/project selection.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.syncInbox)
+				.onChange(async (value) => {
+					this.plugin.settings.syncInbox = value;
 					await this.plugin.saveSettings();
 				})
 			);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export interface AmazingMarvinPluginSettings {
 	autoRefreshTodayTasks: boolean;
 	todayRefreshIntervalMinutes: number;
 	obsidianLinkFormat: ObsidianLinkFormat;
+	syncFolder: string;
 }
 
 export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
@@ -31,6 +32,7 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	autoRefreshTodayTasks: true,
 	todayRefreshIntervalMinutes: 5,
 	obsidianLinkFormat: "advanced-uri",
+	syncFolder: "AmazingMarvin",
 	attemptToMarkTasksAsDone: false,
 };
 
@@ -81,6 +83,21 @@ private a(href: string, text: string) {
 				.setValue(this.plugin.settings.attemptToMarkTasksAsDone)
 				.onChange(async (value) => {
 					this.plugin.settings.attemptToMarkTasksAsDone = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setHeading().setName("Category and project import");
+
+		new Setting(containerEl)
+			.setName("Managed folder")
+			.setDesc("Vault-relative folder for imported categories, projects, and Inbox. Existing category and project notes move when their Marvin ID can be identified; old empty folders are left in place.")
+			.addText(text => text
+				.setPlaceholder("AmazingMarvin")
+				.setValue(this.plugin.settings.syncFolder)
+				.onChange(async (value) => {
+					this.plugin.settings.syncFolder = value.trim() || "AmazingMarvin";
 					await this.plugin.saveSettings();
 				})
 			);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,6 +39,11 @@ export interface AmazingMarvinPluginSettings {
 	syncSelectionMode: SyncSelectionMode;
 	syncRoots: SyncRootSelection[];
 	syncInbox: boolean;
+	incrementalSyncEnabled: boolean;
+	databaseUri: string;
+	databaseUser: string;
+	databasePassword: string;
+	incrementalSyncIntervalMinutes: number;
 }
 
 export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
@@ -64,6 +69,11 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	syncSelectionMode: "all",
 	syncRoots: [],
 	syncInbox: true,
+	incrementalSyncEnabled: false,
+	databaseUri: "",
+	databaseUser: "",
+	databasePassword: "",
+	incrementalSyncIntervalMinutes: 1,
 	attemptToMarkTasksAsDone: false,
 };
 
@@ -265,6 +275,96 @@ private a(href: string, text: string) {
 					await this.plugin.saveSettings();
 				})
 			);
+
+		new Setting(containerEl)
+			.setHeading().setName("Experimental incremental import");
+
+		new Setting(containerEl)
+			.setName("Use persistent incremental cache")
+			.setDesc("Opt in to a local cache and CouchDB changes feed. This requires separate full-database credentials; the limited API token remains the default and fallback.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.incrementalSyncEnabled)
+				.onChange(async (value) => {
+					this.plugin.settings.incrementalSyncEnabled = value;
+					await this.plugin.saveSettings();
+					this.display();
+				})
+			);
+
+		if (this.plugin.settings.incrementalSyncEnabled) {
+			new Setting(containerEl)
+				.setName("Database URI")
+				.setDesc("Full HTTPS database URI from Marvin's API settings. Credentials embedded in the URI are rejected.")
+				.addText(text => text
+					.setPlaceholder("https://.../database")
+					.setValue(this.plugin.settings.databaseUri)
+					.onChange(async (value) => {
+						this.plugin.settings.databaseUri = value.trim();
+						await this.plugin.saveSettings();
+					})
+				);
+
+			new Setting(containerEl)
+				.setName("Database user")
+				.addText(text => text
+					.setValue(this.plugin.settings.databaseUser)
+					.onChange(async (value) => {
+						this.plugin.settings.databaseUser = value.trim();
+						await this.plugin.saveSettings();
+					})
+				);
+
+			new Setting(containerEl)
+				.setName("Database password")
+				.setDesc("Stored locally in this plugin's Obsidian settings and never exposed through MCP.")
+				.addText(text => {
+					text.inputEl.type = "password";
+					text
+						.setValue(this.plugin.settings.databasePassword)
+						.onChange(async (value) => {
+							this.plugin.settings.databasePassword = value;
+							await this.plugin.saveSettings();
+						});
+				});
+
+			new Setting(containerEl)
+				.setName("Catch-up interval")
+				.setDesc("Minutes between long-poll catch-ups while Obsidian is active.")
+				.addText(text => text
+					.setPlaceholder("1")
+					.setValue(
+						this.plugin.settings.incrementalSyncIntervalMinutes.toString(),
+					)
+					.onChange(async (value) => {
+						const parsed = Number.parseInt(value, 10);
+						if (Number.isFinite(parsed) && parsed > 0) {
+							this.plugin.settings.incrementalSyncIntervalMinutes = parsed;
+							await this.plugin.saveSettings();
+						}
+					})
+				);
+
+			const status = this.plugin.getIncrementalSyncStatus();
+			new Setting(containerEl)
+				.setName("Incremental status")
+				.setDesc(
+					status.error
+						? `Recoverable error: ${status.error}`
+						: status.lastSuccessfulSyncAt
+							? `Last successful catch-up: ${new Date(
+								status.lastSuccessfulSyncAt,
+							).toLocaleString()}`
+							: "Not hydrated yet. Run Import categories and tasks.",
+				)
+				.addButton(button => button
+					.setButtonText("Reset cache")
+					.setWarning()
+					.onClick(async () => {
+						await this.plugin.clearIncrementalCache();
+						this.display();
+					})
+				);
+		}
 
 		new Setting(containerEl)
 			.setHeading().setName("Today Tasks");

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,10 +3,10 @@ import AmazingMarvinPlugin from "./main";
 
 export interface AmazingMarvinPluginSettings {
 	linkBackToObsidianText: string;
-	attemptToMarkTasksAsDone: any;
+	attemptToMarkTasksAsDone: boolean;
 	useLocalServer: boolean;
 	localServerHost: string;
-	localServerPort: any;
+	localServerPort: number | string;
 	apiKey: string;
 	showDueDate: boolean;
 	showStartDate: boolean;
@@ -202,4 +202,3 @@ private a(href: string, text: string) {
 		}
 	}
 }
-

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, Platform, PluginSettingTab, Setting } from "obsidian";
 import AmazingMarvinPlugin from "./main";
 import type { ObsidianLinkFormat } from "./marvin/obsidianLinks";
+import type { TaskMetadataFormat } from "./marvin/taskFormatting";
 
 export interface AmazingMarvinPluginSettings {
 	linkBackToObsidianText: string;
@@ -12,6 +13,12 @@ export interface AmazingMarvinPluginSettings {
 	showDueDate: boolean;
 	showStartDate: boolean;
 	showScheduledDate: boolean;
+	taskMetadataFormat: TaskMetadataFormat;
+	taskTitleFirst: boolean;
+	taskDateLinkFormat: string;
+	taskTag: string;
+	showMarvinLabelsAsTags: boolean;
+	marvinLabelTagPrefix: string;
 	todayTasksToShow: 'due' | 'scheduled' | 'both';
 	autoRefreshTodayTasks: boolean;
 	todayRefreshIntervalMinutes: number;
@@ -28,6 +35,12 @@ export const DEFAULT_SETTINGS: AmazingMarvinPluginSettings = {
 	showDueDate: true,
 	showStartDate: true,
 	showScheduledDate: true,
+	taskMetadataFormat: "dataview",
+	taskTitleFirst: false,
+	taskDateLinkFormat: "YYYY-MM-DD",
+	taskTag: "",
+	showMarvinLabelsAsTags: false,
+	marvinLabelTagPrefix: "marvin",
 	todayTasksToShow: 'both',
 	autoRefreshTodayTasks: true,
 	todayRefreshIntervalMinutes: 5,
@@ -183,6 +196,79 @@ private a(href: string, text: string) {
 
 		new Setting(containerEl)
 			.setHeading().setName("Task formatting");
+
+		new Setting(containerEl)
+			.setName("Metadata format")
+			.setDesc("Keep the existing Dataview fields, or emit a format that Obsidian Tasks can query.")
+			.addDropdown(dropdown => dropdown
+				.addOption("dataview", "Dataview (current)")
+				.addOption("tasks-dataview", "Tasks Dataview")
+				.addOption("tasks-emoji", "Tasks emoji")
+				.setValue(this.plugin.settings.taskMetadataFormat)
+				.onChange(async (value: TaskMetadataFormat) => {
+					this.plugin.settings.taskMetadataFormat = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Put task title first")
+			.setDesc("For the current Dataview format, put readable task text before dates. Tasks-compatible formats always put the title first.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.taskTitleFirst)
+				.onChange(async (value) => {
+					this.plugin.settings.taskTitleFirst = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Date link format")
+			.setDesc("Moment format for Dataview date links. For example, YYYY-[W]WW links each date to its weekly note while keeping the date as the alias.")
+			.addText(text => text
+				.setPlaceholder("YYYY-MM-DD")
+				.setValue(this.plugin.settings.taskDateLinkFormat)
+				.onChange(async (value) => {
+					this.plugin.settings.taskDateLinkFormat = value.trim()
+						|| "YYYY-MM-DD";
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Task query tag")
+			.setDesc("Optional tag added to every projected Marvin task, such as #task for an Obsidian Tasks global filter.")
+			.addText(text => text
+				.setPlaceholder("#task")
+				.setValue(this.plugin.settings.taskTag)
+				.onChange(async (value) => {
+					this.plugin.settings.taskTag = value.trim();
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Marvin labels as tags")
+			.setDesc("Resolve Marvin label IDs through the limited API and add their names as Obsidian tags.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.showMarvinLabelsAsTags)
+				.onChange(async (value) => {
+					this.plugin.settings.showMarvinLabelsAsTags = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName("Marvin label tag prefix")
+			.setDesc("Optional tag namespace. The default turns “Knowledge work” into #marvin/Knowledge-work.")
+			.addText(text => text
+				.setPlaceholder("marvin")
+				.setValue(this.plugin.settings.marvinLabelTagPrefix)
+				.onChange(async (value) => {
+					this.plugin.settings.marvinLabelTagPrefix = value.trim();
+					await this.plugin.saveSettings();
+				})
+			);
 
 		new Setting(containerEl)
 			.setName("Show Due Date")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: [
+			"packages/**/*.test.ts",
+			"src/**/*.test.ts",
+		],
+	},
+});


### PR DESCRIPTION
## Summary

- add an opt-in CouchDB changes-feed client with opaque checkpoints, credential-safe errors, and no hidden retries
- hydrate a persistent task/category cache through a fresh local-first REST snapshot, then reconcile only affected managed notes
- persist projection intent across restarts, serialize note projection, back off after failures, and retain the REST importer as the default/fallback
- expose credentials, interval, status, and cache reset in Obsidian settings while keeping full-database access out of the shared client and MCP

Closes #55

## Verification

- npm test (99 tests)
- npm run typecheck
- npm run build
- git diff --check

## Human verification

- authenticate to a real Marvin _changes endpoint with separate database credentials and confirm neither credentials nor raw error bodies appear in logs, URLs, cache state, or MCP
- initialize the cache in Obsidian and compare the resulting hierarchy with a normal REST import
- make task/category create, rename, move, complete, restore, and delete changes from Marvin web/mobile and from the plugin, then confirm targeted notes converge after focus/startup/restart
- interrupt connectivity and restart Obsidian to verify opaque checkpoint resume, pending-projection replay, bounded backoff, visible status, and REST fallback
- repeat on every supported Obsidian runtime, especially mobile, before treating the experimental path as generally available

## Stack

- base: #62
- this is the final planned implementation layer in the issue #51 QoL cluster