### PR TITLE
Use window timers instead of activeWindow timers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -106,7 +106,7 @@ const animateNotice = (notice: Notice) => {
 		message = message.replace(" ...", "    ");
 	}
 	notice.setMessage(message);
-	activeWindow.setTimeout(() => animateNotice(notice), 500);
+	window.setTimeout(() => animateNotice(notice), 500);
 };
 
 export default class AmazingMarvinPlugin extends Plugin {
@@ -225,7 +225,7 @@ export default class AmazingMarvinPlugin extends Plugin {
 		this.registerDomEvent(activeWindow, "focus", () => {
 			void this.runAutomaticTodayRefresh("window focus");
 		});
-		this.registerInterval(activeWindow.setInterval(() => {
+		this.registerInterval(window.setInterval(() => {
 			void this.runAutomaticTodayRefresh("interval");
 		}, 60_000));
 		this.app.workspace.onLayoutReady(() => {


### PR DESCRIPTION
## Summary
- Switch `activeWindow.setTimeout()` / `activeWindow.setInterval()` to `window.setTimeout()` / `window.setInterval()` in `src/main.ts`, per the official `eslint-plugin-obsidianmd` [`prefer-window-timers`](https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/prefer-window-timers.md) rule, which flags `activeWindow.*` timer calls and requires `window.*` for popout-window compatibility.
- This reverses the older activeWindow-over-globals guidance that #69 followed for these two call sites. Non-timer `activeWindow` usage (`registerDomEvent(activeWindow, "focus", ...)`) is unaffected and left as-is.

Fixes #70

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (79 tests passed)
- [x] `npm run build`