### PR TITLE
Report what a requested cache refresh actually did

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,24 @@ would. Repeated calls don't stack up waiting on a plugin that isn't
 answering — an unclaimed request file is treated as evidence that nothing is
 listening, and the next call skips the wait until the plugin picks up again.
 
+Because that means `refresh: true` can succeed, time out, or decline to try,
+a read that requested one carries a `refresh` object saying which happened:
+
+```json
+"refresh": { "requested": true, "outcome": "synced", "waitedMs": 820 }
+```
+
+`outcome` is `synced` when the plugin's checkpoint advanced, `timed_out` when
+the request was written but no sync was observed inside the window, or
+`skipped` when nothing was attempted — with a `reason` explaining why, such as
+no cache being configured or an earlier request still sitting unclaimed. The
+surrounding `freshness`/`origin` fields still describe where the answer came
+from; this describes what the refresh did. The object is absent entirely when
+`refresh` wasn't requested.
+
+Incremental sync is desktop-only on the plugin side, so `refresh: true` will
+report `timed_out` or `skipped` when the vault it points at is open on mobile.
+
 ### Tool workflow
 
 | Tool | Use it for |

--- a/packages/marvin-mcp/src/incrementalRefresh.test.ts
+++ b/packages/marvin-mcp/src/incrementalRefresh.test.ts
@@ -61,10 +61,12 @@ describe("createCacheRefreshRequester", () => {
 			},
 		});
 
-		await request();
+		const result = await request();
 
 		expect(polls).toBe(2);
 		expect(JSON.parse(fs.files.get(CACHE)!).lastSuccessfulSyncAt).toBe(9_999);
+		expect(result).toMatchObject({ requested: true, outcome: "synced" });
+		expect(result.waitedMs).toBeGreaterThan(0);
 	});
 
 	it("gives up at the timeout when nothing services the request", async () => {
@@ -89,10 +91,11 @@ describe("createCacheRefreshRequester", () => {
 			},
 		});
 
-		await request();
+		const result = await request();
 
 		// Bounded: ~5 polls at 100ms inside a 500ms budget, not an open loop.
 		expect(polls).toBeLessThanOrEqual(6);
+		expect(result).toMatchObject({ requested: true, outcome: "timed_out" });
 	});
 
 	it("returns immediately when a previous request was never picked up", async () => {
@@ -115,9 +118,11 @@ describe("createCacheRefreshRequester", () => {
 			sleep,
 		});
 
-		await request();
+		const result = await request();
 
 		expect(sleep).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ requested: true, outcome: "skipped" });
+		expect(result.reason).toContain("nothing is listening");
 	});
 
 	it("still waits when a pending request is recent enough to be in flight", async () => {
@@ -166,9 +171,10 @@ describe("createCacheRefreshRequester", () => {
 			},
 		});
 
-		await request();
+		const result = await request();
 
 		expect(fs.files.has(CACHE)).toBe(true);
+		expect(result).toMatchObject({ requested: true, outcome: "synced" });
 	});
 
 	it("never throws when the request file can't be written", async () => {
@@ -181,7 +187,10 @@ describe("createCacheRefreshRequester", () => {
 			sleep: async () => {},
 		});
 
-		// A refresh is a nicety, not a precondition — the caller falls back.
-		await expect(request()).resolves.toBeUndefined();
+		// A refresh is a nicety, not a precondition — the caller falls back,
+		// and is told why rather than left guessing.
+		const result = await request();
+		expect(result).toMatchObject({ requested: true, outcome: "skipped" });
+		expect(result.reason).toContain("EACCES");
 	});
 });

