### PR TITLE
Preserve every MCP operation through the incremental-cache wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,16 +319,44 @@ local-first reads through the Amazing Marvin desktop API. The optional
 `AMAZING_MARVIN_LOCAL_API_URL` and `AMAZING_MARVIN_PUBLIC_API_URL` override
 their endpoints.
 
+#### Reading the plugin's incremental cache (optional)
+
 If the Obsidian plugin's experimental incremental sync (below) is enabled
-for the same Amazing Marvin account, point the MCP server at the same
-persisted cache file with `AMAZING_MARVIN_INCREMENTAL_CACHE_PATH` (the
-plugin's data directory, `marvin-incremental-cache-v1.json`) so
-`marvin_categories`/`marvin_children` read from it instead of a REST round
-trip when it's fresh enough. This is read-only and best-effort: the MCP
-server never needs the database credentials, and it falls back to REST on
-any failure — missing file, unparseable, or older than
-`AMAZING_MARVIN_INCREMENTAL_CACHE_MAX_AGE_MS` (default 10 minutes). Leave
-it unset for the existing REST-only behavior.
+for the same Amazing Marvin account, the MCP server can read the same
+persisted cache file so `marvin_categories`/`marvin_children` skip a REST
+round trip when it's fresh enough. This is read-only and best-effort: the
+MCP server never needs the database credentials, and it falls back to REST
+on any failure. Leave it unset for the existing REST-only behavior.
+
+**The MCP server and the Obsidian plugin are separate installs.** Installing
+or updating the plugin (via BRAT or the community store) does not update this
+repository's checkout, which is what `packages/marvin-mcp/dist/server.js` is
+built from. A checkout older than the release that introduced this feature has
+no code reading the variable at all, so setting it there is **silently
+ignored** — no warning, no error, it just keeps using REST. Before setting it:
+
+```sh
+git -C /path/to/obsidian-am fetch --tags
+git -C /path/to/obsidian-am checkout <release-tag>   # e.g. 0.11.0-beta3
+npm --prefix /path/to/obsidian-am ci
+npm --prefix /path/to/obsidian-am run build
+```
+
+Then set:
+
+- `AMAZING_MARVIN_INCREMENTAL_CACHE_PATH` — absolute path to
+  `<vault>/.obsidian/plugins/<plugin-id>/marvin-incremental-cache-v1.json`.
+  The file only exists after the plugin has run incremental sync at least
+  once; check that it exists before pointing at it.
+- `AMAZING_MARVIN_INCREMENTAL_CACHE_MAX_AGE_MS` (optional) — how stale the
+  cache may be before REST is preferred instead. Default 10 minutes.
+
+To confirm it's actually working, call `marvin_categories` and check the
+result envelope: a cache hit reports `"freshness": "cached"` with
+`"origin": "local"`, while a REST read reports `"freshness": "fresh"` with
+`"origin": "public"`. If you see `fresh`/`public` with the variable set,
+either the path is wrong, the cache is stale, or the build predates this
+feature.
 
 ### Tool workflow
 

--- a/packages/marvin-mcp/src/incrementalCacheOperations.test.ts
+++ b/packages/marvin-mcp/src/incrementalCacheOperations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { MarvinReadResult, TaskOrProject } from "@open-horizon/marvin-client";
+import type { MarkDoneResult, MarvinReadResult, Task, TaskOrProject } from "@open-horizon/marvin-client";
 
 import { createCachePreferringOperations } from "./incrementalCacheOperations.js";
 import type { MarvinOperations } from "./tools.js";
@@ -13,17 +13,29 @@ const restResult: MarvinReadResult<TaskOrProject[]> = {
 	warnings: [],
 };
 
-function fallbackOperations(overrides: Partial<MarvinOperations> = {}): MarvinOperations {
-	return {
-		getTodayItems: async () => restResult,
-		getDueItems: async () => restResult,
-		getCategories: vi.fn(async () => ({ ...restResult, data: [] })),
-		getChildren: vi.fn(async () => restResult),
-		getLabels: async () => ({ ...restResult, data: [] }),
-		addTask: async () => { throw new Error("not used in these tests"); },
-		markDone: async () => { throw new Error("not used in these tests"); },
-		...overrides,
-	};
+// A real class, not an object literal: MarvinRouter (the real fallback
+// passed in production) defines its methods on the prototype, not as own
+// properties. A fixture built from an object literal can't catch a
+// `{...fallback}` bug — spreading an object literal copies its methods
+// fine, since object-literal methods ARE own properties. This is exactly
+// why that regression (issue #81) shipped untested: getCategories/
+// getChildren were the only methods asserted directly; the rest were
+// "spread through" a fixture shape that could never expose the bug.
+class FakeMarvinRouter implements MarvinOperations {
+	getCategoriesMock = vi.fn(async () => ({ ...restResult, data: [] }));
+	getChildrenMock = vi.fn(async (_parentId: string) => restResult);
+
+	async getTodayItems() { return restResult; }
+	async getDueItems() { return restResult; }
+	async getCategories() { return this.getCategoriesMock(); }
+	async getChildren(parentId: string) { return this.getChildrenMock(parentId); }
+	async getLabels() { return { ...restResult, data: [] }; }
+	async addTask(): Promise<Task> { throw new Error("not used in these tests"); }
+	async markDone(): Promise<MarkDoneResult> { throw new Error("not used in these tests"); }
+}
+
+function fallbackOperations(): FakeMarvinRouter {
+	return new FakeMarvinRouter();
 }
 
 function cacheFile(overrides: Record<string, unknown> = {}) {
@@ -60,7 +72,7 @@ describe("createCachePreferringOperations", () => {
 		expect(result.data).toEqual([expect.objectContaining({ _id: "work" })]);
 		expect(result.freshness).toBe("cached");
 		expect(result.origin).toBe("local");
-		expect(fallback.getCategories).not.toHaveBeenCalled();
+		expect(fallback.getCategoriesMock).not.toHaveBeenCalled();
 	});
 
 	it("falls back to REST when the cache file doesn't exist", async () => {
@@ -74,7 +86,7 @@ describe("createCachePreferringOperations", () => {
 
 		expect(result.origin).toBe("public");
 		expect(result.data).toEqual([]);
-		expect(fallback.getCategories).toHaveBeenCalledTimes(1);
+		expect(fallback.getCategoriesMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("falls back to REST when the cache file is unparseable", async () => {
@@ -85,7 +97,7 @@ describe("createCachePreferringOperations", () => {
 		});
 
 		await operations.getCategories();
-		expect(fallback.getCategories).toHaveBeenCalledTimes(1);
+		expect(fallback.getCategoriesMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("falls back to REST when the cache is older than maxAgeMs", async () => {
@@ -97,7 +109,7 @@ describe("createCachePreferringOperations", () => {
 		});
 
 		await operations.getCategories();
-		expect(fallback.getCategories).toHaveBeenCalledTimes(1);
+		expect(fallback.getCategoriesMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("respects a configured maxAgeMs instead of the default", async () => {
@@ -110,7 +122,7 @@ describe("createCachePreferringOperations", () => {
 		});
 
 		await operations.getCategories();
-		expect(fallback.getCategories).toHaveBeenCalledTimes(1);
+		expect(fallback.getCategoriesMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("strips plain sub-categories from getChildren to match REST's contract exactly", async () => {
@@ -124,7 +136,7 @@ describe("createCachePreferringOperations", () => {
 		const result = await operations.getChildren("work");
 
 		expect(result.data.map((item) => item._id)).toEqual(["task-1"]);
-		expect(fallback.getChildren).not.toHaveBeenCalled();
+		expect(fallback.getChildrenMock).not.toHaveBeenCalled();
 	});
 
 	it("falls back to REST for a parentId the cache never tracked", async () => {
@@ -138,17 +150,47 @@ describe("createCachePreferringOperations", () => {
 		const result = await operations.getChildren("never-hydrated");
 
 		expect(result).toBe(restResult);
-		expect(fallback.getChildren).toHaveBeenCalledWith("never-hydrated");
+		expect(fallback.getChildrenMock).toHaveBeenCalledWith("never-hydrated");
 	});
 
-	it("leaves every other operation delegated to the fallback untouched", async () => {
+	it("preserves EVERY operation, including prototype methods a spread would drop", async () => {
+		// Regression guard for issue #81: a `{...fallback}` spread silently
+		// dropped every prototype method, so with a cache path configured,
+		// marvin_today / marvin_due / marvin_labels / marvin_create_task /
+		// marvin_mark_done all failed with "... is not a function" while
+		// only categories/children worked.
 		const fallback = fallbackOperations();
 		const operations = createCachePreferringOperations(fallback, {
 			cachePath: "/fake/path.json",
 			readFile: async () => cacheFile(),
 		});
 
+		const required: Array<keyof MarvinOperations> = [
+			"getTodayItems",
+			"getDueItems",
+			"getCategories",
+			"getChildren",
+			"getLabels",
+			"addTask",
+			"markDone",
+		];
+		for (const method of required) {
+			expect(typeof operations[method], `${method} must be callable`).toBe("function");
+		}
+	});
+
+	it("actually routes the non-cached reads through to the fallback", async () => {
+		const fallback = fallbackOperations();
+		const operations = createCachePreferringOperations(fallback, {
+			cachePath: "/fake/path.json",
+			readFile: async () => cacheFile(),
+			now: () => 1_500,
+		});
+
+		// A valid, fresh cache is present — these must still hit REST,
+		// because only categories/children are ever served from cache.
 		expect(await operations.getTodayItems()).toBe(restResult);
-		expect(await operations.getLabels()).not.toBe(undefined);
+		expect(await operations.getDueItems()).toBe(restResult);
+		expect((await operations.getLabels()).data).toEqual([]);
 	});
 });

--- a/packages/marvin-mcp/src/incrementalCacheOperations.ts
+++ b/packages/marvin-mcp/src/incrementalCacheOperations.ts
@@ -82,7 +82,19 @@ export function createCachePreferringOperations(
 	options: IncrementalCacheReaderOptions,
 ): MarvinOperations {
 	return {
-		...fallback,
+		// Explicit delegation, not a `...fallback` spread: fallback is
+		// typically a MarvinRouter class instance, whose methods live on
+		// the prototype. Object spread only copies own enumerable
+		// properties, so `{...fallback}` silently drops every method
+		// (getTodayItems, getDueItems, getLabels, addTask, markDone) —
+		// confirmed as a real regression (issue #81): every MCP tool
+		// except marvin_categories/marvin_children broke the moment a
+		// cache path was configured, not just an edge case.
+		getTodayItems: (date) => fallback.getTodayItems(date),
+		getDueItems: (by) => fallback.getDueItems(by),
+		getLabels: () => fallback.getLabels(),
+		addTask: (task) => fallback.addTask(task),
+		markDone: (itemId, timeZoneOffset) => fallback.markDone(itemId, timeZoneOffset),
 		async getCategories() {
 			const state = await loadFreshState(options);
 			if (state) {


### PR DESCRIPTION
Fixes #81.

## Root cause

`createCachePreferringOperations()` returned `{...fallback, getCategories, getChildren}`. The fallback is a `MarvinRouter` **class instance**, whose methods live on the prototype — and object spread only copies own enumerable properties. So the moment a cache path was configured, every other method silently vanished: `marvin_today`, `marvin_due`, `marvin_labels`, `marvin_create_task`, and `marvin_mark_done` all failed with `... is not a function`.

Replaced with explicit per-method delegation.

## Why it shipped untested

The test fixture was an object literal. Object-literal methods **are** own properties, so spreading it worked perfectly — the fixture was structurally incapable of exposing this bug, no matter how many cases were added. Rebuilt it as a real class and added two regression tests. Both were confirmed to fail against the old code with the exact error the tester reported (`operations.getTodayItems is not a function`) before the fix was restored.

## Documentation gap (the other half of the report)

The tester also hit this: they added `AMAZING_MARVIN_INCREMENTAL_CACHE_PATH` to an MCP checkout still on `0.9.9` and it was **silently ignored** — an older build has no code reading that variable. Updating the plugin via BRAT does not update this repository's checkout, which is what `packages/marvin-mcp/dist/server.js` is built from. README now spells out the fetch/checkout/build steps and how to verify a real cache hit via the `freshness`/`origin` fields.

## Verification

- `npm test`: 132 passed, 2 skipped
- `npm run typecheck`: clean
- `npm run build`: clean