### PR TITLE
Keep completed tasks in the managed Today region

### DIFF
--- a/src/marvin/todayProjection.test.ts
+++ b/src/marvin/todayProjection.test.ts
@@ -183,3 +183,100 @@ describe("refreshTodayRegion", () => {
 		expect(result.lateIds).toEqual([]);
 	});
 });
+
+describe("preserving completed Today tasks", () => {
+	const date = "2026-07-26";
+	const open = (id: string, title: string) => ({
+		id,
+		title,
+		done: false,
+		deepLink: `https://app.amazingmarvin.com/#t=${id}`,
+	});
+
+	function firstPass(items: ReturnType<typeof open>[]) {
+		return refreshTodayRegion("", { date, items }).content;
+	}
+
+	it("keeps a completed task in place after Marvin stops returning it", () => {
+		// Marvin's Today/due reads only return open work, so a checked task
+		// vanishes from the read entirely. It must not vanish from the note.
+		const morning = firstPass([open("a", "First"), open("b", "Second"), open("c", "Third")]);
+		const checked = morning.replace(
+			"- [ ] Second [⚓](https://app.amazingmarvin.com/#t=b)",
+			"- [x] Second [⚓](https://app.amazingmarvin.com/#t=b)",
+		);
+		expect(checked).toContain("- [x] Second");
+
+		const after = refreshTodayRegion(checked, {
+			date,
+			items: [open("a", "First"), open("c", "Third")],
+		});
+
+		expect(after.content).toContain("- [x] Second");
+		// In place: still between First and Third, not moved to the end.
+		const ids = marvinIdsInMarkdown(after.content);
+		expect(ids).toEqual(["a", "b", "c"]);
+		expect(after.morningIds).toEqual(["a", "b", "c"]);
+	});
+
+	it("is idempotent across repeated refreshes", () => {
+		const morning = firstPass([open("a", "First"), open("b", "Second")]);
+		const checked = morning.replace("- [ ] Second", "- [x] Second");
+
+		const once = refreshTodayRegion(checked, { date, items: [open("a", "First")] });
+		const twice = refreshTodayRegion(once.content, { date, items: [open("a", "First")] });
+
+		expect(twice.content).toBe(once.content);
+		expect(twice.changed).toBe(false);
+		expect(marvinIdsInMarkdown(twice.content)).toEqual(["a", "b"]);
+	});
+
+	it("does not preserve an unchecked task Marvin no longer returns", () => {
+		// Unchecked and absent from the read means it genuinely left the
+		// projection — deleted, rescheduled, or unscheduled. Preserving those
+		// would pin stale work into the note permanently.
+		const morning = firstPass([open("a", "First"), open("b", "Second")]);
+
+		const after = refreshTodayRegion(morning, { date, items: [open("a", "First")] });
+
+		expect(after.content).not.toContain("Second");
+		expect(marvinIdsInMarkdown(after.content)).toEqual(["a"]);
+	});
+
+	it("lets a live item win when Marvin returns the task again", () => {
+		// Un-completed in Marvin: the read is authoritative, so it renders
+		// open again rather than staying stuck as the preserved checked line.
+		const morning = firstPass([open("a", "First")]);
+		const checked = morning.replace("- [ ] First", "- [x] First");
+
+		const after = refreshTodayRegion(checked, { date, items: [open("a", "First")] });
+
+		expect(after.content).toContain("- [ ] First");
+		expect(after.content).not.toContain("- [x] First");
+	});
+
+	it("keeps a completed task that was added after morning", () => {
+		const morning = firstPass([open("a", "First")]);
+		const withLate = refreshTodayRegion(morning, {
+			date,
+			items: [open("a", "First"), open("late", "Added later")],
+		}).content;
+		expect(withLate).toContain("### Added since morning");
+
+		const checked = withLate.replace("- [ ] Added later", "- [x] Added later");
+		const after = refreshTodayRegion(checked, { date, items: [open("a", "First")] });
+
+		expect(after.content).toContain("- [x] Added later");
+		expect(after.lateIds).toEqual(["late"]);
+	});
+
+	it("does not show the empty placeholder when only completed work remains", () => {
+		const morning = firstPass([open("a", "First")]);
+		const checked = morning.replace("- [ ] First", "- [x] First");
+
+		const after = refreshTodayRegion(checked, { date, items: [] });
+
+		expect(after.content).toContain("- [x] First");
+		expect(after.content).not.toContain("No Amazing Marvin tasks for this date");
+	});
+});

--- a/src/marvin/todayProjection.ts
+++ b/src/marvin/todayProjection.ts
@@ -85,10 +85,43 @@ export function refreshTodayRegion(
 	}
 
 	const currentIds = new Set(uniqueItems.map((item) => item.id));
-	morningIds = dedupeStrings(morningIds).filter((id) => currentIds.has(id));
+
+	// Marvin's Today/due reads only return open work — /dueItems is
+	// documented as "open" and there is no endpoint that lists what was
+	// completed on a day. So once a task is checked off, the next refresh
+	// used to drop it, erasing the record of what the day actually
+	// contained. Checked Marvin lines already in the region are carried
+	// through instead, verbatim, so the region becomes a record of the day
+	// rather than only a snapshot of what is still outstanding.
+	const preserved = existingRegion
+		? findCompletedMarvinLines(
+			lines.slice(existingRegion.start + 1, existingRegion.end),
+			currentIds,
+		)
+		: new Map<string, string>();
+
+	morningIds = dedupeStrings(morningIds)
+		.filter((id) => currentIds.has(id) || preserved.has(id));
 	const morningIdSet = new Set(morningIds);
