### PR TITLE
Fix settings tab teardown behind the credential-fields bug, and its broader IA

### DIFF
--- a/.impeccable/critique/2026-07-26T20-44-59Z__src-settings-ts.md
+++ b/.impeccable/critique/2026-07-26T20-44-59Z__src-settings-ts.md
@@ -1,0 +1,67 @@
+---
+target: src/settings.ts
+total_score: 19
+max_score: 36
+na_heuristics: 7
+p0_count: 1
+p1_count: 2
+timestamp: 2026-07-26T20-44-59Z
+slug: src-settings-ts
+---
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | ~25 of 30 fields autosave silently on onChange; only 2 buttons show a Notice |
+| 2 | Match System / Real World | 3 | Strong Marvin vocabulary; "Moment format" and Cloudant assumed without explanation |
+| 3 | User Control and Freedom | 3 | Good escape hatches (remove root, reset cache); no confirm before either |
+| 4 | Consistency and Standards | 2 | Three different idioms for attaching descriptions; inconsistent desc coverage between sibling fields |
+| 5 | Error Prevention | 1 | Zero validation on the 4 credential fields; "Reset cache" fires with no confirm |
+| 6 | Recognition Rather Than Recall | 2 | Two of four credential fields have no placeholder |
+| 7 | Flexibility and Efficiency | n/a | Flat native settings list — no fair shortcut/power-user axis |
+| 8 | Aesthetic and Minimalist Design | 1 | One undifferentiated scroll mixing everyday and advanced/experimental config |
+| 9 | Error Recovery | 2 | Two async paths show real errors well; most others have no error path at all |
+| 10 | Help and Documentation | 3 | API Token and Local Server both link out; incremental sync's disclaimer doesn't |
+
+Total: 19/36 (9 heuristics scored) — Acceptable (53%)
+
+## Design Specificity Verdict
+
+Specific content, generic design. Copy is genuinely product-specific (throttling disclaimer, 4-field credential split mirroring Marvin's own page) but the structure is new Setting().setName().setDesc().addX() repeated ~30 times with bold text as the only divider — indistinguishable from the Obsidian sample-plugin template.
+
+## Overall Impression
+
+The reported bug is real but not what it looks like: nothing is broken, it's a discoverability failure from a destructive re-render pattern that's inconsistent within this same file.
+
+## What's Working
+
+- 4-field credential split mirrors Marvin's own page, explicitly documented, for copy-paste convenience
+- Real error paths (sync-root loading, incremental sync) catch/log/surface Notice text, not silent failure
+- Documented edge-case discipline (Reset Cache rendering outside the enabled-gate on purpose)
+
+## Priority Issues
+
+[P0] The reported bug's actual cause: destructive full-tab re-render with zero visual continuity. Toggling "Enable incremental sync" calls this.display(), tearing down and rebuilding the entire ~30-row tab. The 4 credential fields do get created, in the right place — but no scroll, no focus management, no visual distinction from unrelated rows. Fix: use the Local Server section's own better pattern in this same file — .setDisabled() on already-rendered fields, no teardown. Suggested command: /impeccable layout
+
+[P1] No progressive disclosure across a file that has outgrown a flat list. Nine sections, one scroll, bold text as the only divider. Fix: collapsed-by-default disclosure element for Experimental incremental sync and Local Server. Suggested command: /impeccable distill
+
+[P1] Zero validation/confirmation on the highest-risk actions. No format check on credential fields despite the file's own "grants full read access" admission; Reset cache fires instantly with no confirm. Suggested command: /impeccable harden
+
+[P2] Inconsistent description coverage breaks scanning rhythm — Database name/user have no description while siblings do; three different idioms for attaching descriptions exist in this file. Suggested command: /impeccable clarify
+
+[P2] The disclaimer explaining why credentials are needed renders as unlabeled body text (Setting with no .setName()) — doesn't read as a warning, breaks screen-reader name/description pairing. Suggested command: /impeccable clarify
+
+## Persona Red Flags
+
+Jordan (first-timer): flips the toggle expecting inline expansion, gets a silent full rebuild instead — the exact reported bug. Disclaimer paragraph doesn't read as a warning (no name). Database server gets no help link unlike API Token two sections up.
+
+Sam (accessibility): nameless Setting breaks name+description pairing. Every this.display() call (6 places) drops keyboard focus with no restoration. Database password has no autocomplete attribute.
+
+## Minor Observations
+
+Reset cache and the status line sit outside the enabled-gate on purpose (documented, good) but nothing tells a first-timer why it's visible when the feature looks off.
+
+## Questions to Consider
+
+- Does incremental sync actually need a full-tab teardown, or was this.display() just the path of least resistance?
+- If this tab keeps growing, does it stay one flat list, or is it time for real sectioning?

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -279,8 +279,21 @@ private a(href: string, text: string) {
 				})
 			);
 
