### PR TITLE
Let MCP reads ask the plugin for a fresh cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,27 @@ result envelope: a cache hit reports `"freshness": "cached"` with
 either the path is wrong, the cache is stale, or the build predates this
 feature.
 
+##### Asking for a fresh cache on a specific call
+
+By default this reading is passive: the cache is used if the plugin already
+happened to sync it, and otherwise the read falls through to REST. When a
+particular question needs current data, `marvin_categories` and
+`marvin_children` accept an optional `refresh: true` parameter. That asks the
+running plugin to sync first and waits briefly before answering.
+
+It works by dropping a small request file next to the cache file, which the
+plugin polls for and services — so the plugin keeps sole custody of the
+database credentials, and nothing here opens a network listener or needs a
+shared secret. Set `AMAZING_MARVIN_REFRESH_TIMEOUT_MS` to change how long a
+refresh-requesting read waits (default 5 seconds).
+
+The parameter defaults to `false`, and it is a best-effort nicety rather than
+a guarantee: if Obsidian isn't running, the plugin is disabled, or the sync
+fails, the wait ends and the read answers from cache or REST as it otherwise
+would. Repeated calls don't stack up waiting on a plugin that isn't
+answering — an unclaimed request file is treated as evidence that nothing is
+listening, and the next call skips the wait until the plugin picks up again.
+
 ### Tool workflow
 
 | Tool | Use it for |

--- a/packages/marvin-client/src/incrementalCacheState.ts
+++ b/packages/marvin-client/src/incrementalCacheState.ts
@@ -9,6 +9,37 @@ import type { Category, Project, Task } from "./types.js";
 
 type CouchSequence = unknown;
 
+/** The plugin writes its incremental cache here, inside its own plugin data
+ * directory. Named once, shared, so the writer and the cross-process reader
+ * can't drift apart. */
+export const INCREMENTAL_CACHE_FILENAME = "marvin-incremental-cache-v1.json";
+
+/** Sentinel the MCP server drops beside the cache file to ask the running
+ * plugin for a sync. A file, not a socket: the MCP server already has this
+ * directory path (it reads the cache from it), so this needs no network
+ * listener on the plugin side and no shared secret between the processes.
+ * The plugin polls for it, syncs, and deletes it. */
+export const INCREMENTAL_SYNC_REQUEST_FILENAME = "marvin-sync-request.json";
+
+export interface IncrementalSyncRequest {
+	/** When the request was written, so the plugin can ignore ancient ones
+	 * and the requester can tell its own request from a stale leftover. */
+	requestedAt: number;
+}
+
+export function parseIncrementalSyncRequest(
+	value: unknown,
+): IncrementalSyncRequest | undefined {
+	if (
+		typeof value !== "object"
+		|| value === null
+		|| typeof (value as Partial<IncrementalSyncRequest>).requestedAt !== "number"
+	) {
+		return undefined;
+	}
+	return { requestedAt: (value as IncrementalSyncRequest).requestedAt };
+}
+
 export type CachedMarvinItem = Category | Project | Task;
 export type CachedMarvinContainer = Category | Project;
 

