### PR TITLE
State that the incremental cache holds only derived data

### DIFF
--- a/docs/architecture/marvin-client-and-mcp.md
+++ b/docs/architecture/marvin-client-and-mcp.md
@@ -77,6 +77,38 @@ Its provenance and MIT license are retained in
 Only Amazing Marvin's limited `X-API-Token` endpoints are in scope. Full-access
 CouchDB operations are intentionally absent.
 
+### Cache holds only derived data
+
+Everything in `marvin-incremental-cache-v1.json` must be reconstructible by
+re-reading Amazing Marvin. Nothing unique lives there. That invariant is load
+bearing in three places:
+
+- **"Reset cache" is a recovery step, not data loss.** The settings button
+  deletes the file outright, and the next sync rebuilds it.
+- **A schema change re-hydrates instead of migrating.**
+  `parseIncrementalCacheState` returns `undefined` on an unrecognized shape and
+  the cache rebuilds. A store holding unique data could not simply discard
+  itself.
+- **The opt-in framing stays honest.** "Off by default, delete it any time, the
+  limited REST API remains the source of truth" is only true while the file is
+  derived.
+
+The tempting violation is completion history. Marvin's REST API cannot list
+what was completed on a day — `/dueItems` is documented as open-only, there is
+no parameter for completed items, and no `doneItems` endpoint exists — while
+the CouchDB documents do carry `done` and `doneAt`. Retaining those in the
+cache would make it the only copy, which is precisely what turns a cache into a
+system of record.
+
+Durable user data belongs in the vault instead: versioned, backed up, portable,
+and readable without this plugin. `src/marvin/todayProjection.ts` keeps checked
+Marvin lines in the daily note for exactly this reason, so completion history
+lives in the notes rather than in plugin state.
+
+If a future need genuinely cannot be served from the notes, read it live at
+projection time rather than storing it. A one-off query has a different
+lifetime from a cache entry and no reason to share the file.
+
 ### Why edit and delete are not exposed
 
 The limited API has no update or delete endpoint. Its writes are `addTask`,

--- a/packages/marvin-client/src/incrementalCacheState.ts
+++ b/packages/marvin-client/src/incrementalCacheState.ts
@@ -43,6 +43,19 @@ export function parseIncrementalSyncRequest(
 export type CachedMarvinItem = Category | Project | Task;
 export type CachedMarvinContainer = Category | Project;
 
+/** Every field here must be **derived** — reconstructible by re-reading
+ * Amazing Marvin from scratch. That invariant is what makes the file
+ * disposable: a failed parse re-hydrates instead of migrating, and "Reset
+ * cache" is a recovery step rather than data loss.
+ *
+ * Do not add a field holding the only copy of something. The tempting case is
+ * completion history, since Marvin's REST API cannot list what was completed
+ * on a day — which is exactly why storing it here would make this a system of
+ * record rather than a cache. Durable user data goes in the vault, where it is
+ * versioned, backed up, and readable without this plugin.
+ *
+ * See "Cache holds only derived data" in
+ * docs/architecture/marvin-client-and-mcp.md. */
 export interface IncrementalCacheState {
 	version: 1;
 	sourceKey: string;

--- a/src/marvin/incrementalCache.ts
+++ b/src/marvin/incrementalCache.ts
@@ -349,6 +349,22 @@ export function applyCouchChanges(
 
 		if (!physicallyDeleted && doc?.db === "Tasks") {
 			const task = taskFromDocument(doc);
+			// Completed tasks are dropped, not retained. This looks like an
+			// easy place to add "keep done tasks so we can show what was
+			// finished today" — don't. Marvin's REST API cannot list
+			// completions, so this file would become the only copy of that
+			// history, and it would stop being a cache: "Reset cache" would
+			// turn into data loss, a schema bump would need a migration
+			// instead of just re-hydrating, and "delete it any time, REST is
+			// the source of truth" would no longer be true.
+			//
+			// Completion history belongs in the vault, where it is versioned,
+			// backed up, portable, and readable without this plugin.
+			// src/marvin/todayProjection.ts already keeps checked lines in the
+			// daily note for exactly that reason. If a future need can't be
+			// met from the notes, read it live at projection time rather than
+			// storing it here. See "Cache holds only derived data" in
+			// docs/architecture/marvin-client-and-mcp.md.
 			if (task && isPresentDocument(doc) && doc.done !== true) {
 				addChild(state.children, task.parentId, task);
 				markParent(task.parentId, affectedContainerIds, () => {

--- a/src/marvin/obsidianIncremental.ts
+++ b/src/marvin/obsidianIncremental.ts
@@ -91,6 +91,11 @@ export class ObsidianIncrementalCacheStore implements IncrementalCacheStore {
 		}
 	}
 
+	/** Deletes the cache outright. Safe only because everything in the file is
+	 * derived and the next sync re-hydrates it — see the invariant on
+	 * IncrementalCacheState. If anything unique ever gets stored here, this
+	 * stops being a recovery step and becomes data loss, and the settings
+	 * button that calls it becomes a trap. */
 	async clear(): Promise<void> {
 		if (await this.adapter.exists(this.path)) {
 			await this.adapter.remove(this.path);


### PR DESCRIPTION
Records an invariant that was load bearing but unwritten, after a design discussion where I proposed violating it and was rightly pushed back on.

## The invariant

Everything in `marvin-incremental-cache-v1.json` must be reconstructible by re-reading Amazing Marvin. Nothing unique lives there. Three shipped behaviors depend on it:

- **"Reset cache" is a recovery step, not data loss.** The settings button deletes the file; the next sync rebuilds it.
- **A schema change re-hydrates instead of migrating.** `parseIncrementalCacheState` returns `undefined` on an unrecognized shape and the cache rebuilds.
- **The opt-in framing stays honest.** "Off by default, delete it any time, REST remains the source of truth" is only true while the file is derived.

## The tempting violation

Completion history. Marvin's REST API *cannot* list what was completed on a day, while the CouchDB documents carry `done`/`doneAt` — so the cache looks like the obvious place to keep it. That's exactly what would make it the only copy, and turn a cache into a system of record.

I suggested doing this after #93 and was corrected: "no, then it's no longer a cache." Correct, and the consequences are concrete — `clear()` becomes destructive and a version bump needs a migration path.

Durable user data belongs in the vault: versioned, backed up, portable, readable without this plugin. `todayProjection.ts` already keeps checked lines in the daily note, so completion history lives in the notes rather than in plugin state. If a future need can't be met from the notes, the shape is a live read at projection time, not cache retention.

## Where it's written

Deliberately at the places someone would be standing when they'd break it, not only in a doc nobody opens mid-PR:

- The done-pruning line in `applyCouchChanges` — the literal line a "keep completed tasks" change would edit
- The `IncrementalCacheState` declaration — for anyone adding a field
- `ObsidianIncrementalCacheStore.clear()` — whose safety depends on it
- A "Cache holds only derived data" section in `docs/architecture/marvin-client-and-mcp.md`

Docs and comments only; no behavior change.

## Verification

`npm test` 150 passed / 2 skipped · `npm run typecheck` clean · `npm run build` clean