### PR TITLE
Expose project creation over MCP; document why edit/delete stay out

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ it is running but the plugin has incremental sync disabled.
 | `marvin_children` | Read direct tasks/projects under a discovered parent ID. |
 | `marvin_labels` | Discover stable label IDs before task creation. |
 | `marvin_today` / `marvin_due` | Read scheduled or due work for an optional `YYYY-MM-DD` date. |
+| `marvin_create_project` | Create a project to hold tasks, before creating them. |
 | `marvin_create_task` | Create a task, optionally with `parentId`, dates, labels, note, and estimate. |
 | `marvin_mark_done` | Complete a task or project by stable ID. |
 

--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -77,6 +77,32 @@ Its provenance and MIT license are retained in
 Only Amazing Marvin's limited `X-API-Token` endpoints are in scope. Full-access
 CouchDB operations are intentionally absent.
 
+### Why edit and delete are not exposed
+
+The limited API has no update or delete endpoint. Its writes are `addTask`,
+`addProject`, `addEvent`, `markDone`, time tracking, reward points, reminders,
+and `updateHabit` — nothing that renames an item, reparents it, or changes its
+dates. Those need `/api/doc/update` and `/api/doc/delete`, which require a
+third credential (`X-Full-Access-Token`) beyond the API token and the database
+credentials, and which Marvin's own documentation warns about directly:
+updating a document with the wrong shape "might cause Marvin to crash on
+startup," and deleting through the API bypasses Marvin's client-side Trash so
+"you won't be able to recover any documents deleted in this way."
+
+A tool that can permanently destroy unrecoverable user data, or corrupt the
+app's startup state, is not something to hand an autonomous caller because it
+would round out a CRUD surface. Editing and deleting stay in Amazing Marvin's
+own clients, which is also where users already do them.
+
+This is a scope decision, not a missing feature: reopening it means writing an
+evaluation for the third credential the way
+`docs/evaluations/0053-amazing-marvin-client.md` did for the client fork.
+
+Note for test planning: verifying that renames, moves, and deletions propagate
+into the vault does **not** require MCP routes for them. Perform the operation
+in Amazing Marvin and watch the plugin's incremental sync pick it up — which is
+also how real users do it.
+
 The MCP starts only a stdio transport; it does not construct a Hono HTTP
 server, serve static files, or expose a network listener. Dependency audits may
 still report the SDK's transitive Hono adapter. Treat that report as an

--- a/packages/marvin-client/src/client.ts
+++ b/packages/marvin-client/src/client.ts
@@ -1,5 +1,7 @@
 import { asMarvinError, MarvinError } from "./errors.js";
 import type {
+	AddProjectRequest,
+	AddProjectResult,
 	AddTaskRequest,
 	Category,
 	Label,
@@ -148,6 +150,31 @@ export class MarvinApiClient {
 			...task,
 		});
 		return requireTask(value, this.context("add task", endpoint, "POST"));