--- a/packages/marvin-mcp/src/incrementalRefresh.test.ts
+++ b/packages/marvin-mcp/src/incrementalRefresh.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createCacheRefreshRequester } from "./incrementalRefresh.js";
+
+const CACHE = "/fake/marvin-incremental-cache-v1.json";
+const REQUEST = "/fake/marvin-sync-request.json";
+
+function cacheJson(lastSuccessfulSyncAt: number) {
+	return JSON.stringify({
+		version: 1,
+		sourceKey: "irrelevant",
+		lastSeq: "1",
+		categories: [],
+		children: {},
+		lastSuccessfulSyncAt,
+		projectionPending: false,
+	});
+}
+
+/** A fake filesystem whose cache file can be advanced mid-wait, standing in
+ * for the plugin picking up the request and syncing. */
+function fakeFs(initial: Record<string, string> = {}) {
+	const files = new Map(Object.entries(initial));
+	return {
+		files,
+		readFile: async (p: string) => {
+			const v = files.get(p);
+			if (v === undefined) {
+				throw new Error(`ENOENT: ${p}`);
+			}
+			return v;
+		},
+		writeFile: async (p: string, data: string) => {
+			files.set(p, data);
+		},
+	};
+}
+
+describe("createCacheRefreshRequester", () => {
+	it("writes a request and returns once the cache's sync timestamp advances", async () => {
+		const fs = fakeFs({ [CACHE]: cacheJson(1_000) });
+		let clock = 5_000;
+		let polls = 0;
+
+		const request = createCacheRefreshRequester({
+			cachePath: CACHE,
+			syncRequestPath: REQUEST,
+			readFile: fs.readFile,
+			writeFile: fs.writeFile,
+			now: () => clock,
+			timeoutMs: 5_000,
+			pollIntervalMs: 100,
+			sleep: async () => {
+				clock += 100;
+				polls += 1;
+				// Simulate the plugin servicing the request on the 2nd poll.
+				if (polls === 2) {
+					fs.files.set(CACHE, cacheJson(9_999));
+					fs.files.delete(REQUEST);
+				}
+			},
+		});
+
+		await request();
+
+		expect(polls).toBe(2);
+		expect(JSON.parse(fs.files.get(CACHE)!).lastSuccessfulSyncAt).toBe(9_999);
+	});
+
+	it("gives up at the timeout when nothing services the request", async () => {
+		const fs = fakeFs({ [CACHE]: cacheJson(1_000) });
+		let clock = 5_000;
+		let polls = 0;
+
+		const request = createCacheRefreshRequester({
+			cachePath: CACHE,
+			syncRequestPath: REQUEST,
+			readFile: fs.readFile,
+			writeFile: fs.writeFile,
+			now: () => clock,
+			timeoutMs: 500,
+			pollIntervalMs: 100,
+			sleep: async () => {
+				clock += 100;
+				polls += 1;
+				if (polls > 50) {
+					throw new Error("did not respect the timeout");
+				}
+			},
+		});
+
+		await request();
+
+		// Bounded: ~5 polls at 100ms inside a 500ms budget, not an open loop.
+		expect(polls).toBeLessThanOrEqual(6);
+	});
+
+	it("returns immediately when a previous request was never picked up", async () => {
+		// Obsidian closed or the plugin disabled: a stale request file is
+		// still sitting there. Waiting the full timeout on every call in that
+		// state would make every refresh-requesting read slow.
+		const fs = fakeFs({
+			[CACHE]: cacheJson(1_000),
+			[REQUEST]: JSON.stringify({ requestedAt: 0 }),
+		});
+		const sleep = vi.fn(async () => {});
+
+		const request = createCacheRefreshRequester({
+			cachePath: CACHE,
+			syncRequestPath: REQUEST,
+			readFile: fs.readFile,
+			writeFile: fs.writeFile,
+			now: () => 999_999,
+			timeoutMs: 5_000,
+			sleep,
+		});
+
+		await request();
+
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("still waits when a pending request is recent enough to be in flight", async () => {
+		// A concurrent call just asked; that's not evidence of a dead plugin.
+		const fs = fakeFs({
+			[CACHE]: cacheJson(1_000),
+			[REQUEST]: JSON.stringify({ requestedAt: 4_900 }),
+		});
+		let clock = 5_000;
+		const sleep = vi.fn(async () => {
+			clock += 100;
+			fs.files.set(CACHE, cacheJson(7_777));
+		});
+
+		const request = createCacheRefreshRequester({
+			cachePath: CACHE,
+			syncRequestPath: REQUEST,
+			readFile: fs.readFile,
+			writeFile: fs.writeFile,
+			now: () => clock,
+			timeoutMs: 5_000,
+			pollIntervalMs: 100,
+			sleep,
+		});
+
+		await request();
+
+		expect(sleep).toHaveBeenCalled();
+	});
+
+	it("treats a cache that appears mid-wait as a successful refresh", async () => {
+		const fs = fakeFs({}); // no cache file at all yet
+		let clock = 5_000;
+
+		const request = createCacheRefreshRequester({
+			cachePath: CACHE,
+			syncRequestPath: REQUEST,
+			readFile: fs.readFile,
+			writeFile: fs.writeFile,
+			now: () => clock,
+			timeoutMs: 5_000,
+			pollIntervalMs: 100,
+			sleep: async () => {
+				clock += 100;
+				fs.files.set(CACHE, cacheJson(6_000));
+			},
+		});
+
+		await request();
+
+		expect(fs.files.has(CACHE)).toBe(true);
+	});
+
+	it("never throws when the request file can't be written", async () => {
+		const request = createCacheRefreshRequester({
+			cachePath: CACHE,
+			syncRequestPath: REQUEST,
+			readFile: async () => { throw new Error("ENOENT"); },
+			writeFile: async () => { throw new Error("EACCES"); },
+			now: () => 1_000,
+			sleep: async () => {},
+		});
+
+		// A refresh is a nicety, not a precondition — the caller falls back.
+		await expect(request()).resolves.toBeUndefined();
+	});
+});

--- a/packages/marvin-mcp/src/incrementalRefresh.ts
+++ b/packages/marvin-mcp/src/incrementalRefresh.ts
@@ -1,0 +1,116 @@
+import {
+	parseIncrementalCacheState,
+	parseIncrementalSyncRequest,
+} from "@open-horizon/marvin-client";
+
+// Asks the running Obsidian plugin to sync, then waits a bounded window for
+// it to happen — by dropping a request file beside the cache file the MCP
+// server already reads, and watching for the cache's own
+// lastSuccessfulSyncAt to advance.
+//
+// A file rather than a socket, deliberately: the plugin keeps sole custody
+// of the CouchDB credentials either way, but this adds no inbound network
+// listener to the user's note-taking app and needs no shared secret between
+// the two processes. The cost is the plugin polling for the request, which
+// is one stat() per tick.
+//
+// Every failure mode ends the same way — return and let the caller fall
+// back to whatever it already had (a fresh-enough cache, or REST). This
+// never surfaces an error of its own: an agent asked for fresher data as a
+// nicety, not as a precondition.
+
+export interface CacheRefreshRequesterOptions {
+	cachePath: string;
+	syncRequestPath: string;
+	readFile: (path: string) => Promise<string>;
+	writeFile: (path: string, data: string) => Promise<void>;
+	now?: () => number;
+	/** How long to wait for the plugin to sync before giving up. */
+	timeoutMs?: number;
+	/** How often to re-read the cache while waiting. */
+	pollIntervalMs?: number;
+	sleep?: (ms: number) => Promise<void>;
+}
+
+async function lastSyncedAt(
+	options: CacheRefreshRequesterOptions,
+): Promise<number | undefined> {
+	try {
+		const state = parseIncrementalCacheState(
+			JSON.parse(await options.readFile(options.cachePath)) as unknown,
+		);
+		return state?.lastSuccessfulSyncAt;
+	} catch {
+		return undefined;
+	}
+}
+
+/** True when a request file is already sitting there unconsumed, which means
+ * nothing is picking requests up — Obsidian closed, the plugin disabled, or
+ * incremental sync switched off. Waiting the full timeout on every call in
+ * that state would make every refresh-requesting tool call slow, so detect
+ * it and skip the wait. Self-correcting: the moment the plugin runs again it
+ * clears the file, and the next call waits normally. */
+async function requestsAreGoingUnanswered(
+	options: CacheRefreshRequesterOptions,
+	staleAfterMs: number,
+): Promise<boolean> {
+	let raw: string;
+	try {
+		raw = await options.readFile(options.syncRequestPath);
+	} catch {
+		return false; // No pending request: nothing to conclude.
+	}
+	let pending: unknown;
+	try {
+		pending = JSON.parse(raw);
+	} catch {
+		return true; // Unparseable and never cleaned up.
+	}
+	const request = parseIncrementalSyncRequest(pending);
+	if (!request) {
+		return true;
+	}
+	const now = options.now?.() ?? Date.now();
+	return now - request.requestedAt > staleAfterMs;
+}
+
+/** Returns a function that requests one sync and waits for it, bounded. */
+export function createCacheRefreshRequester(
+	options: CacheRefreshRequesterOptions,
+): () => Promise<void> {
+	const timeoutMs = options.timeoutMs ?? 5_000;
+	const pollIntervalMs = options.pollIntervalMs ?? 250;
+	const sleep = options.sleep
+		?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+	return async () => {
+		if (await requestsAreGoingUnanswered(options, timeoutMs)) {
+			return;
+		}
+
+		const before = await lastSyncedAt(options);
+		const now = options.now?.() ?? Date.now();
+		try {
+			await options.writeFile(
+				options.syncRequestPath,
+				JSON.stringify({ requestedAt: now }),
+			);
+		} catch {
+			return; // Can't ask; caller falls back.
+		}
+
+		const deadline = now + timeoutMs;
+		for (;;) {
+			await sleep(pollIntervalMs);
+			const after = await lastSyncedAt(options);
+			// A cache that didn't exist before and does now also counts.
+			if (after !== undefined && (before === undefined || after > before)) {
+				return;
+			}
+			if ((options.now?.() ?? Date.now()) >= deadline) {
+				return;
+			}
+		}
+	};
+}

--- a/packages/marvin-mcp/src/server.ts
+++ b/packages/marvin-mcp/src/server.ts
@@ -1,12 +1,15 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
+import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
 	FetchTransport,
+	INCREMENTAL_SYNC_REQUEST_FILENAME,
 	MarvinApiClient,
 	MarvinRouter,
 } from "@open-horizon/marvin-client";
 import { createCachePreferringOperations } from "./incrementalCacheOperations.js";
+import { createCacheRefreshRequester } from "./incrementalRefresh.js";
 import { createMarvinMcpServer, type MarvinOperations } from "./tools.js";
 
 export interface MarvinMcpEnvironment {
@@ -20,6 +23,9 @@ export interface MarvinMcpEnvironment {
 	// enabled. Optional — REST remains the default with no config at all.
 	AMAZING_MARVIN_INCREMENTAL_CACHE_PATH?: string;
 	AMAZING_MARVIN_INCREMENTAL_CACHE_MAX_AGE_MS?: string;
+	// How long a refresh-requesting read waits for the plugin before giving
+	// up and answering from cache/REST. Default 5s.
+	AMAZING_MARVIN_REFRESH_TIMEOUT_MS?: string;
 }
 
 export function createRouterFromEnvironment(
@@ -70,10 +76,37 @@ export function createOperationsFromEnvironment(
 	});
 }
 
+/** Wires the `refresh` tool parameter, but only when a cache path is
+ * configured — without one there's no plugin cache to ask about, and the
+ * parameter stays an accepted no-op. */
+export function createRefreshRequesterFromEnvironment(
+	environment: MarvinMcpEnvironment = process.env,
+): (() => Promise<void>) | undefined {
+	const cachePath = environment.AMAZING_MARVIN_INCREMENTAL_CACHE_PATH?.trim();
+	if (!cachePath) {
+		return undefined;
+	}
+	const timeoutMs = Number(environment.AMAZING_MARVIN_REFRESH_TIMEOUT_MS);
+	return createCacheRefreshRequester({
+		cachePath,
+		syncRequestPath: path.join(
+			path.dirname(cachePath),
+			INCREMENTAL_SYNC_REQUEST_FILENAME,
+		),
+		readFile: (target) => readFile(target, "utf8"),
+		writeFile: (target, data) => writeFile(target, data, "utf8"),
+		...(Number.isFinite(timeoutMs) && timeoutMs > 0 ? { timeoutMs } : {}),
+	});
+}
+
 export async function runMcpServer(
 	environment: MarvinMcpEnvironment = process.env,
 ): Promise<void> {
-	const server = createMarvinMcpServer(createOperationsFromEnvironment(environment));
+	const requestCacheRefresh = createRefreshRequesterFromEnvironment(environment);
+	const server = createMarvinMcpServer(
+		createOperationsFromEnvironment(environment),
+		{ ...(requestCacheRefresh ? { requestCacheRefresh } : {}) },
+	);
 	await server.connect(new StdioServerTransport());
 	console.error("Amazing Marvin MCP server running on stdio");
 }

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -7,7 +7,7 @@ import {
 	type Task,
 	type TaskOrProject,
 } from "@open-horizon/marvin-client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	createMarvinMcpServer,
 	type MarvinOperations,
@@ -60,8 +60,11 @@ describe("Amazing Marvin MCP", () => {
 		await Promise.all(close.splice(0).map((callback) => callback()));
 	});
 
-	async function connect(ops: MarvinOperations) {
-		const server = createMarvinMcpServer(ops);
+	async function connect(
+		ops: MarvinOperations,
+		options?: { requestCacheRefresh?: () => Promise<void> },
+	) {
+		const server = createMarvinMcpServer(ops, options);
 		const client = new Client({ name: "test-client", version: "0.1.0" });
 		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 		await server.connect(serverTransport);
@@ -244,4 +247,38 @@ describe("Amazing Marvin MCP", () => {
 			["markDone", "created-1", -240],
 		]);
 	});
+
+	it("requests a cache refresh only when the refresh parameter is true", async () => {
+		const requestCacheRefresh = vi.fn(async () => {});
+		const client = await connect(operations(), { requestCacheRefresh });
+
+		// Default (omitted) must not trigger a refresh — the passive,
+		// zero-latency read stays the norm.
+		await client.callTool({ name: "marvin_categories", arguments: {} });
+		expect(requestCacheRefresh).not.toHaveBeenCalled();
+
+		await client.callTool({
+			name: "marvin_categories",
+			arguments: { refresh: true },
+		});
+		expect(requestCacheRefresh).toHaveBeenCalledTimes(1);
+
+		await client.callTool({
+			name: "marvin_children",
+			arguments: { parentId: "project-1", refresh: true },
+		});
+		expect(requestCacheRefresh).toHaveBeenCalledTimes(2);
+	});
+
+	it("accepts refresh as a no-op when no refresh hook is wired", async () => {
+		// Without a configured cache path the server has nothing to ask, but
+		// the parameter must still be accepted rather than erroring.
+		const client = await connect(operations());
+		const result = await client.callTool({
+			name: "marvin_categories",
+			arguments: { refresh: true },
+		});
+		expect(result.isError ?? false).toBe(false);
+	});
+
 });

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -129,9 +129,32 @@ function failure(error: unknown) {
 	};
 }
 