--- a/packages/marvin-mcp/src/incrementalRefresh.ts
+++ b/packages/marvin-mcp/src/incrementalRefresh.ts
@@ -19,6 +19,18 @@ import {
 // never surfaces an error of its own: an agent asked for fresher data as a
 // nicety, not as a precondition.
 
+/** What a requested refresh actually did, so a caller can tell a
+ * newly-synchronized cache hit from a silent timeout that fell back. */
+export type CacheRefreshOutcome = "synced" | "timed_out" | "skipped";
+
+export interface CacheRefreshResult {
+	requested: true;
+	outcome: CacheRefreshOutcome;
+	waitedMs: number;
+	/** Present on `skipped` to say why nothing was attempted. */
+	reason?: string;
+}
+
 export interface CacheRefreshRequesterOptions {
 	cachePath: string;
 	syncRequestPath: string;
@@ -75,41 +87,54 @@ async function requestsAreGoingUnanswered(
 	return now - request.requestedAt > staleAfterMs;
 }
 
-/** Returns a function that requests one sync and waits for it, bounded. */
+/** Returns a function that requests one sync and waits for it, bounded,
+ * reporting what happened. */
 export function createCacheRefreshRequester(
 	options: CacheRefreshRequesterOptions,
-): () => Promise<void> {
+): () => Promise<CacheRefreshResult> {
 	const timeoutMs = options.timeoutMs ?? 5_000;
 	const pollIntervalMs = options.pollIntervalMs ?? 250;
 	const sleep = options.sleep
 		?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
-	return async () => {
+	return async (): Promise<CacheRefreshResult> => {
+		const startedAt = options.now?.() ?? Date.now();
+		const waited = () => (options.now?.() ?? Date.now()) - startedAt;
+
 		if (await requestsAreGoingUnanswered(options, timeoutMs)) {
-			return;
+			return {
+				requested: true,
+				outcome: "skipped",
+				waitedMs: waited(),
+				reason: "an earlier request is still unclaimed, so nothing is listening",
+			};
 		}
 
 		const before = await lastSyncedAt(options);
-		const now = options.now?.() ?? Date.now();
 		try {
 			await options.writeFile(
 				options.syncRequestPath,
-				JSON.stringify({ requestedAt: now }),
+				JSON.stringify({ requestedAt: startedAt }),
 			);
-		} catch {
-			return; // Can't ask; caller falls back.
+		} catch (error) {
+			return {
+				requested: true,
+				outcome: "skipped",
+				waitedMs: waited(),
+				reason: `could not write the sync request: ${error instanceof Error ? error.message : String(error)}`,
+			};
 		}
 
-		const deadline = now + timeoutMs;
+		const deadline = startedAt + timeoutMs;
 		for (;;) {
 			await sleep(pollIntervalMs);
 			const after = await lastSyncedAt(options);
 			// A cache that didn't exist before and does now also counts.
 			if (after !== undefined && (before === undefined || after > before)) {
-				return;
+				return { requested: true, outcome: "synced", waitedMs: waited() };
 			}
 			if ((options.now?.() ?? Date.now()) >= deadline) {
-				return;
+				return { requested: true, outcome: "timed_out", waitedMs: waited() };
 			}
 		}
 	};

--- a/packages/marvin-mcp/src/server.ts
+++ b/packages/marvin-mcp/src/server.ts
@@ -9,7 +9,10 @@ import {
 	MarvinRouter,
 } from "@open-horizon/marvin-client";
 import { createCachePreferringOperations } from "./incrementalCacheOperations.js";
-import { createCacheRefreshRequester } from "./incrementalRefresh.js";
+import {
+	createCacheRefreshRequester,
+	type CacheRefreshResult,
+} from "./incrementalRefresh.js";
 import { createMarvinMcpServer, type MarvinOperations } from "./tools.js";
 
 export interface MarvinMcpEnvironment {
@@ -81,7 +84,7 @@ export function createOperationsFromEnvironment(
  * parameter stays an accepted no-op. */
 export function createRefreshRequesterFromEnvironment(
 	environment: MarvinMcpEnvironment = process.env,
-): (() => Promise<void>) | undefined {
+): (() => Promise<CacheRefreshResult>) | undefined {
 	const cachePath = environment.AMAZING_MARVIN_INCREMENTAL_CACHE_PATH?.trim();
 	if (!cachePath) {
 		return undefined;

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -10,6 +10,7 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	createMarvinMcpServer,
+	type MarvinMcpServerOptions,
 	type MarvinOperations,
 } from "./tools.js";
 
@@ -62,7 +63,7 @@ describe("Amazing Marvin MCP", () => {
 
 	async function connect(
 		ops: MarvinOperations,
-		options?: { requestCacheRefresh?: () => Promise<void> },
+		options?: MarvinMcpServerOptions,
 	) {
 		const server = createMarvinMcpServer(ops, options);
 		const client = new Client({ name: "test-client", version: "0.1.0" });
@@ -249,13 +250,21 @@ describe("Amazing Marvin MCP", () => {
 	});
 
 	it("requests a cache refresh only when the refresh parameter is true", async () => {
-		const requestCacheRefresh = vi.fn(async () => {});
+		const requestCacheRefresh = vi.fn(async () => ({
+			requested: true as const,
+			outcome: "synced" as const,
+			waitedMs: 820,
+		}));
 		const client = await connect(operations(), { requestCacheRefresh });
 
 		// Default (omitted) must not trigger a refresh — the passive,
-		// zero-latency read stays the norm.
-		await client.callTool({ name: "marvin_categories", arguments: {} });
+		// zero-latency read stays the norm — and must not report on one.
+		const passive = await client.callTool({
+			name: "marvin_categories",
+			arguments: {},
+		});
 		expect(requestCacheRefresh).not.toHaveBeenCalled();
+		expect(passive.structuredContent).not.toHaveProperty("refresh");
 
 		await client.callTool({
 			name: "marvin_categories",
@@ -270,15 +279,48 @@ describe("Amazing Marvin MCP", () => {
 		expect(requestCacheRefresh).toHaveBeenCalledTimes(2);
 	});
 
-	it("accepts refresh as a no-op when no refresh hook is wired", async () => {
-		// Without a configured cache path the server has nothing to ask, but
-		// the parameter must still be accepted rather than erroring.
+	it("reports what a requested refresh actually did", async () => {
+		// freshness/origin say where the answer came from; this says whether
+		// the refresh the caller asked for actually ran, so they can tell a
+		// newly-synced cache hit from a silent timeout that fell back.
+		for (const outcome of ["synced", "timed_out", "skipped"] as const) {
+			const client = await connect(operations(), {
+				requestCacheRefresh: async () => ({
+					requested: true as const,
+					outcome,
+					waitedMs: 820,
+				}),
+			});
+
+			for (const call of [
+				{ name: "marvin_categories", arguments: { refresh: true } },
+				{ name: "marvin_children", arguments: { parentId: "project-1", refresh: true } },
+			]) {
+				const result = await client.callTool(call);
+				expect(result.structuredContent).toMatchObject({
+					refresh: { requested: true, outcome, waitedMs: 820 },
+				});
+			}
+		}
+	});
+
+	it("reports skipped with a reason when no cache is configured", async () => {
+		// Without a configured cache path there is nothing to ask, but the
+		// parameter must still be accepted and honestly reported rather than
+		// silently ignored.
 		const client = await connect(operations());
 		const result = await client.callTool({
 			name: "marvin_categories",
 			arguments: { refresh: true },
 		});
+
 		expect(result.isError ?? false).toBe(false);
+		expect(result.structuredContent).toMatchObject({
+			refresh: { requested: true, outcome: "skipped", waitedMs: 0 },
+		});
+		expect(
+			(result.structuredContent as { refresh: { reason?: string } }).refresh.reason,
+		).toContain("no incremental cache");
 	});
 
 });

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -9,6 +9,7 @@ import {
 	type MarvinRouter,
 	marvinDeepLink,
 } from "@open-horizon/marvin-client";
+import type { CacheRefreshResult } from "./incrementalRefresh.js";
 
 export type MarvinOperations = Pick<
 	MarvinRouter,
@@ -97,10 +98,18 @@ function success(structuredContent: Record<string, unknown>) {
 	};
 }
 
-function readSuccess(result: MarvinReadResult<MarvinItem[]>) {
+function readSuccess(
+	result: MarvinReadResult<MarvinItem[]>,
+	refresh?: CacheRefreshResult,
+) {
 	const { data, ...metadata } = result;
 	return success({
 		...metadata,
+		// Only present when the caller asked for a refresh. freshness/origin
+		// say where the answer came from; this says whether the refresh they
+		// requested actually ran, which is what tells them a cache hit is
+		// newly synchronized rather than a silent timeout that fell back.
+		...(refresh ? { refresh } : {}),
 		items: data.map(itemForTool),
 	});
 }
@@ -132,8 +141,9 @@ function failure(error: unknown) {
 export interface MarvinMcpServerOptions {
 	/** Asks the running Obsidian plugin to sync its incremental cache and
 	 * waits, bounded, before the read proceeds. Only wired when a cache path
-	 * is configured; the `refresh` tool parameter is a no-op without it. */
-	requestCacheRefresh?: () => Promise<void>;
+	 * is configured; the `refresh` tool parameter reports `skipped` without
+	 * it. */
+	requestCacheRefresh?: () => Promise<CacheRefreshResult>;
 }
 
 export function createMarvinMcpServer(
@@ -150,10 +160,21 @@ export function createMarvinMcpServer(
 		+ "to the normal read if Obsidian isn't running. Default false.",
 	);
 
-	const maybeRefresh = async (refresh: boolean | undefined) => {
-		if (refresh && options.requestCacheRefresh) {
-			await options.requestCacheRefresh();
+	const maybeRefresh = async (
+		refresh: boolean | undefined,
+	): Promise<CacheRefreshResult | undefined> => {
+		if (!refresh) {
+			return undefined;
 		}
+		if (!options.requestCacheRefresh) {
+			return {
+				requested: true,
+				outcome: "skipped",
+				waitedMs: 0,
+				reason: "no incremental cache is configured for this server",
+			};
+		}
+		return options.requestCacheRefresh();
 	};
 	const server = new McpServer({
 		name: "amazing-marvin",
@@ -216,8 +237,8 @@ export function createMarvinMcpServer(
 		},
 	}, async ({ refresh }) => {
 		try {
-			await maybeRefresh(refresh);
-			return readSuccess(await operations.getCategories());
+			const refreshResult = await maybeRefresh(refresh);
+			return readSuccess(await operations.getCategories(), refreshResult);
 		} catch (error) {
 			return failure(error);
 		}
@@ -237,8 +258,8 @@ export function createMarvinMcpServer(
 		},
 	}, async ({ parentId, refresh }) => {
 		try {
-			await maybeRefresh(refresh);
-			return readSuccess(await operations.getChildren(parentId));
+			const refreshResult = await maybeRefresh(refresh);
+			return readSuccess(await operations.getChildren(parentId), refreshResult);
 		} catch (error) {
 			return failure(error);
 		}


### PR DESCRIPTION
Implements the beta6 tester's follow-up on #55, to the shape they specified.

## The gap

`refresh: true` was a black box. `freshness`/`origin` say where an answer came from, but not whether the refresh actually ran — so a cache hit that was *newly synchronized* and one that *silently timed out and fell back* looked identical. An agent couldn't tell whether to trust the answer, retry, or proceed.

## The shape

```json
"refresh": { "requested": true, "outcome": "synced", "waitedMs": 820 }
```

- **`synced`** — the plugin's checkpoint advanced
- **`timed_out`** — request written, no sync observed inside the window
- **`skipped`** — nothing attempted, plus a `reason`

The `reason` on `skipped` matters more than it looks: "no incremental cache is configured for this server" and "an earlier request is still unclaimed, so nothing is listening" lead to completely different decisions for a caller. One is permanent, one clears the moment Obsidian comes back.

Absent entirely when `refresh` wasn't requested, so passive reads are byte-identical to before. Existing fallback behavior unchanged, as asked.

Also documents that incremental sync being desktop-only (#88) means `refresh: true` reports `timed_out`/`skipped` against a vault open on mobile.

## Verification

`npm test` 141 passed / 2 skipped · `npm run typecheck` clean · `npm run build` clean

New coverage asserts the reported outcome on every path — synced, timed-out, unclaimed-request skip, write-failure skip, no-hook skip — plus that the object is absent on a passive read.