-		new Setting(containerEl)
-			.setHeading().setName("Experimental incremental sync");
+		// Collapsed by default and never torn down/rebuilt on toggle: a
+		// prior version called this.display() on every change here, which
+		// destroyed and rebuilt the whole tab with no scroll/focus
+		// continuity — a real tester reported "there's no place to put the
+		// additional creds" because the newly-created fields landed below
+		// the fold with no visual cue anything had changed. Fields are now
+		// always present (matching the Local Server section's own
+		// setDisabled pattern below) and just enabled/disabled in place.
+		const incrementalDetails = containerEl.createEl("details");
+		const incrementalSummary = incrementalDetails.createEl("summary", {
+			text: "Experimental incremental sync",
+		});
+		incrementalSummary.style.cursor = "pointer";
+		incrementalSummary.style.fontWeight = "600";
+		incrementalSummary.style.padding = "8px 0";
 
 		const incrementalDescEl = createFragment();
 		incrementalDescEl.appendText(
@@ -290,10 +303,32 @@ private a(href: string, text: string) {
 			+ "API token above) for avoiding that throttling entirely during ongoing sync. The limited "
 			+ "token remains the default and fallback; this is opt-in and off by default.",
 		);
-		const incrementalHeading = new Setting(containerEl);
-		incrementalHeading.descEl.appendChild(incrementalDescEl);
+		new Setting(incrementalDetails)
+			.setName("Why this needs a bigger credential")
+			.setDesc(incrementalDescEl);
 
-		new Setting(containerEl)
+		const incrementalFieldSettings: Setting[] = [];
+
+		const credentialsLookComplete = () => Boolean(
+			this.plugin.settings.databaseServer.trim()
+			&& this.plugin.settings.databaseName.trim()
+			&& this.plugin.settings.databaseUser.trim()
+			&& this.plugin.settings.databasePassword,
+		);
+
+		let syncNowSetting: Setting;
+		const updateSyncNowState = () => {
+			const enabled = this.plugin.settings.incrementalSyncEnabled;
+			const ready = enabled && credentialsLookComplete();
+			syncNowSetting.setDisabled(!ready);
+			syncNowSetting.setDesc(
+				enabled && !ready
+					? "Fill in all four database fields above to enable this."
+					: "Manually trigger an incremental sync using the credentials above.",
+			);
+		};
+
+		new Setting(incrementalDetails)
 			.setName("Enable incremental sync")
 			.setDesc("Requires separate database credentials from Amazing Marvin's API settings page, not the limited API token.")
 			.addToggle(toggle => toggle
@@ -301,47 +336,67 @@ private a(href: string, text: string) {
 				.onChange(async (value) => {
 					this.plugin.settings.incrementalSyncEnabled = value;
 					await this.plugin.saveSettings();
-					this.display();
+					for (const setting of incrementalFieldSettings) {
+						setting.setDisabled(!value);
+					}
+					updateSyncNowState();
 				})
 			);
 
-		if (this.plugin.settings.incrementalSyncEnabled) {
-			new Setting(containerEl)
+		const fieldsDisabled = !this.plugin.settings.incrementalSyncEnabled;
+
+		incrementalFieldSettings.push(
+			new Setting(incrementalDetails)
 				.setName("Database server")
 				.setDesc("From Amazing Marvin's API settings page — the server field, without the database name.")
+				.setDisabled(fieldsDisabled)
 				.addText(text => text
 					.setPlaceholder("https://your-instance.cloudant.com")
 					.setValue(this.plugin.settings.databaseServer)
 					.onChange(async (value) => {
 						this.plugin.settings.databaseServer = value.trim();
 						await this.plugin.saveSettings();
+						updateSyncNowState();
 					})
-				);
+				),
+		);
 
-			new Setting(containerEl)
+		incrementalFieldSettings.push(
+			new Setting(incrementalDetails)
 				.setName("Database name")
+				.setDesc("The database identifier from the same page, separate from the server.")
+				.setDisabled(fieldsDisabled)
 				.addText(text => text
 					.setPlaceholder("u1234567")
 					.setValue(this.plugin.settings.databaseName)
 					.onChange(async (value) => {
 						this.plugin.settings.databaseName = value.trim();
 						await this.plugin.saveSettings();
+						updateSyncNowState();
 					})
-				);
+				),
+		);
 
-			new Setting(containerEl)
+		incrementalFieldSettings.push(
+			new Setting(incrementalDetails)
 				.setName("Database user")
+				.setDesc("The database username, distinct from your Amazing Marvin login.")
+				.setDisabled(fieldsDisabled)
 				.addText(text => text
 					.setValue(this.plugin.settings.databaseUser)
 					.onChange(async (value) => {
 						this.plugin.settings.databaseUser = value.trim();
 						await this.plugin.saveSettings();
+						updateSyncNowState();
 					})
-				);
+				),
+		);
 
