### PR TITLE
Document the one-way beta version convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,29 @@ generated `dist/` output.
 
 ## Release
 
-Maintainers use `./release.sh <plugin-version> <minimum-obsidian-version>`
-from a clean `master` checkout. The tag workflow builds the plugin and creates
-a GitHub release; verify its assets and notes before publishing it.
+Maintainers cut releases from a clean `master` checkout:
+
+- Stable: `./release.sh <plugin-version> <minimum-obsidian-version>`. The tag
+  workflow builds the plugin and creates a GitHub release; verify its assets
+  and notes before publishing it.
+- Beta: `./release-beta.sh <plugin-version> <minimum-obsidian-version>` opens
+  a `beta/<version>` PR. Merging it automatically tags, builds, and publishes
+  the beta release (via `.github/workflows/release.yml`).
+
+### Beta version numbers are one-way
+
+Obsidian's stock "Check for updates" does not support the full semver spec -
+it only compares plain `number.number.number` versions and does not
+understand pre-release suffixes at all. If a user installs `X.Y.Z-betaN` (via
+BRAT) and you later publish the real `X.Y.Z` stable release, Obsidian's
+updater will not offer it - the user is stuck reporting "up to date" forever,
+with no path back to the stable channel short of a manual reinstall.
+
+**Once any `X.Y.Z-betaN` has shipped, `X.Y.Z` is burned.** The real stable
+release for that work must ship as a version *higher* than `X.Y.Z` - bump at
+least the patch, and prefer a minor bump for a safer margin. Never reuse the
+exact base version the betas were numbered against.
+
+See [obsidian42-brat's developer guide](https://github.com/TfTHacker/obsidian42-brat/blob/main/BRAT-DEVELOPER-GUIDE.md)
+and this [forum thread](https://forum.obsidian.md/t/functional-update-to-brat-version-picker-github-pre-releases-and-frozen-version-updates/98951)
+for the underlying mechanics.

--- a/release-beta.sh
+++ b/release-beta.sh
@@ -9,6 +9,13 @@ if [ "$#" -ne 2 ]; then
     echo ""
     echo "Example usage:"
     echo "./release-beta.sh 0.11.0-beta1 1.12.7"
+    echo ""
+    echo "IMPORTANT: once X.Y.Z-betaN ships, X.Y.Z is burned - Obsidian's"
+    echo "stock update checker cannot compare pre-release suffixes, so a"
+    echo "later stable release reusing that exact base version will never"
+    echo "reach users who installed the beta. The real stable release must"
+    echo "ship higher than X.Y.Z (bump at least the patch). See"
+    echo "CONTRIBUTING.md for details."
     echo "Exiting."
 
     exit 1

--- a/release.sh
+++ b/release.sh
@@ -9,6 +9,13 @@ if [ "$#" -ne 2 ]; then
     echo ""
     echo "Example usage:"
     echo "./release.sh 0.3.0 0.11.13"
+    echo ""
+    echo "IMPORTANT: if any <new-version>-betaN pre-release has already"
+    echo "shipped, do not reuse <new-version> here - Obsidian's stock"
+    echo "update checker can't compare pre-release suffixes, so users who"
+    echo "installed the beta would never see this release as an update."
+    echo "Bump at least the patch version higher than the beta's base."
+    echo "See CONTRIBUTING.md for details."
     echo "Exiting."
 
     exit 1


### PR DESCRIPTION
## Summary

Ported from the same fix in obsidian-ics (open-horizon-labs/obsidian-ics#221), where we hit this directly: shipped 1.12.1-beta1..4, then shipped stable as 1.12.1 (same base number) - anyone who'd installed a beta via BRAT got stuck reporting "up to date" forever, because Obsidian's stock "Check for updates" doesn't support the full semver spec and can't compare pre-release suffixes.

Confirmed against two independent sources:
- [obsidian42-brat's developer guide](https://github.com/TfTHacker/obsidian42-brat/blob/main/BRAT-DEVELOPER-GUIDE.md): "Obsidian does not support the full semver spec... unless the version number is bumped at least a minor release number higher than the beta version."
- [an Obsidian forum thread](https://forum.obsidian.md/t/functional-update-to-brat-version-picker-github-pre-releases-and-frozen-version-updates/98951) describing the identical failure mode.

## Changes

- \`CONTRIBUTING.md\`'s Release section only documented \`release.sh\` - updated it to also cover \`release-beta.sh\`'s branch+PR+auto-publish flow (added in #72), plus the versioning rule.
- Inline reminder printed in both \`release.sh\` and \`release-beta.sh\`'s usage output.

## Note

\`0.10.2-beta1\` has already shipped (#73) using the pattern this fixes - a future \`0.10.2\` stable release would need to bump higher than that to avoid repeating this bug. Not addressed in this PR; flagging for whoever cuts that release.