+	}
+
+	async addProject(project: AddProjectRequest): Promise<AddProjectResult> {
+		const endpoint = "/addProject";
+		const value = await this.requestJson("add project", endpoint, "POST", {
+			done: false,
+			...project,
+		});
+		// Not requireTask()'s strict _id check. Marvin documents that
+		// addProject's response will carry _id/_rev "in the future", so a
+		// successful create today can come back without them. Throwing here
+		// would report a failure for a project that exists, and invite a
+		// retry that creates a second one.
+		if (
+			typeof value === "object"
+			&& value !== null
+			&& typeof (value as Partial<Project>)._id === "string"
+			&& typeof (value as Partial<Project>).title === "string"
+		) {
+			return {
+				project: { ...(value as Project), type: "project" },
+				idUnavailable: false,
+			};
+		}
+		return { idUnavailable: true };
 	}
 
 	async markDone(itemId: string, timeZoneOffset?: number): Promise<MarkDoneResult> {

--- a/packages/marvin-client/src/router.ts
+++ b/packages/marvin-client/src/router.ts
@@ -9,6 +9,8 @@ import {
 	asMarvinError,
 } from "./errors.js";
 import type {
+	AddProjectRequest,
+	AddProjectResult,
 	AddTaskRequest,
 	Category,
 	Label,
@@ -158,6 +160,20 @@ export class MarvinRouter {
 		}
 	}
 
+	async addProject(project: AddProjectRequest): Promise<AddProjectResult> {
+		try {
+			return await this.runPublic(
+				"add project",
+				(client) => client.addProject(project),
+			);
+		} finally {
+			// A new project changes the category/project tree, so the cached
+			// categories list and any children list it could appear under are
+			// both stale now.
+			this.invalidateProjectLists();
+		}
+	}
+
 	async markDone(itemId: string, timeZoneOffset?: number): Promise<MarkDoneResult> {
 		try {
 			return await this.runPublic(
@@ -175,6 +191,10 @@ export class MarvinRouter {
 
 	private invalidateTaskLists(): void {
 		this.cache.invalidatePrefixes(["today:", "due:", "children:"]);
+	}
+
+	private invalidateProjectLists(): void {
+		this.cache.invalidatePrefixes(["categories", "children:"]);
 	}
 
 	private async readThrough<T>(

--- a/packages/marvin-client/src/types.ts
+++ b/packages/marvin-client/src/types.ts
@@ -84,6 +84,49 @@ export interface Label extends BaseMarvinItem {
 export type TaskOrProject = Task | Project;
 export type MarvinItem = Task | Project | Category;
 
+/** Fields /api/addProject documents. Deliberately not `AddTaskRequest`:
+ * projects carry `priority`, and do not support the `plannedWeek` /
+ * `plannedMonth` / `isStarred` fields tasks do. */
+export interface AddProjectRequest {
+	title: string;
+	done?: boolean;
+	day?: string;
+	parentId?: string;
+	labelIds?: string[];
+	firstScheduled?: string;
+	rank?: number;
+	dailySection?: string;
+	bonusSection?: string;
+	customSection?: string;
+	timeBlockSection?: string;
+	note?: string;
+	dueDate?: string;
+	timeEstimate?: number;
+	isReward?: boolean;
+	priority?: "high" | "mid" | "low";
+	isFrogged?: boolean | number;
+	rewardPoints?: number;
+	rewardId?: string;
+	backburner?: boolean;
+	reviewDate?: string;
+	itemSnoozeTime?: number;
+	permaSnoozeTime?: number;
+	timeZoneOffset?: number;
+}
+
+/** What /api/addProject actually gives back. Marvin's docs say the new
+ * document's `_id` and `_rev` "will be included in the response in the
+ * future" — so today a successful create may return neither. Modeled as
+ * optional rather than required: the project exists either way, and
+ * rejecting the response would push a caller toward retrying a write that
+ * already succeeded. */
+export interface AddProjectResult {
+	project?: Project;
+	/** True when the response carried no usable project document, so the
+	 * caller knows the create succeeded but the ID must be looked up. */
+	idUnavailable: boolean;
+}
+
 export interface AddTaskRequest {
 	title: string;
 	done?: boolean;

--- a/packages/marvin-mcp/src/incrementalCacheOperations.test.ts
+++ b/packages/marvin-mcp/src/incrementalCacheOperations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { MarkDoneResult, MarvinReadResult, Task, TaskOrProject } from "@open-horizon/marvin-client";
+import type { AddProjectResult, MarkDoneResult, MarvinReadResult, Task, TaskOrProject } from "@open-horizon/marvin-client";
 
 import { createCachePreferringOperations } from "./incrementalCacheOperations.js";
 import type { MarvinOperations } from "./tools.js";
@@ -31,6 +31,7 @@ class FakeMarvinRouter implements MarvinOperations {
 	async getChildren(parentId: string) { return this.getChildrenMock(parentId); }
 	async getLabels() { return { ...restResult, data: [] }; }
 	async addTask(): Promise<Task> { throw new Error("not used in these tests"); }
+	async addProject(): Promise<AddProjectResult> { throw new Error("not used in these tests"); }
 	async markDone(): Promise<MarkDoneResult> { throw new Error("not used in these tests"); }
 }
 

--- a/packages/marvin-mcp/src/incrementalCacheOperations.ts
+++ b/packages/marvin-mcp/src/incrementalCacheOperations.ts
@@ -94,6 +94,7 @@ export function createCachePreferringOperations(
 		getDueItems: (by) => fallback.getDueItems(by),
 		getLabels: () => fallback.getLabels(),
 		addTask: (task) => fallback.addTask(task),
+		addProject: (project) => fallback.addProject(project),
 		markDone: (itemId, timeZoneOffset) => fallback.markDone(itemId, timeZoneOffset),
 		async getCategories() {
 			const state = await loadFreshState(options);

--- a/packages/marvin-mcp/src/tools.test.ts
+++ b/packages/marvin-mcp/src/tools.test.ts
@@ -49,6 +49,7 @@ function operations(overrides: Partial<MarvinOperations> = {}): MarvinOperations
 			title: input.title,
 			done: false,
 		}),
+		addProject: async () => ({ idUnavailable: true }),
 		markDone: async () => ({ success: true }),
 		...overrides,
 	};
@@ -98,6 +99,7 @@ describe("Amazing Marvin MCP", () => {
 		expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
 			"marvin_categories",
 			"marvin_children",
+			"marvin_create_project",
 			"marvin_create_task",
 			"marvin_due",
 			"marvin_labels",
@@ -321,6 +323,91 @@ describe("Amazing Marvin MCP", () => {
 		expect(
 			(result.structuredContent as { refresh: { reason?: string } }).refresh.reason,
 		).toContain("no incremental cache");
+	});
+
+
+	it("creates a project and returns its identified document", async () => {
+		const calls: unknown[] = [];
+		const client = await connect(operations({
+			addProject: async (input) => {
+				calls.push(input);
+				return {
+					project: {
+						_id: "project-new",
+						title: input.title,
+						type: "project" as const,
+						// Conditional spread, not `parentId: input.parentId`:
+						// exactOptionalPropertyTypes rejects an explicit
+						// undefined for an optional property.
+						...(input.parentId === undefined
+							? {}
+							: { parentId: input.parentId }),
+					},
+					idUnavailable: false as const,
+				};
+			},
+		}));
+
+		const result = await client.callTool({
+			name: "marvin_create_project",
+			arguments: {
+				title: "Launch plan",
+				parentId: "project-1",
+				priority: "high",
+			},
+		});
+
+		expect(result.structuredContent).toMatchObject({
+			created: true,
+			project: {
+				id: "project-new",
+				title: "Launch plan",
+				type: "project",
+				deepLink: "https://app.amazingmarvin.com/#p=project-new",
+			},
+		});
+		expect(calls).toMatchObject([{
+			title: "Launch plan",
+			parentId: "project-1",
+			priority: "high",
+		}]);
+	});
+
+	it("reports a created project whose ID Marvin did not return, without erroring", async () => {
+		// Marvin documents that addProject will carry the new _id/_rev "in the
+		// future", so a success today can come back without one. Treating that
+		// as a failure would invite a retry that creates a second project.
+		const client = await connect(operations({
+			addProject: async () => ({ idUnavailable: true }),
+		}));
+
+		const result = await client.callTool({
+			name: "marvin_create_project",
+			arguments: { title: "Launch plan" },
+		});
+
+		expect(result.isError ?? false).toBe(false);
+		expect(result.structuredContent).toMatchObject({
+			created: true,
+			idUnavailable: true,
+		});
+		expect(
+			(result.structuredContent as { note: string }).note,
+		).toContain("would create a duplicate");
+	});
+
+	it("rejects a malformed project date in the structured error envelope", async () => {
+		const client = await connect(operations());
+
+		const result = await client.callTool({
+			name: "marvin_create_project",
+			arguments: { title: "Launch plan", dueDate: "nope" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toEqual({
+			error: { kind: "input", field: "dueDate", message: "Use YYYY-MM-DD" },
+		});
 	});
 
 });

--- a/packages/marvin-mcp/src/tools.ts
+++ b/packages/marvin-mcp/src/tools.ts
@@ -19,6 +19,7 @@ export type MarvinOperations = Pick<
 	| "getChildren"
 	| "getLabels"
 	| "addTask"
+	| "addProject"
 	| "markDone"
 >;
 
@@ -320,6 +321,70 @@ export function createMarvinMcpServer(
 				...(input.timeEstimate === undefined ? {} : { timeEstimate: input.timeEstimate }),
 			});
 			return success({ task: itemForTool(task) });
+		} catch (error) {
+			return failure(error);
+		}
+	});
+
+	server.registerTool("marvin_create_project", {
+		title: "Create Amazing Marvin Project",
+		description:
+			"Create one project in Amazing Marvin with the limited API token. "
+			+ "Use this to make a container before creating tasks inside it.",
+		inputSchema: {
+			title: z.string().trim().min(1).describe("Project title"),
+			parentId: z.string().trim().min(1).optional()
+				.describe("Parent category/project ID from marvin_categories"),
+			labelIds: z.array(z.string().trim().min(1)).optional()
+				.describe("Stable IDs returned by marvin_labels"),
+			day: dateSchema,
+			dueDate: dateSchema,
+			note: z.string().optional(),
+			priority: z.enum(["high", "mid", "low"]).optional()
+				.describe("Projects support priority; tasks do not"),
+			timeEstimate: z.number().int().nonnegative().optional()
+				.describe("Estimated duration in milliseconds"),
+		},
+		annotations: {
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		},
+	}, async (input) => {
+		try {
+			const day = requireOptionalDate(input.day, "day");
+			const dueDate = requireOptionalDate(input.dueDate, "dueDate");
+			const result = await operations.addProject({
+				title: input.title,
+				timeZoneOffset: new Date().getTimezoneOffset() * -1,
+				...(input.parentId === undefined ? {} : { parentId: input.parentId }),
+				...(input.labelIds === undefined ? {} : { labelIds: input.labelIds }),
+				...(day === undefined ? {} : { day }),
+				...(dueDate === undefined ? {} : { dueDate }),
+				...(input.note === undefined ? {} : { note: input.note }),
+				...(input.priority === undefined ? {} : { priority: input.priority }),
+				...(input.timeEstimate === undefined ? {} : { timeEstimate: input.timeEstimate }),
+			});
+			// Marvin documents that addProject will return the new _id/_rev
+			// "in the future", so today a success can come back without one.
+			// Reported as created-but-unidentified rather than as an error:
+			// the project exists, and a caller that treats this as a failure
+			// would retry and create a duplicate.
+			if (result.project) {
+				return success({
+					created: true,
+					project: itemForTool(result.project),
+				});
+			}
+			return success({
+				created: true,
+				idUnavailable: true,
+				note:
+					"Amazing Marvin did not return the new project's ID. The project "
+					+ "was created; call marvin_categories to find it rather than "
+					+ "retrying this call, which would create a duplicate.",
+			});
 		} catch (error) {
 			return failure(error);
 		}


### PR DESCRIPTION
Answers "why not expose them??" with three findings rather than one.

## 1. rename/move/delete: a real constraint, verified

Marvin's **limited API has no update or delete endpoint at all.** Its writes are `addTask`, `addProject`, `addEvent`, `markDone`, time tracking, reward points, reminders, `updateHabit`. Renaming, reparenting, or rescheduling needs `/api/doc/update` and `/api/doc/delete` — a **third credential** (`X-Full-Access-Token`), on top of the API token and the database credentials.

Marvin's own docs on those endpoints:

> "Be careful with this API! Updating a document, especially a setting, and giving it the wrong shape might cause Marvin to crash on startup."

> "Be careful with this API! Marvin's Trash functionality is client-side only, so you won't be able to recover any documents deleted in this way."

Not something to hand an autonomous caller to round out a CRUD surface. Documented in the architecture notes with the reasoning, so this gets read rather than re-derived, and so reopening it means writing an evaluation for the third credential the way #53 did for the client fork.

## 2. A mis-scoped test note, corrected

I'd carried "rename/move/delete propagation — blocked, MCP doesn't expose those routes" across several release notes. **That test never needed MCP.** Do it in Amazing Marvin and watch the plugin's incremental sync pick it up — which is also how real users work. My framing invented a blocker.

## 3. A real gap, now closed: `marvin_create_project`

An agent could create tasks but not a project to hold them. `addProject` is limited-token, so no new credential.

Two asymmetries with `addTask` worth noting:

- Projects carry `priority` (high/mid/low) and lack tasks' `plannedWeek`/`plannedMonth`/`isStarred`, so `AddProjectRequest` is its own type.
- **Marvin documents that `addProject`'s response will carry the new `_id`/`_rev` "in the future"** — so a success today can return neither. Reusing `requireTask()`'s strict `_id` check would report a *failure for a project that exists*, and invite a retry creating a duplicate. Modeled as optional-project + `idUnavailable`, and the tool returns `created: true` with a note to look the ID up rather than retry.

Worth flagging: adding this operation **failed the build** until the incremental-cache wrapper delegated it — which is the #81 fix earning its keep. Explicit delegation makes a new operation a compile error instead of a silent runtime hole.

## Verification

`npm test` 144 passed / 2 skipped · `npm run typecheck` clean · `npm run build` clean