-			new Setting(containerEl)
+		incrementalFieldSettings.push(
+			new Setting(incrementalDetails)
 				.setName("Database password")
 				.setDesc("Stored locally in this plugin's Obsidian settings. Treat it as highly sensitive — it grants full read access to your Amazing Marvin database, not just the limited API surface.")
+				.setDisabled(fieldsDisabled)
 				.addText(text => {
 					text.inputEl.type = "password";
 					text
@@ -349,56 +404,69 @@ private a(href: string, text: string) {
 						.onChange(async (value) => {
 							this.plugin.settings.databasePassword = value;
 							await this.plugin.saveSettings();
+							updateSyncNowState();
 						});
-				});
+				}),
+		);
 
-			new Setting(containerEl)
-				.setName("Sync now")
-				.setDesc("Manually trigger an incremental sync using the credentials above.")
-				.addButton(button => button
-					.setButtonText("Sync now")
-					.onClick(async () => {
-						try {
-							await this.plugin.runIncrementalSync("manual");
-							new Notice("Amazing Marvin incremental sync complete.");
-						} catch (error) {
-							console.error("Amazing Marvin incremental sync failed:", error);
-							new Notice(`Amazing Marvin incremental sync failed: ${error instanceof Error ? error.message : String(error)}`);
-						}
-						// Otherwise the Status line below stays stale (still
-						// "Not yet synced" or a prior error) until the user
-						// closes and reopens the settings tab.
-						this.display();
-					})
-				);
-		}
+		syncNowSetting = new Setting(incrementalDetails)
+			.setName("Sync now")
+			.addButton(button => button
+				.setButtonText("Sync now")
+				.onClick(async () => {
+					try {
+						await this.plugin.runIncrementalSync("manual");
+						new Notice("Amazing Marvin incremental sync complete.");
+					} catch (error) {
+						console.error("Amazing Marvin incremental sync failed:", error);
+						new Notice(`Amazing Marvin incremental sync failed: ${error instanceof Error ? error.message : String(error)}`);
+					}
+					updateStatusSetting();
+				})
+			);
+		updateSyncNowState();
 
-		// Deliberately outside the enabled-only block: a stale cache file
-		// from before the user disabled incremental sync (or cleared
+		// Deliberately not gated on incrementalSyncEnabled: a stale cache
+		// file from before the user disabled the feature (or cleared
 		// credentials) must still be clearable. resetIncrementalCache() is
 		// a safe no-op when there's nothing to clear, and in-memory status
 		// (unlike the on-disk file) doesn't survive an Obsidian restart, so
 		// there's no reliable signal to gate this on beyond "always show it."
