### PR TITLE
Automate beta release: branch+PR script and CI auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,15 @@ on:
   push:
     tags:
       - '*'
+  pull_request:
+    types:
+      - closed # Trigger only when a PR is closed (merged)
+    branches:
+      - master
 
 jobs:
   build:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -37,3 +43,41 @@ jobs:
             dist/styles.css \
             dist/main.js \
             dist/manifest.json
+
+  beta-release:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.head_ref, 'beta/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - name: Use Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20.x'
+      - name: Create and push a tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+      - name: Build
+        run: |
+          npm ci
+          npm run build --if-present
+          cp manifest-beta.json dist/manifest.json
+          cp styles.css dist/
+          ls dist/
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          gh release create "$VERSION" \
+            --prerelease \
+            --title="$VERSION" \
+            --notes "Automated beta release for version $VERSION" \
+            dist/main.js dist/styles.css dist/manifest.json

--- a/release-beta.sh
+++ b/release-beta.sh
@@ -8,7 +8,7 @@ if [ "$#" -ne 2 ]; then
     echo "Second one must be the minimum obsidian version for this release."
     echo ""
     echo "Example usage:"
-    echo "./release-beta.sh 0.3.0 0.11.13"
+    echo "./release-beta.sh 0.11.0-beta1 1.12.7"
     echo "Exiting."
 
     exit 1
@@ -23,6 +23,7 @@ fi
 
 NEW_VERSION=$1
 MINIMUM_OBSIDIAN_VERSION=$2
+BRANCH_NAME="beta/${NEW_VERSION}"
 
 echo "Updating to version ${NEW_VERSION} with minimum obsidian version ${MINIMUM_OBSIDIAN_VERSION}"
 
@@ -30,6 +31,9 @@ read -p "Continue? [y/N] " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
+  echo "Creating branch ${BRANCH_NAME}"
+  git checkout -b "${BRANCH_NAME}"
+
   echo "Updating package.json"
   TEMP_FILE=$(mktemp)
   jq ".version |= \"${NEW_VERSION}\"" package.json > "$TEMP_FILE" || exit 1
@@ -45,16 +49,27 @@ then
   jq ". += {\"${NEW_VERSION}\": \"${MINIMUM_OBSIDIAN_VERSION}\"}" versions.json > "$TEMP_FILE" || exit 1
   mv "$TEMP_FILE" versions.json
 
-  read -p "Create git commit, tag, and push? [y/N] " -n 1 -r
+  echo "Updating package-lock.json"
+  npm install
+
+  read -p "Create git commit, push, and open a pull request? [y/N] " -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]
   then
+    git add package.json package-lock.json manifest-beta.json versions.json
+    git commit -m "Update to version ${NEW_VERSION}"
+    git push --set-upstream origin "${BRANCH_NAME}"
 
-    git add -A .
-    git commit -m"Update to version ${NEW_VERSION}"
-    git tag "${NEW_VERSION}"
-    git push
-    git push --tags
+    echo "Creating a pull request..."
+    gh pr create \
+      --title "Update to version ${NEW_VERSION}" \
+      --body "Beta version bump to ${NEW_VERSION} (minimum Obsidian version ${MINIMUM_OBSIDIAN_VERSION})." \
+      --base master \
+      --head "${BRANCH_NAME}"
+
+    echo ""
+    echo "Pull request created. Merging it into master will automatically tag,"
+    echo "build, and publish the ${NEW_VERSION} beta release (via .github/workflows/release.yml)."
   fi
 else
   echo "Exiting."


### PR DESCRIPTION
## Summary
- `release-beta.sh` now branches (`beta/<version>`), commits, pushes, and opens a PR instead of committing/tagging/pushing straight to the checked-out branch — mirroring `release.sh`'s existing pattern and matching what [open-horizon-labs/obsidian-ics#204](https://github.com/open-horizon-labs/obsidian-ics/pull/204) did there.
- Adds a `beta-release` job to `.github/workflows/release.yml` that fires when a `beta/*` PR merges into `master`: tags the merge commit with the version from `package.json`, builds, and publishes a `--prerelease` GitHub release using `manifest-beta.json` — so no manual build/`gh release create` step is needed after merging the version-bump PR. Matches [open-horizon-labs/obsidian-ics#206](https://github.com/open-horizon-labs/obsidian-ics/pull/206).
- The existing tag-push-triggered `build` job (regular releases, `--draft`) is untouched aside from a `github.event_name == 'push'` guard so it doesn't also try to run on the new `pull_request` trigger.

## Test plan
- [x] YAML validated (`js-yaml` parse)
- [x] `bash -n release-beta.sh` syntax check
- [ ] Exercised end-to-end by the next beta cut: `./release-beta.sh <version> <min-obsidian>` → merge the PR it opens → confirm the `beta-release` job tags, builds, and publishes automatically