### PR TITLE
Gate incremental sync at the runtime, not just in settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import {
 	Notice,
 	type Editor,
+	Platform,
 	Plugin,
 	TFile,
 	TFolder,
@@ -691,6 +692,18 @@ export default class AmazingMarvinPlugin extends Plugin {
 	}
 
 	private getOrCreateIncrementalCache(): IncrementalMarvinCache | undefined {
+		// Desktop-only at the runtime, not just in settings. The settings
+		// section is desktop-gated because full-database credentials are the
+		// wrong thing to type on a phone keyboard — but plugin settings sync
+		// between devices, so gating only the UI left mobile running a
+		// background sync with those credentials and no way to see its
+		// status, read its errors, sync manually, or reset its cache. An
+		// invisible, uncontrollable background process is worse than not
+		// having the optimization: mobile falls back to the REST importer,
+		// which works there and stays the default everywhere anyway.
+		if (!Platform.isDesktopApp) {
+			return undefined;
+		}
 		if (!this.settings.incrementalSyncEnabled) {
 			return undefined;
 		}
@@ -738,7 +751,10 @@ export default class AmazingMarvinPlugin extends Plugin {
 	 * waiting on it, not a background tick. Backoff is still respected, so a
 	 * failing endpoint can't be hammered through this path. */
 	private async serveIncrementalSyncRequest(): Promise<void> {
-		if (!this.settings.incrementalSyncEnabled) {
+		// Checked here as well as in getOrCreateIncrementalCache so mobile
+		// isn't stat-ing for a request file every couple of seconds that it
+		// could never service anyway.
+		if (!Platform.isDesktopApp || !this.settings.incrementalSyncEnabled) {
 			return;
 		}
 		const store = new ObsidianIncrementalCacheStore(


### PR DESCRIPTION
Follow-up to a bad call in #84/beta5, flagged immediately: I gated the incremental sync **settings UI** to desktop and described gating the runtime as "a separate behavioral change." It isn't — it's the other half of the same change, and shipping only the first half left an incoherent state.

## What beta5 actually shipped

Plugin settings sync between devices. So on mobile: `incrementalSyncEnabled` true, credentials present, background sync firing on focus/interval/startup — and **no UI anywhere** to see its status, read its errors, trigger a manual sync, or reset its cache. An invisible, uncontrollable background process holding full-database credentials is worse than either coherent option.

## Fix

Gated at `getOrCreateIncrementalCache()` — the single chokepoint every path routes through, so automatic syncs, the command-palette entry, the settings "Sync now" button, and MCP-requested refresh all no-op on mobile together. The 2s sentinel poll is gated separately so mobile isn't stat-ing for requests it could never service.

Mobile keeps the REST importer, which works there and is the default on every platform anyway. The cost is losing the throttle-avoidance optimization on mobile specifically.

## The alternative, for the record

The other coherent option was to *un*-gate the UI and instead fix the thing that motivated gating — add a reveal toggle to the password field so a phone keyboard's autocorrect is checkable. That keeps incremental sync working on mobile. Worth revisiting if mobile users ask for it; the credential-entry concern is fixable rather than fundamental.

## Verification

`npm test` 140 passed / 2 skipped · `npm run typecheck` clean · `npm run build` clean