-	const morning = uniqueItems.filter((item) => morningIdSet.has(item.id));
-	const late = uniqueItems.filter((item) => !morningIdSet.has(item.id));
+	const itemsById = new Map(uniqueItems.map((item) => [item.id, item]));
+
+	// Rendered here rather than inside renderManagedBlock so a completed
+	// task keeps its original position: morningIds carries the ordering, and
+	// each slot resolves to either the live item or the preserved line.
+	const morning = morningIds.map((id) => {
+		const item = itemsById.get(id);
+		return item ? renderItem(item) : preserved.get(id)!;
+	});
+	const lateIds = [
+		...uniqueItems
+			.filter((item) => !morningIdSet.has(item.id))
+			.map((item) => item.id),
+		...[...preserved.keys()].filter((id) => !morningIdSet.has(id)),
+	];
+	const late = lateIds.map((id) => {
+		const item = itemsById.get(id);
+		return item ? renderItem(item) : preserved.get(id)!;
+	});
 	const block = renderManagedBlock(options.date, morningIds, morning, late);
 
 	lines.splice(replaceFrom, replaceTo - replaceFrom, ...block);
@@ -100,7 +133,7 @@ export function refreshTodayRegion(
 		changed: content !== original,
 		createdRegion,
 		morningIds,
-		lateIds: late.map((item) => item.id),
+		lateIds,
 	};
 }
 
@@ -229,11 +262,37 @@ function findLegacyMarvinItems(
 	};
 }
 
+/** Checked Marvin task lines in the region whose IDs the current read no
+ * longer returns, keyed by ID and kept in their existing order.
+ *
+ * Only checked lines are carried through. An unchecked line Marvin no longer
+ * returns has genuinely left the projection — it was deleted, rescheduled, or
+ * unscheduled — and preserving those would pin stale work into the note
+ * permanently. The limited API is also one-way here (`markDone` with no
+ * un-complete counterpart), so unchecking a preserved line in Obsidian does
+ * not resurrect it in Marvin; the next refresh drops it. */
+function findCompletedMarvinLines(
+	regionLines: string[],
+	currentIds: ReadonlySet<string>,
+): Map<string, string> {
+	const preserved = new Map<string, string>();
+	for (const line of regionLines) {
+		if (!/^\s*[-*+]\s*\[[xX]\]/.test(line)) {
+			continue;
+		}
+		const id = line.match(MARVIN_ITEM_LINK)?.[1];
+		if (id && !currentIds.has(id) && !preserved.has(id)) {
+			preserved.set(id, line);
+		}
+	}
+	return preserved;
+}
+
 function renderManagedBlock(
 	date: string,
 	morningIds: string[],
-	morning: TodayProjectionItem[],
-	late: TodayProjectionItem[],
+	morning: string[],
+	late: string[],
 ): string[] {
 	const metadata: TodayRegionMetadata = {
 		version: 1,
@@ -242,13 +301,13 @@ function renderManagedBlock(
 	};
 	const lines = [
 		`${TODAY_REGION_PREFIX}${JSON.stringify(metadata)} -->`,
-		...morning.map(renderItem),
+		...morning,
 	];
 	if (late.length > 0) {
 		if (morning.length > 0) {
 			lines.push("");
 		}
-		lines.push("### Added since morning", ...late.map(renderItem));
+		lines.push("### Added since morning", ...late);
 	}
 	if (morning.length === 0 && late.length === 0) {
 		lines.push("<!-- No Amazing Marvin tasks for this date. -->");


### PR DESCRIPTION
Fixes the clobbering: completing a task erased it from the daily note.

## Why it happened

Marvin's Today/due reads only return **open** work. `/dueItems` is documented as "open", `/todayItems` takes no parameter for completed items, and there is **no endpoint that lists what was completed on a day**. So the moment a task was checked, the next refresh saw it absent from the read and deleted the line — destroying the record of what the day actually contained.

The renderer already knew how to draw `- [x]`; the data just never survived to reach it.

## The fix

Checked Marvin-linked lines already in the region are carried through verbatim when the current read no longer returns them, **in their original position**. `morningIds` already stored the ordering, so each slot now resolves to either the live item or the preserved line. The region becomes a record of the day rather than only a snapshot of what's outstanding.

Deliberately narrow, because the failure mode of over-preserving is stale work pinned into notes forever:

- **Only checked lines.** An unchecked line Marvin no longer returns has genuinely left the projection — deleted, rescheduled, unscheduled.
- **A live item always wins** over a preserved line for the same ID, so un-completing in Marvin renders it open again.
- **Bounded to the note's own dated region**, so nothing accumulates across days.

No new credentials; works on the plain REST importer.

## What this does *not* cover

A task you completed in Marvin's app that was never rendered in the note won't appear — nothing in the note to preserve. The CouchDB cache *does* have done tasks with `doneAt` and could source those, but it currently prunes completed tasks. That's a reasonable follow-up and a real second payoff for the database credential beyond throttle-avoidance.

Also distinct from #65, which is about one-time migration of *legacy* notes and explicitly scoped itself out of "retaining completed tasks in the live projection." This is that second thing.

## Verification

`npm test` 150 passed / 2 skipped · `npm run typecheck` clean · `npm run build` clean

6 new tests. I confirmed 4 of them **fail against the old implementation** and pass with the fix; the other 2 guard behavior that was already correct (not preserving unchecked items, live-item-wins).