+export interface MarvinMcpServerOptions {
+	/** Asks the running Obsidian plugin to sync its incremental cache and
+	 * waits, bounded, before the read proceeds. Only wired when a cache path
+	 * is configured; the `refresh` tool parameter is a no-op without it. */
+	requestCacheRefresh?: () => Promise<void>;
+}
+
 export function createMarvinMcpServer(
 	operations: MarvinOperations,
+	options: MarvinMcpServerOptions = {},
 ): McpServer {
+	// Exposed as a per-call parameter rather than a server-wide setting: the
+	// caller knows whether this particular question needs current data
+	// ("did my task land?") or tolerates a cached answer ("what's in Work?").
+	// Defaults to false so the passive, zero-latency read stays the norm.
+	const refreshSchema = z.boolean().optional().describe(
+		"Ask Obsidian to sync its Marvin cache first and wait briefly. Only "
+		+ "affects setups using the plugin's incremental cache; falls through "
+		+ "to the normal read if Obsidian isn't running. Default false.",
+	);
+
+	const maybeRefresh = async (refresh: boolean | undefined) => {
+		if (refresh && options.requestCacheRefresh) {
+			await options.requestCacheRefresh();
+		}
+	};
 	const server = new McpServer({
 		name: "amazing-marvin",
 		version: "0.1.0",
@@ -184,13 +207,16 @@ export function createMarvinMcpServer(
 	server.registerTool("marvin_categories", {
 		title: "Amazing Marvin Categories and Projects",
 		description: "Read stable category/project IDs and their parent hierarchy.",
-		inputSchema: {},
+		inputSchema: {
+			refresh: refreshSchema,
+		},
 		annotations: {
 			readOnlyHint: true,
 			openWorldHint: true,
 		},
-	}, async () => {
+	}, async ({ refresh }) => {
 		try {
+			await maybeRefresh(refresh);
 			return readSuccess(await operations.getCategories());
 		} catch (error) {
 			return failure(error);
@@ -203,13 +229,15 @@ export function createMarvinMcpServer(
 		inputSchema: {
 			parentId: z.string().trim().min(1)
 				.describe("Category/project ID, or unassigned for Inbox"),
+			refresh: refreshSchema,
 		},
 		annotations: {
 			readOnlyHint: true,
 			openWorldHint: true,
 		},
-	}, async ({ parentId }) => {
+	}, async ({ parentId, refresh }) => {
 		try {
+			await maybeRefresh(refresh);
 			return readSuccess(await operations.getChildren(parentId));
 		} catch (error) {
 			return failure(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -284,6 +284,13 @@ export default class AmazingMarvinPlugin extends Plugin {
 		this.registerInterval(window.setInterval(() => {
 			void this.runAutomaticIncrementalSync("interval");
 		}, 60_000));
+		// Short poll for an MCP-dropped sync request. One exists() per tick,
+		// and only while incremental sync is actually configured — this is
+		// what lets an agent ask for current data instead of waiting out the
+		// 60s interval above. See INCREMENTAL_SYNC_REQUEST_FILENAME.
+		this.registerInterval(window.setInterval(() => {
+			void this.serveIncrementalSyncRequest();
+		}, 2_000));
 		this.app.workspace.onLayoutReady(() => {
 			void this.runAutomaticIncrementalSync("startup");
 		});
@@ -723,6 +730,38 @@ export default class AmazingMarvinPlugin extends Plugin {
 		// this.incrementalBackoff's max delay (5 minutes).
 		this.incrementalBackoff.recordSuccess();
 		return this.incrementalCache;
+	}
+
+	/** Picks up a sync request dropped by the MCP server and services it.
+	 * Deliberately bypasses runAutomaticIncrementalSync's rate limiting: the
+	 * request is an explicit ask from a caller that is currently blocked
+	 * waiting on it, not a background tick. Backoff is still respected, so a
+	 * failing endpoint can't be hammered through this path. */
+	private async serveIncrementalSyncRequest(): Promise<void> {
+		if (!this.settings.incrementalSyncEnabled) {
+			return;
+		}
+		const store = new ObsidianIncrementalCacheStore(
+			this.buildObsidianFileAdapter(),
+			this.getPluginDataDir(),
+		);
+		let requested: boolean;
+		try {
+			requested = await store.consumeSyncRequest();
+		} catch (error) {
+			console.warn("Could not read the Amazing Marvin sync request:", error);
+			return;
+		}
+		if (!requested || !this.incrementalBackoff.canRun()) {
+			return;
+		}
+		try {
+			await this.runIncrementalSync("MCP request");
+		} catch (error) {
+			// The requester's bounded wait times out and falls back to REST;
+			// no notice, since nothing the user did triggered this.
+			console.warn("Amazing Marvin sync requested by MCP failed:", error);
+		}
 	}
 
 	private async runAutomaticIncrementalSync(reason: string): Promise<void> {

--- a/src/marvin/obsidianIncremental.ts
+++ b/src/marvin/obsidianIncremental.ts
@@ -1,3 +1,8 @@
+import {
+	INCREMENTAL_CACHE_FILENAME,
+	INCREMENTAL_SYNC_REQUEST_FILENAME,
+} from "@open-horizon/marvin-client";
+
 import type {
 	CouchChangesTransport,
 } from "./couchChanges";
@@ -36,14 +41,31 @@ export function createObsidianCouchTransport(
 
 export class ObsidianIncrementalCacheStore implements IncrementalCacheStore {
 	readonly path: string;
+	/** Where the MCP server drops a sync request for this plugin to pick up. */
+	readonly syncRequestPath: string;
 
 	constructor(
 		private readonly adapter: IncrementalFileAdapter,
 		pluginDirectory: string,
 	) {
 		this.path = normalizeAdapterPath(
-			`${pluginDirectory}/marvin-incremental-cache-v1.json`,
+			`${pluginDirectory}/${INCREMENTAL_CACHE_FILENAME}`,
 		);
+		this.syncRequestPath = normalizeAdapterPath(
+			`${pluginDirectory}/${INCREMENTAL_SYNC_REQUEST_FILENAME}`,
+		);
+	}
+
+	/** Consumes a pending MCP sync request, returning whether one was there.
+	 * Deleted before syncing, not after: if the sync fails, the requester's
+	 * bounded wait should time out and fall back to REST rather than have
+	 * the plugin retry the same request on its next tick forever. */
+	async consumeSyncRequest(): Promise<boolean> {
+		if (!await this.adapter.exists(this.syncRequestPath)) {
+			return false;
+		}
+		await this.adapter.remove(this.syncRequestPath);
+		return true;
 	}
 
 	async load(): Promise<unknown> {


### PR DESCRIPTION
Implements the follow-up request from the beta4 tester on #55.

## The problem

The MCP cache reader was passive: it used the plugin's cache only if Obsidian happened to have synced it, otherwise falling through to REST. Dependable enough for browsing, but not for an agent that just wrote something and wants to read it back — freshness depended on focus/interval timing.

## The approach

`marvin_categories` and `marvin_children` take an optional **`refresh: boolean`, default false**. When true, the server drops a small request file beside the cache file it already reads; the plugin polls for it (~2s), syncs, clears it, and the requester waits a bounded window (default 5s) for the cache's `lastSuccessfulSyncAt` to advance.

**A file rather than a socket, deliberately.** The plugin keeps sole custody of the CouchDB credentials under either design — that was the tester's constraint and it's the right one. But a file adds no inbound network listener to the user's note-taking app and needs no shared secret between the two processes. The MCP server already had this directory path (it reads the cache from it), so the signal costs one `stat()` per plugin tick and zero new permissions. The tradeoff is polling latency, which is ~2s and irrelevant for an agent read.

**Per-call rather than server-wide** because the caller is the one who knows whether *this* question needs current data. A server-wide flag would either slow every read or help none.

## Failure modes all degrade to today's behavior

Obsidian closed, plugin disabled, sync failed, write refused — every path ends the wait and answers from cache or REST. A refresh is a nicety, not a precondition, so this never surfaces an error of its own.

Repeated calls also can't pile up against a plugin that isn't answering: an unclaimed request file is treated as evidence nothing is listening, so the next call skips the wait entirely — self-correcting the moment the plugin runs again and clears it.

## Also

Cache and request filenames now live as shared constants in `marvin-client`, so the writer and the cross-process reader can't drift apart.

## Verification

`npm test` 140 passed / 2 skipped (8 new: bounded-timeout, unanswered-request skip, cache-appears-mid-wait, never-throws, and refresh-param on/off/no-hook) · `npm run typecheck` clean · `npm run build` clean