### PR TITLE
Credit Open Horizon Labs in the beta manifest too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: '20.x'
           cache: npm
       - run: npm ci
+      - run: npm run check:manifests
       - run: npm run typecheck
       - run: npm test
       - run: npm run build

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -3,8 +3,8 @@
   "name": "Amazing Marvin Integration",
   "version": "0.11.0-beta9",
   "minAppVersion": "1.12.7",
-  "description": "Integration with Amazing Marvin",
-  "author": "Cloud Atlas",
-  "authorUrl": "https://cloud-atlas.ai",
+  "description": "Integration with Amazing Marvin.",
+  "author": "Open Horizon Labs",
+  "authorUrl": "https://openhorizonlabs.ai/",
   "isDesktopOnly": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cloud-atlas-am",
+  "name": "open-horizon-am",
   "version": "0.11.0-beta9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cloud-atlas-am",
+      "name": "open-horizon-am",
       "version": "0.11.0-beta9",
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloud-atlas-am",
+  "name": "open-horizon-am",
   "version": "0.11.0-beta9",
   "description": "Interoperability between Obsidian and Amazing Marvin",
   "private": true,
@@ -15,11 +15,12 @@
     "dev": "npm run build:client && node esbuild.config.mjs",
     "dev-build": "npm run build:client && tsc -noEmit -skipLibCheck && node esbuild.config.mjs dev-build",
     "test": "npm run build:client && vitest run",
+    "check:manifests": "node scripts/check-manifests.mjs",
     "typecheck": "npm run build:client && tsc -noEmit -skipLibCheck && npm run typecheck --workspaces --if-present",
     "version": "node version-bump.mjs && git add manifest.json versions.json"
   },
   "keywords": [],
-  "author": "",
+  "author": "Open Horizon Labs",
   "license": "MIT",
   "dependencies": {
     "@open-horizon/marvin-client": "file:packages/marvin-client",

--- a/scripts/check-manifests.mjs
+++ b/scripts/check-manifests.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Fails when manifest.json and manifest-beta.json disagree on anything other
+// than the version they're releasing.
+//
+// This exists because they already drifted once and shipped: a commit updating
+// the author to Open Horizon Labs touched manifest.json only, and since the
+// beta release workflow copies manifest-beta.json over dist/manifest.json,
+// every beta went out crediting the previous org while stable was correct. The
+// two files duplicate identity by hand, so nothing but a check keeps them
+// honest.
+//
+// `id` is compared like any other field, but it is not a field to "fix" if it
+// ever looks stale: it is the plugin's folder name under .obsidian/plugins/,
+// so changing it orphans existing installs along with their settings and
+// cache, and it is the documented handle other plugins use to reach this one
+// (app.plugins.plugins["<id>"].api).
+
+import { readFile } from "node:fs/promises";
+
+const SHARED_FIELDS = [
+	"id",
+	"name",
+	"description",
+	"author",
+	"authorUrl",
+	"isDesktopOnly",
+	"fundingUrl",
+];
+
+// Only these may differ, since a beta is by definition a different version and
+// may require a newer Obsidian than the current stable does.
+const RELEASE_SPECIFIC_FIELDS = ["version", "minAppVersion"];
+
+async function readJson(path) {
+	return JSON.parse(await readFile(path, "utf8"));
+}
+
+const stable = await readJson("manifest.json");
+const beta = await readJson("manifest-beta.json");
+
+const problems = [];
+
+for (const field of SHARED_FIELDS) {
+	const a = stable[field];
+	const b = beta[field];
+	if (JSON.stringify(a) !== JSON.stringify(b)) {
+		problems.push(
+			`${field}: manifest.json has ${JSON.stringify(a)}, `
+			+ `manifest-beta.json has ${JSON.stringify(b)}`,
+		);
+	}
+}
+
+// A field present in one file and absent from the other is drift too, and
+// would otherwise slip through the loop above whenever both read undefined.
+const unexpected = [...new Set([...Object.keys(stable), ...Object.keys(beta)])]
+	.filter((key) => !SHARED_FIELDS.includes(key) && !RELEASE_SPECIFIC_FIELDS.includes(key));
+for (const field of unexpected) {
+	problems.push(
+		`${field}: not covered by this check — add it to SHARED_FIELDS or `
+		+ "RELEASE_SPECIFIC_FIELDS in scripts/check-manifests.mjs",
+	);
+}
+
+if (problems.length > 0) {
+	console.error("manifest.json and manifest-beta.json disagree:\n");
+	for (const problem of problems) {
+		console.error(`  - ${problem}`);
+	}
+	console.error(
+		"\nEverything except version and minAppVersion must match, or betas "
+		+ "ship different metadata than stable.",
+	);
+	process.exit(1);
+}
+
+console.log(
+	`Manifests agree on ${SHARED_FIELDS.length} shared fields `
+	+ `(stable ${stable.version}, beta ${beta.version}).`,
+);


### PR DESCRIPTION
Every beta since the rename has shipped crediting the old org.

## Cause

`chore: credit Open Horizon Labs` (ca753fa) updated **`manifest.json` only**. The beta release workflow does `cp manifest-beta.json dist/manifest.json`, so:

- **stable** → correct: "Open Horizon Labs" / openhorizonlabs.ai
- **every beta** → stale: "Cloud Atlas" / cloud-atlas.ai

The `description` had drifted a trailing period as well. The two files duplicate identity by hand, so nothing was keeping them honest.

## Fix

`manifest-beta.json` now matches, and **`scripts/check-manifests.mjs` runs in CI** so it can't recur: the manifests must agree on every field except `version` and `minAppVersion`, which are legitimately release-specific (a beta may require a newer Obsidian). An unrecognized field also fails the check, so a future addition can't silently escape the comparison.

I confirmed the guard reproduces the exact bug — reintroducing `"author": "Cloud Atlas"` fails with a precise message.

Also renames the npm package `cloud-atlas-am` → `open-horizon-am` and fills its empty `author`. That name is `private: true` and referenced nowhere else, so it's cosmetic.

## Deliberately not changed: the plugin `id`

`id` stays `cloudatlas-o-am`. It's stale branding, but it is **not** safe to change:

- It's the folder name under `.obsidian/plugins/`, so changing it orphans every existing install — settings, `data.json`, and the incremental cache file all live there. Users would see a fresh, unconfigured plugin.
- It's the documented handle other plugins and scripts use to reach this one: `app.plugins.plugins["cloudatlas-o-am"].api` (`src/api.ts`).

Not worth breaking installs and a public API handle over an internal identifier nobody sees. Flagging it explicitly so it reads as a decision rather than an oversight.

## Verification

`npm run check:manifests` passes · `npm test` 150 passed / 2 skipped · `npm run typecheck` clean · `npm run build` clean