-		{
+		let statusSetting: Setting;
+		const updateStatusSetting = () => {
 			const status = this.plugin.getIncrementalSyncStatus();
-			new Setting(containerEl)
-				.setName("Incremental sync status")
-				.setDesc(
-					status.lastError
-						? `Last error: ${status.lastError}`
-						: status.lastSuccessfulSyncAt
-							? `Last synced: ${new Date(status.lastSuccessfulSyncAt).toLocaleString()}`
-							: "Not yet synced.",
-				)
-				.addButton(button => button
-					.setButtonText("Reset cache")
-					.onClick(async () => {
-						await this.plugin.resetIncrementalCache();
-						new Notice("Amazing Marvin incremental cache reset. The next sync will re-hydrate from scratch.");
-						this.display();
-					})
-				);
-		}
+			statusSetting.setDesc(
+				status.lastError
+					? `Last error: ${status.lastError}`
+					: status.lastSuccessfulSyncAt
+						? `Last synced: ${new Date(status.lastSuccessfulSyncAt).toLocaleString()}`
+						: "Not yet synced.",
+			);
+		};
+		statusSetting = new Setting(incrementalDetails)
+			.setName("Incremental sync status")
+			.addButton(button => {
+				let confirming = false;
+				let confirmTimer: number | undefined;
+				button.setButtonText("Reset cache").onClick(async () => {
+					if (!confirming) {
+						confirming = true;
+						button.setButtonText("Click again to confirm");
+						confirmTimer = window.setTimeout(() => {
+							confirming = false;
+							button.setButtonText("Reset cache");
+						}, 4_000);
+						return;
+					}
+					window.clearTimeout(confirmTimer);
+					confirming = false;
+					button.setButtonText("Reset cache");
+					await this.plugin.resetIncrementalCache();
+					new Notice("Amazing Marvin incremental cache reset. The next sync will re-hydrate from scratch.");
+					updateStatusSetting();
+				});
+			});
+		updateStatusSetting();
 
 		new Setting(containerEl)
 			.setHeading().setName("Today Tasks");
@@ -586,21 +654,28 @@ private a(href: string, text: string) {
 			);
 
 		if (Platform.isDesktopApp) {
+			const localServerDetails = containerEl.createEl("details");
+			const localServerSummary = localServerDetails.createEl("summary", {
+				text: "Local Server",
+			});
+			localServerSummary.style.cursor = "pointer";
+			localServerSummary.style.fontWeight = "600";
+			localServerSummary.style.padding = "8px 0";
+
 			const lsDescEl = createFragment();
 			lsDescEl.appendText('The local API can speed up the plugin. See the ');
 			lsDescEl.appendChild(this.a('https://help.amazingmarvin.com/en/articles/5165191-desktop-local-api-server', 'Desktop Local API Server'));
 			lsDescEl.appendText(' for more information.');
-
-			let ls = new Setting(containerEl)
-				.setHeading().setName("Local Server");
-			ls.descEl.appendChild(lsDescEl);
+			new Setting(localServerDetails)
+				.setName("About the local server")
+				.setDesc(lsDescEl);
 
 			// Local Server Toggle
-			let localServerToggle = new Setting(containerEl)
+			let localServerToggle = new Setting(localServerDetails)
 				.setName("Use Local Server")
 				.setDesc("Attempt to use the local Amazing Marvin server first");
 
-			let localServerHostSetting = new Setting(containerEl)
+			let localServerHostSetting = new Setting(localServerDetails)
 				.setName("Host")
 				.addText(text => text
 					.setPlaceholder("localhost")
@@ -613,7 +688,7 @@ private a(href: string, text: string) {
 				);
 
 			// Local Server Port
-			let localServerPortSetting = new Setting(containerEl)
+			let localServerPortSetting = new Setting(localServerDetails)
 				.setName("Port")
 				.addText(text => text
 					.setPlaceholder("12082")


### PR DESCRIPTION
## Summary

Ran `/impeccable critique` against the whole settings tab after the "no place to put the additional creds" report. Root cause: the incremental-sync toggle called `this.display()`, tearing down and rebuilding the entire ~30-row settings tab on every change, with no scroll or focus continuity. The credential fields did render — just below the fold, with nothing signaling that anything had changed.

Score: 19/36 ("Acceptable"), full report in `.impeccable/critique/`.

## Changes

- Incremental sync's credential fields now always render, matching the Local Server section's existing `setDisabled()` pattern, instead of being created/destroyed via `this.display()`
- "Experimental incremental sync" and "Local Server" both collapse into `<details>` elements, closed by default
- "Sync now" is disabled with an inline reason until all four credential fields are filled in
- "Reset cache" requires a second click within 4s to confirm
- The disclaimer explaining why a bigger credential is needed now has a real heading instead of unlabeled body text
- Database name/user fields now have descriptions matching their siblings

## Verification

- `npm test`: 131 passed, 2 skipped
- `npm run typecheck`: clean
- `npm run build`: clean